### PR TITLE
Change group column name for persistence

### DIFF
--- a/sdk/core/src/main/java/avalanche/core/persistence/AvalancheDatabasePersistence.java
+++ b/sdk/core/src/main/java/avalanche/core/persistence/AvalancheDatabasePersistence.java
@@ -32,7 +32,7 @@ public class AvalancheDatabasePersistence extends AvalanchePersistence implement
      * Name of group column in the table.
      */
     @VisibleForTesting
-    static final String COLUMN_GROUP = "group";
+    static final String COLUMN_GROUP = "persistence_group";
 
     /**
      * Name of log column in the table.


### PR DESCRIPTION
`group` is a keyword. I don't know why unit test and instrumented test didn't fail but I can find an error log whenever I run Sasquatch app.
