### PR TITLE
Move user confirmation annotation to package private top level class

### DIFF
--- a/sdk/errors/src/main/java/com/microsoft/sonoma/errors/ErrorReporting.java
+++ b/sdk/errors/src/main/java/com/microsoft/sonoma/errors/ErrorReporting.java
@@ -2,7 +2,6 @@ package com.microsoft.sonoma.errors;
 
 import android.content.Context;
 import android.os.SystemClock;
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -27,8 +26,6 @@ import org.json.JSONException;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -184,7 +181,7 @@ public class ErrorReporting extends AbstractSonomaFeature {
      * @see #DONT_SEND
      * @see #ALWAYS_SEND
      */
-    public static void notifyUserConfirmation(@ConfirmationDef int userConfirmation) {
+    public static void notifyUserConfirmation(@UserConfirmationDef int userConfirmation) {
         getInstance().handleUserConfirmation(userConfirmation);
     }
 
@@ -436,7 +433,7 @@ public class ErrorReporting extends AbstractSonomaFeature {
     }
 
     @VisibleForTesting
-    private synchronized void handleUserConfirmation(@ConfirmationDef int userConfirmation) {
+    private synchronized void handleUserConfirmation(@UserConfirmationDef int userConfirmation) {
         if (mChannel == null) {
             SonomaLog.error(LOG_TAG, "ErrorReporting feature not initialized, discarding calls.");
             return;
@@ -478,15 +475,6 @@ public class ErrorReporting extends AbstractSonomaFeature {
     @VisibleForTesting
     void setLogSerializer(LogSerializer logSerializer) {
         mLogSerializer = logSerializer;
-    }
-
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({
-            SEND,
-            DONT_SEND,
-            ALWAYS_SEND
-    })
-    private @interface ConfirmationDef {
     }
 
     /**

--- a/sdk/errors/src/main/java/com/microsoft/sonoma/errors/UserConfirmationDef.java
+++ b/sdk/errors/src/main/java/com/microsoft/sonoma/errors/UserConfirmationDef.java
@@ -1,0 +1,15 @@
+package com.microsoft.sonoma.errors;
+
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.SOURCE)
+@IntDef({
+        ErrorReporting.SEND,
+        ErrorReporting.DONT_SEND,
+        ErrorReporting.ALWAYS_SEND
+})
+@interface UserConfirmationDef {
+}


### PR DESCRIPTION
We very often get this exception, forcing us to clean build:

Execution failed for task ':sdk:errors:compileDebugUnitTestJavaWithJavac'.
Unable to read class file: 'D:\git\Sonoma-SDK-Android\sdk\errors\build\intermediates\classes\debug\com\microsoft\sonoma\errors\ErrorReporting$ConfirmationDef.class'

Trying to avoid this by making the class top level.
