### PR TITLE
Bintray publish settings update

### DIFF
--- a/apps/demo/build.gradle
+++ b/apps/demo/build.gradle
@@ -4,15 +4,17 @@
 
 evaluationDependsOn(':apps')
 
-apply plugin: 'maven'
-
+/*
+ * Not a secret, will be shared with private beta customers git itself is private.
+ * This account is read only, we use different secret credentials to publish.
+ */
 repositories {
     maven {
+        url 'http://microsoftsonoma.bintray.com/sonoma'
         credentials {
-            username rootProject.ext.bintrayUser
-            password rootProject.ext.bintrayKey
+            username 'sonoma-beta'
+            password 'cbaf881993ad1ab4128f71da716d060e8590906a'
         }
-        url "https://microsoftsonoma.bintray.com/sonoma"
     }
 }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -4,7 +4,7 @@ ext {
     siteUrl = 'https://github.com/Microsoft/Sonoma-SDK-Android'
     gitUrl = 'https://github.com/Microsoft/Sonoma-SDK-Android.git'
     groupId = 'com.microsoft.sonoma'
-    sdkDescription = 'Microsoft Sonoma SDK'
+    sdkDescription = 'Microsoft Sonoma SDK for Android'
 
     Properties properties = new Properties()
     File file = rootProject.file('local.properties')
@@ -19,10 +19,11 @@ ext {
     bintrayRepo = properties.getProperty("bintray.repo")
     bintrayPackageNamePrefix = properties.getProperty("bintray.package.prefix")
 
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseSite = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    licenseName = 'The MIT License (MIT)'
+    licenseSite = 'https://opensource.org/licenses/MIT'
+    licenseCode = 'MIT'
 
     developerId = 'microsoft'
     developerName = 'Microsoft'
-    developerEmail = 'sonoma.sdk@gmail.com'
+    developerEmail = 'mobiledevopssdk@microsoft.com'
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -107,6 +107,9 @@ subprojects {
         from javadoc.destinationDir
     }
 
+    // FIXME On some machines the following task dependency seems broken, force it
+    bintrayUpload.dependsOn tasks.install
+
     artifacts {
         archives javadocJar
         archives sourcesJar
@@ -117,14 +120,16 @@ subprojects {
         key = ext.bintrayKey
 
         configurations = ['archives']
+
+        publish = true
+
         pkg {
             repo = ext.bintrayRepo
             name = ext.bintrayPackageNamePrefix + project.name
             userOrg = ext.bintrayUserOrg
             websiteUrl = ext.siteUrl
             vcsUrl = ext.gitUrl
-            licenses = ["Apache-2.0"]
-            publish = true
+            licenses = [ext.licenseCode]
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,9 +4,10 @@ include ':sdk:core'
 include ':sdk:errors'
 include ':sdk:analytics'
 
+// common test code
 include ':test'
 
 // test apps
 include ':apps'
 include ':apps:sasquatch'
-// include ':apps:demo'
+include ':apps:demo'


### PR DESCRIPTION
- Fix a gradle dependency bug occurring on some machines.
- Demo now uses a shared read only user name and password to access private repos.
- Change license to MIT.
