### PR TITLE
Remove useless gradle empty tasks

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -186,14 +186,6 @@ task coverageReport(type: JacocoReport, dependsOn: subprojects.coverageReport) {
     executionData = files(subprojects.coverageReport.executionData)
 }
 
-task javadoc(type: Javadoc, dependsOn: subprojects.javadoc) {
-    // Do nothing for :sdk but run the task for its children.
-}
-
-task bintrayUpload(dependsOn: [subprojects.bintrayUpload, subprojects.assembleRelease]) {
-    // Do nothing for :sdk but run the task for its children.
-}
-
 task clean(type: Delete) {
     delete project.buildDir
 }


### PR DESCRIPTION
Could publish the same without those `./gradlew clean bintrayUpload`.
