### PR TITLE
Fix sdkName that was injected into non SDK modules BuildConfig

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,6 +22,8 @@ subprojects {
 
     def ext = rootProject.ext
 
+    ext.sdkName = 'sonoma.android'
+
     android {
         buildToolsVersion ext.buildToolsVersion
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,6 @@
 // Version constants
 
 ext {
-    sdkName = 'sonoma.android'
     versionCode = 1
     versionName = '0.1.0'
     minSdkVersion = 15


### PR DESCRIPTION
For some reason I could not use:

```
ext {
   sdkName = 'sonoma.android'
}
```

syntax there.
