### PR TITLE
Make sure wrapper sdk is always up to date in device properties

### DIFF
--- a/sdk/core/src/main/java/com/microsoft/sonoma/core/Sonoma.java
+++ b/sdk/core/src/main/java/com/microsoft/sonoma/core/Sonoma.java
@@ -91,7 +91,7 @@ public final class Sonoma {
      */
     @SuppressWarnings("WeakerAccess")
     public static void setWrapperSdk(WrapperSdk wrapperSdk) {
-        DeviceInfoHelper.setWrapperSdk(wrapperSdk);
+        getInstance().setInstanceWrapperSdk(wrapperSdk);
     }
 
     /**
@@ -208,6 +208,17 @@ public final class Sonoma {
      */
     public static UUID getInstallId() {
         return IdHelper.getInstallId();
+    }
+
+    /**
+     * {@link #setWrapperSdk(WrapperSdk)} implementation at instance level.
+     *
+     * @param wrapperSdk wrapper SDK information.
+     */
+    private synchronized void setInstanceWrapperSdk(WrapperSdk wrapperSdk) {
+        DeviceInfoHelper.setWrapperSdk(wrapperSdk);
+        if (mChannel != null)
+            mChannel.invalidateDeviceCache();
     }
 
     /**

--- a/sdk/core/src/main/java/com/microsoft/sonoma/core/channel/Channel.java
+++ b/sdk/core/src/main/java/com/microsoft/sonoma/core/channel/Channel.java
@@ -65,6 +65,11 @@ public interface Channel {
     void clear(String groupName);
 
     /**
+     * Invalidate device cache that this channel may have.
+     */
+    void invalidateDeviceCache();
+
+    /**
      * Add a global listener to the channel.
      *
      * @param listener listener to add.

--- a/sdk/core/src/main/java/com/microsoft/sonoma/core/channel/DefaultChannel.java
+++ b/sdk/core/src/main/java/com/microsoft/sonoma/core/channel/DefaultChannel.java
@@ -196,6 +196,11 @@ public class DefaultChannel implements Channel {
         mPersistence.deleteLogs(groupName);
     }
 
+    @Override
+    public synchronized void invalidateDeviceCache() {
+        mDevice = null;
+    }
+
     /**
      * Stop sending logs until app is restarted or the channel is enabled again.
      *

--- a/sdk/core/src/test/java/com/microsoft/sonoma/core/SonomaTest.java
+++ b/sdk/core/src/test/java/com/microsoft/sonoma/core/SonomaTest.java
@@ -380,12 +380,29 @@ public class SonomaTest {
     }
 
     @Test
-    public void setWrapperSdkTest() {
+    public void setWrapperSdkTest() throws Exception {
+
+        /* Setup  mocking. */
+        DefaultChannel channel = mock(DefaultChannel.class);
+        whenNew(DefaultChannel.class).withAnyArguments().thenReturn(channel);
         mockStatic(DeviceInfoHelper.class);
+
+        /* Call method. */
         WrapperSdk wrapperSdk = new WrapperSdk();
         Sonoma.setWrapperSdk(wrapperSdk);
+
+        /* Check propagation. */
         verifyStatic();
         DeviceInfoHelper.setWrapperSdk(wrapperSdk);
+
+        /* Since the channel was not created when setting wrapper, no need to refresh channel after start. */
+        Sonoma.start(application, DUMMY_APP_SECRET, DummyFeature.class);
+        verify(channel, never()).invalidateDeviceCache();
+
+        /* Update wrapper SDK and check channel refreshed. */
+        wrapperSdk = new WrapperSdk();
+        Sonoma.setWrapperSdk(wrapperSdk);
+        verify(channel).invalidateDeviceCache();
     }
 
 


### PR DESCRIPTION
If calling Sonoma.setWrapperSdk after Sonoma.start it will now consider the change.
