### PR TITLE
Add support for Wrapper SDK listener on crash, and overriding error log file content

### DIFF
--- a/sdk/crashes/src/main/java/com/microsoft/sonoma/crashes/Crashes.java
+++ b/sdk/crashes/src/main/java/com/microsoft/sonoma/crashes/Crashes.java
@@ -122,6 +122,11 @@ public class Crashes extends AbstractSonomaFeature {
      */
     private CrashesListener mCrashesListener;
 
+    /**
+     * Wrapper SDK listener.
+     */
+    private WrapperSdkListener mWrapperSdkListener;
+
     private ErrorReport mLastSessionErrorReport;
 
     private Crashes() {
@@ -321,6 +326,7 @@ public class Crashes extends AbstractSonomaFeature {
      *
      * @return initialization timestamp expressed using {@link SystemClock#elapsedRealtime()}.
      */
+    @VisibleForTesting
     synchronized long getInitializeTimestamp() {
         return mInitializeTimestamp;
     }
@@ -335,7 +341,7 @@ public class Crashes extends AbstractSonomaFeature {
                 mUncaughtExceptionHandler = null;
             }
         } else if (mContext != null) {
-            mUncaughtExceptionHandler = new UncaughtExceptionHandler(mContext);
+            mUncaughtExceptionHandler = new UncaughtExceptionHandler();
             mUncaughtExceptionHandler.register();
         }
 
@@ -446,6 +452,16 @@ public class Crashes extends AbstractSonomaFeature {
         mCrashesListener = listener;
     }
 
+    /**
+     * Set wrapper SDK listener.
+     *
+     * @param wrapperSdkListener listener.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void setWrapperSdkListener(WrapperSdkListener wrapperSdkListener) {
+        mWrapperSdkListener = wrapperSdkListener;
+    }
+
     @VisibleForTesting
     private synchronized void handleUserConfirmation(@UserConfirmationDef int userConfirmation) {
         if (mChannel == null) {
@@ -492,15 +508,83 @@ public class Crashes extends AbstractSonomaFeature {
     }
 
     /**
+     * Save a crash.
+     *
+     * @param thread    origin thread.
+     * @param exception exception.
+     */
+    void saveUncaughtException(Thread thread, Throwable exception) {
+        ManagedErrorLog errorLog = ErrorLogHelper.createErrorLog(mContext, thread, exception, Thread.getAllStackTraces(), mInitializeTimestamp);
+        try {
+            File errorStorageDirectory = ErrorLogHelper.getErrorStorageDirectory();
+            String filename = errorLog.getId().toString();
+            SonomaLog.debug(Crashes.LOG_TAG, "Saving uncaught exception:", exception);
+            saveErrorLog(errorLog, errorStorageDirectory, filename);
+            File throwableFile = new File(errorStorageDirectory, filename + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
+            StorageHelper.InternalStorage.writeObject(throwableFile, exception);
+            SonomaLog.debug(Crashes.LOG_TAG, "Saved Throwable as is for client side inspection in " + throwableFile);
+            if (mWrapperSdkListener != null) {
+                mWrapperSdkListener.onCrashCaptured(errorLog);
+            }
+        } catch (JSONException e) {
+            SonomaLog.error(Crashes.LOG_TAG, "Error serializing error log to JSON", e);
+        } catch (IOException e) {
+            SonomaLog.error(Crashes.LOG_TAG, "Error writing error log to file", e);
+        }
+    }
+
+    /**
+     * Serialize error log to a file.
+     */
+    private void saveErrorLog(ManagedErrorLog errorLog, File errorStorageDirectory, String filename) throws JSONException, IOException {
+        File errorLogFile = new File(errorStorageDirectory, filename + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION);
+        String errorLogString = mLogSerializer.serializeLog(errorLog);
+        StorageHelper.InternalStorage.write(errorLogFile, errorLogString);
+        SonomaLog.debug(Crashes.LOG_TAG, "Saved JSON content for ingestion into " + errorLogFile);
+    }
+
+    /**
+     * Save error log modified by a wrapper SDK.
+     *
+     * @param errorLog error log to  save or overwrite.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void saveWrapperSdkErrorLog(ManagedErrorLog errorLog) {
+        try {
+            saveErrorLog(errorLog, ErrorLogHelper.getErrorStorageDirectory(), errorLog.getId().toString());
+        } catch (JSONException e) {
+            SonomaLog.error(Crashes.LOG_TAG, "Error serializing error log to JSON", e);
+        } catch (IOException e) {
+            SonomaLog.error(Crashes.LOG_TAG, "Error writing error log to file", e);
+        }
+    }
+
+    /**
+     * Listener for Wrapper SDK. Meant only for internal use by wrapper SDK developers.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public interface WrapperSdkListener {
+
+        /**
+         * Called when crash has been caught and saved.
+         *
+         * @param errorLog generated error log for the crash.
+         */
+        void onCrashCaptured(ManagedErrorLog errorLog);
+    }
+
+    /**
      * Default crashes listener class.
      */
     private static class DefaultCrashesListener extends AbstractCrashesListener {
+
     }
 
     /**
      * Class holding an error log and its corresponding error report.
      */
     private static class ErrorLogReport {
+
         private final ManagedErrorLog log;
 
         private final ErrorReport report;

--- a/sdk/crashes/src/main/java/com/microsoft/sonoma/crashes/UncaughtExceptionHandler.java
+++ b/sdk/crashes/src/main/java/com/microsoft/sonoma/crashes/UncaughtExceptionHandler.java
@@ -1,37 +1,13 @@
 package com.microsoft.sonoma.crashes;
 
-import android.content.Context;
 import android.os.Process;
 import android.support.annotation.VisibleForTesting;
 
-import com.microsoft.sonoma.core.ingestion.models.json.DefaultLogSerializer;
-import com.microsoft.sonoma.core.ingestion.models.json.LogSerializer;
-import com.microsoft.sonoma.core.utils.SonomaLog;
-import com.microsoft.sonoma.core.utils.StorageHelper;
-import com.microsoft.sonoma.crashes.ingestion.models.ManagedErrorLog;
-import com.microsoft.sonoma.crashes.ingestion.models.json.ManagedErrorLogFactory;
-import com.microsoft.sonoma.crashes.utils.ErrorLogHelper;
-
-import org.json.JSONException;
-
-import java.io.File;
-import java.io.IOException;
-
 class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
-
-    private final Context mContext;
-
-    private final LogSerializer mLogSerializer;
 
     private boolean mIgnoreDefaultExceptionHandler = false;
 
     private Thread.UncaughtExceptionHandler mDefaultUncaughtExceptionHandler;
-
-    UncaughtExceptionHandler(Context context) {
-        mContext = context;
-        mLogSerializer = new DefaultLogSerializer();
-        mLogSerializer.addLogFactory(ManagedErrorLog.TYPE, ManagedErrorLogFactory.getInstance());
-    }
 
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
@@ -40,23 +16,7 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
                 mDefaultUncaughtExceptionHandler.uncaughtException(thread, exception);
             }
         } else {
-            ManagedErrorLog errorLog = ErrorLogHelper.createErrorLog(mContext, thread, exception, Thread.getAllStackTraces(), Crashes.getInstance().getInitializeTimestamp());
-            try {
-                File errorStorageDirectory = ErrorLogHelper.getErrorStorageDirectory();
-                String filename = errorLog.getId().toString();
-                File errorLogFile = new File(errorStorageDirectory, filename + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION);
-                File throwableFile = new File(errorStorageDirectory, filename + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
-                String errorLogString = mLogSerializer.serializeLog(errorLog);
-                SonomaLog.debug(Crashes.LOG_TAG, "Saving uncaught exception:", exception);
-                StorageHelper.InternalStorage.write(errorLogFile, errorLogString);
-                SonomaLog.debug(Crashes.LOG_TAG, "Saved JSON content for ingestion into " + errorLogFile);
-                StorageHelper.InternalStorage.writeObject(throwableFile, exception);
-                SonomaLog.debug(Crashes.LOG_TAG, "Saved Throwable as is for client side inspection in " + throwableFile);
-            } catch (JSONException e) {
-                SonomaLog.error(Crashes.LOG_TAG, "Error serializing error log to JSON", e);
-            } catch (IOException e) {
-                SonomaLog.error(Crashes.LOG_TAG, "Error writing error log to file", e);
-            }
+            Crashes.getInstance().saveUncaughtException(thread, exception);
             if (mDefaultUncaughtExceptionHandler != null) {
                 mDefaultUncaughtExceptionHandler.uncaughtException(thread, exception);
             } else {
@@ -78,7 +38,7 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
         return mDefaultUncaughtExceptionHandler;
     }
 
-    public void register() {
+    void register() {
         if (!mIgnoreDefaultExceptionHandler) {
             mDefaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         } else {
@@ -87,7 +47,7 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
         Thread.setDefaultUncaughtExceptionHandler(this);
     }
 
-    public void unregister() {
+    void unregister() {
         Thread.setDefaultUncaughtExceptionHandler(mDefaultUncaughtExceptionHandler);
     }
 


### PR DESCRIPTION
This is what Xamarin SDK uses to replace java exception by C# one when possible.
