### PR TITLE
Update badges to reflect develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://www.bitrise.io/app/78891228f9c6e6dc.svg?token=KQ6kVAci490XBjulCcQuGQ&branch=develop)](https://www.bitrise.io/app/78891228f9c6e6dc)
-[![codecov](https://codecov.io/gh/Microsoft/MobileCenter-SDK-Android/branch/master/graph/badge.svg?token=YwMZRPnYK3)](https://codecov.io/gh/Microsoft/MobileCenter-SDK-Android)
+[![codecov](https://codecov.io/gh/Microsoft/MobileCenter-SDK-Android/branch/develop/graph/badge.svg?token=YwMZRPnYK3)](https://codecov.io/gh/Microsoft/MobileCenter-SDK-Android)
 
 # Mobile Center SDK for Android
 


### PR DESCRIPTION
We can change it back on master after the merge if we choose not to do the useless merge from master to develop just for merge up-to-date status. That way the status of the badge will reflect the correct branch.