### PR TITLE
Disable services if AppCenter is disabled 

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -452,7 +452,7 @@ public class Analytics extends AbstractAppCenterService {
         }
 
         /* Release resources if disabled and enabled before with resources. */
-        else {
+        else if (mSessionTracker != null) {
             mChannel.removeListener(mSessionTracker);
             mSessionTracker.clearSessions();
             mSessionTracker = null;

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -489,6 +489,19 @@ public class AnalyticsTest {
     }
 
     @Test
+    public void disablePersisted() {
+        when(StorageHelper.PreferencesStorage.getBoolean(ANALYTICS_ENABLED_KEY, true)).thenReturn(false);
+        Analytics analytics = Analytics.getInstance();
+
+        /* Start. */
+        Channel channel = mock(Channel.class);
+        analytics.onStarting(mAppCenterHandler);
+        analytics.onStarted(mock(Context.class), "", channel);
+        verify(channel, never()).removeListener(any(Channel.Listener.class));
+        verify(channel, never()).addListener(any(Channel.Listener.class));
+    }
+
+    @Test
     public void startSessionAfterUserApproval() {
 
         /*

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -444,6 +444,8 @@ public class CrashesTest {
 
     @Test
     public void noQueueingWhenDisabled() {
+        mockStatic(ErrorLogHelper.class);
+        when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(errorStorageDirectory.getRoot());
         when(StorageHelper.PreferencesStorage.getBoolean(CRASHES_ENABLED_KEY, true)).thenReturn(false);
         Channel channel = mock(Channel.class);
         Crashes crashes = Crashes.getInstance();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -134,7 +134,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
 
         /* Initialize channel group. */
         String groupName = getGroupName();
-        if (groupName != null) {
+        if (mChannel != null && groupName != null) {
 
             /* Register service to channel on enabling. */
             if (enabled) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -152,8 +152,12 @@ public abstract class AbstractAppCenterService implements AppCenterService {
         StorageHelper.PreferencesStorage.putBoolean(getEnabledPreferenceKey(), enabled);
         AppCenterLog.info(getLoggerTag(), String.format("%s service has been %s.", getServiceName(), enabled ? "enabled" : "disabled"));
 
-        /* Allow sub-class to handle state change. */
-        applyEnabledState(enabled);
+        /* Don't call it before the service starts. */
+        if (mChannel != null) {
+
+            /* Allow sub-class to handle state change. */
+            applyEnabledState(enabled);
+        }
     }
 
     protected synchronized void applyEnabledState(boolean enabled) {
@@ -189,9 +193,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
             }
         }
         mChannel = channel;
-        if (enabled) {
-            applyEnabledState(true);
-        }
+        applyEnabledState(enabled);
     }
 
     @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -554,6 +554,7 @@ public class AppCenter {
 
     @WorkerThread
     private void finishStartServices(Iterable<AppCenterService> services) {
+        boolean enabled = isInstanceEnabled();
         List<String> serviceNames = new ArrayList<>();
         for (AppCenterService service : services) {
             Map<String, LogFactory> logFactories = service.getLogFactories();
@@ -561,6 +562,9 @@ public class AppCenter {
                 for (Map.Entry<String, LogFactory> logFactory : logFactories.entrySet()) {
                     mLogSerializer.addLogFactory(logFactory.getKey(), logFactory.getValue());
                 }
+            }
+            if (!enabled && service.isInstanceEnabled()) {
+                service.setInstanceEnabled(false);
             }
             service.onStarted(mApplication, mAppSecret, mChannel);
             AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started.");

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -554,6 +554,28 @@ public class AppCenterTest {
     }
 
     @Test
+    public void disableBetweenStartCalls() {
+        DummyService dummyService = DummyService.getInstance();
+        AnotherDummyService anotherDummyService = AnotherDummyService.getInstance();
+
+        /* Start App Center SDK with one service. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+        assertTrue(AppCenter.isEnabled().get());
+        assertTrue(dummyService.isInstanceEnabled());
+
+        /* Disable. */
+        AppCenter.setEnabled(false);
+        assertFalse(AppCenter.isEnabled().get());
+        assertFalse(dummyService.isInstanceEnabled());
+
+        /* Start another one service. */
+        AppCenter.start(AnotherDummyService.class);
+        assertFalse(AppCenter.isEnabled().get());
+        assertFalse(dummyService.isInstanceEnabled());
+        assertFalse(anotherDummyService.isInstanceEnabled());
+    }
+
+    @Test
     public void enableBeforeConfiguredTest() {
         /* Test isEnabled and setEnabled before configure */
         assertFalse(AppCenter.isEnabled().get());

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -566,13 +566,16 @@ public class AppCenterTest {
     @Test
     public void disablePersisted() {
         when(StorageHelper.PreferencesStorage.getBoolean(KEY_ENABLED, true)).thenReturn(false);
+        when(StorageHelper.PreferencesStorage.getBoolean(AnotherDummyService.getInstance().getEnabledPreferenceKey(), true)).thenReturn(false);
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class, AnotherDummyService.class);
         AppCenter appCenter = AppCenter.getInstance();
 
         /* Verify services are disabled by default if App Center is disabled. */
         assertFalse(AppCenter.isEnabled().get());
         for (AppCenterService service : appCenter.getServices()) {
-            assertFalse(((AbstractAppCenterService) service).isInstanceEnabledAsync().get());
+            assertFalse(service.isInstanceEnabled());
+            verify((AbstractAppCenterService) service).applyEnabledState(eq(false));
+            verify((AbstractAppCenterService) service, never()).applyEnabledState(eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(service);
         }
 
@@ -580,7 +583,8 @@ public class AppCenterTest {
         AppCenter.setEnabled(true);
         assertTrue(AppCenter.isEnabled().get());
         for (AppCenterService service : appCenter.getServices()) {
-            assertTrue(((AbstractAppCenterService) service).isInstanceEnabledAsync().get());
+            assertTrue(service.isInstanceEnabled());
+            verify((AbstractAppCenterService) service).applyEnabledState(eq(true));
         }
     }
 


### PR DESCRIPTION
In a case when `AppCenter` is disabled, but some service is enabled, `applyEnabledState(true)` was called.
It's causing some issues, for example, rum sending network requests while `AppCenter` is disabled.