### PR TITLE
use tester app to enable in-app updates if it’s installed

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DeepLinkActivity.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DeepLinkActivity.java
@@ -8,6 +8,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 
 import static com.microsoft.appcenter.distribute.DistributeConstants.EXTRA_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.EXTRA_REQUEST_ID;
+import static com.microsoft.appcenter.distribute.DistributeConstants.EXTRA_TESTER_APP_UPDATE_SETUP_FAILED;
 import static com.microsoft.appcenter.distribute.DistributeConstants.EXTRA_UPDATE_TOKEN;
 import static com.microsoft.appcenter.distribute.DistributeConstants.EXTRA_UPDATE_SETUP_FAILED;
 import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
@@ -27,11 +28,13 @@ public class DeepLinkActivity extends Activity {
         String distributionGroupId = intent.getStringExtra(EXTRA_DISTRIBUTION_GROUP_ID);
         String updateToken = intent.getStringExtra(EXTRA_UPDATE_TOKEN);
         String updateSetupFailed = intent.getStringExtra(EXTRA_UPDATE_SETUP_FAILED);
+        String testerAppUpdateSetupFailed = intent.getStringExtra(EXTRA_TESTER_APP_UPDATE_SETUP_FAILED);
         AppCenterLog.debug(LOG_TAG, getLocalClassName() + ".getIntent()=" + intent);
         AppCenterLog.debug(LOG_TAG, "Intent requestId=" + requestId);
         AppCenterLog.debug(LOG_TAG, "Intent distributionGroupId=" + distributionGroupId);
         AppCenterLog.debug(LOG_TAG, "Intent updateToken passed=" + (updateToken != null));
         AppCenterLog.debug(LOG_TAG, "Intent updateSetupFailed passed=" + (updateSetupFailed != null));
+        AppCenterLog.debug(LOG_TAG, "Intent testerAppUpdateSetupFailed passed=" + (testerAppUpdateSetupFailed != null));
 
         /* Store redirection parameters if both required values were passed. */
         if (requestId != null && distributionGroupId != null) {
@@ -41,6 +44,9 @@ public class DeepLinkActivity extends Activity {
             /* Otherwise just store error message to show update failure dialog in future. */
             Distribute.getInstance().storeUpdateSetupFailedParameter(requestId, updateSetupFailed);
         }
+
+        /* If tester app update setup failed, store that info to later retry using the browser update setup */
+        Distribute.getInstance().storeTesterAppUpdateSetupFailedParameter(requestId, testerAppUpdateSetupFailed);
 
         /*
          * Resume app exactly where it was before with no activity duplicate, or starting the

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DeepLinkActivity.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DeepLinkActivity.java
@@ -46,7 +46,9 @@ public class DeepLinkActivity extends Activity {
         }
 
         /* If tester app update setup failed, store that info to later retry using the browser update setup */
-        Distribute.getInstance().storeTesterAppUpdateSetupFailedParameter(requestId, testerAppUpdateSetupFailed);
+        if (requestId != null && testerAppUpdateSetupFailed != null) {
+            Distribute.getInstance().storeTesterAppUpdateSetupFailedParameter(requestId, testerAppUpdateSetupFailed);
+        }
 
         /*
          * Resume app exactly where it was before with no activity duplicate, or starting the

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -839,7 +839,7 @@ public class Distribute extends AbstractAppCenterService {
     }
 
     /**
-     * Store a flag for failure to enable updates from the tester apps, to later reattempt using the
+     * Store a flag for failure to enable updates from the tester apps, to later reattempt using the browser update setup.
      */
     synchronized void storeTesterAppUpdateSetupFailedParameter(@NonNull String requestId, @NonNull String updateSetupFailed) {
         if (requestId.equals(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID))) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -406,7 +406,6 @@ public class Distribute extends AbstractAppCenterService {
             AppCenterLog.info(LOG_TAG, "Launcher activity restarted.");
             if (getStoredDownloadState() == DOWNLOAD_STATE_COMPLETED) {
                 mWorkflowCompleted = false;
-                mTesterAppOpenedOrAborted = false;
                 mBrowserOpenedOrAborted = false;
             }
         }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -465,6 +465,7 @@ public class Distribute extends AbstractAppCenterService {
             PreferencesStorage.remove(PREFERENCE_KEY_POSTPONE_TIME);
             PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
             PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+            PreferencesStorage.remove(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
 
             /* Disable the distribute info tracker. */
             mChannel.removeListener(mDistributeInfoTracker);
@@ -611,6 +612,7 @@ public class Distribute extends AbstractAppCenterService {
                     AppCenterLog.info(LOG_TAG, "Re-attempting in-app updates setup and cleaning up failure info from storage.");
                     PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
                     PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+                    PreferencesStorage.remove(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
                 }
             }
 
@@ -1288,6 +1290,7 @@ public class Distribute extends AbstractAppCenterService {
 
             /* Clear the update setup failure info from storage, to re-attempt setup on reinstall. */
             PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+            PreferencesStorage.remove(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
         } else {
             showDisabledToast();
         }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -750,11 +750,11 @@ public class Distribute extends AbstractAppCenterService {
 
     private boolean isAppCenterTesterAppInstalled() {
         try {
-            PackageInfo testerApp = mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0);
-            return testerApp != null;
+            mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0);
         } catch (PackageManager.NameNotFoundException ignored) {
             return false;
         }
+        return true;
     }
 
     private void decryptAndGetReleaseDetails(String updateToken, String distributionGroupId, boolean mobileCenterFailOver) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -753,8 +753,8 @@ public class Distribute extends AbstractAppCenterService {
 
     private boolean isAppCenterTesterAppInstalled() {
         try {
-            mPackageInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
-            return true;
+            PackageInfo testerApp = mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0);
+            return testerApp != null;
         } catch (PackageManager.NameNotFoundException e) {
         }
         return false;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -750,7 +750,7 @@ public class Distribute extends AbstractAppCenterService {
 
     private boolean isAppCenterTesterAppInstalled() {
         try {
-            PackageInfo testerApp = mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0);
+            PackageInfo testerApp = mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0);
             return testerApp != null;
         } catch (PackageManager.NameNotFoundException ignored) {
             return false;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -738,7 +738,7 @@ public class Distribute extends AbstractAppCenterService {
 
             /* If not, open native app (if installed) to update setup, unless it already failed. */
             String testerAppUpdateSetupFailedMessage = PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-            boolean testerAppUpdateSetupFailed = testerAppUpdateSetupFailedMessage == null || testerAppUpdateSetupFailedMessage.isEmpty();
+            boolean testerAppUpdateSetupFailed = testerAppUpdateSetupFailedMessage != null && !testerAppUpdateSetupFailedMessage.isEmpty();
             if (isAppCenterTesterAppInstalled() && !mTesterAppOpenedOrAborted && !testerAppUpdateSetupFailed) {
                 mTesterAppOpenedOrAborted = DistributeUtils.updateSetupUsingTesterApp(mForegroundActivity, mPackageInfo);
             }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -740,7 +740,7 @@ public class Distribute extends AbstractAppCenterService {
             String testerAppUpdateSetupFailedMessage = PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
             boolean testerAppUpdateSetupFailed = testerAppUpdateSetupFailedMessage == null || testerAppUpdateSetupFailedMessage.isEmpty();
             if (isAppCenterTesterAppInstalled() && !mTesterAppOpenedOrAborted && !testerAppUpdateSetupFailed) {
-                mTesterAppOpenedOrAborted = DistributeUtils.updateSetupUsingTesterApp(mForegroundActivity, mAppSecret, mPackageInfo);
+                mTesterAppOpenedOrAborted = DistributeUtils.updateSetupUsingTesterApp(mForegroundActivity, mPackageInfo);
             }
 
             /* If the native app could not be opened, use the browser to update setup. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -755,7 +755,7 @@ public class Distribute extends AbstractAppCenterService {
         try {
             PackageInfo testerApp = mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0);
             return testerApp != null;
-        } catch (PackageManager.NameNotFoundException e) {
+        } catch (PackageManager.NameNotFoundException ignored) {
             return false;
         }
     }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -760,7 +760,7 @@ public class Distribute extends AbstractAppCenterService {
 
             /* If not, open native app (if installed) to update setup, unless it already failed. Otherwise, use the browser. */
             String testerAppUpdateSetupFailedMessage = PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-            boolean shouldUseTesterAppForUpdateSetup = isAppCenterTesterAppInstalled() && (testerAppUpdateSetupFailedMessage == null || testerAppUpdateSetupFailedMessage.isEmpty());
+            boolean shouldUseTesterAppForUpdateSetup = isAppCenterTesterAppInstalled() && TextUtils.isEmpty(testerAppUpdateSetupFailedMessage);
             if (shouldUseTesterAppForUpdateSetup && !mTesterAppOpenedOrAborted) {
                 DistributeUtils.updateSetupUsingTesterApp(mForegroundActivity, mPackageInfo);
                 mTesterAppOpenedOrAborted = true;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -41,6 +41,11 @@ final class DistributeConstants {
     static final String EXTRA_UPDATE_SETUP_FAILED = "update_setup_failed";
 
     /**
+     * Used for deep link intent from browser, string field for tester app update setup failed identifier.
+     */
+    static final String EXTRA_TESTER_APP_UPDATE_SETUP_FAILED = "tester_app_update_setup_failed";
+
+    /**
      * Base URL used to open browser to check install and get API token to check latest release.
      */
     static final String DEFAULT_INSTALL_URL = "https://install.appcenter.ms";
@@ -235,6 +240,11 @@ final class DistributeConstants {
      * Preference key for update setup failure error message.
      */
     static final String PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY = PREFERENCE_PREFIX + "update_setup_failed_message";
+
+    /**
+     * Preference key for tester app update setup failure error message.
+     */
+    static final String PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY = PREFERENCE_PREFIX + "tester_app_update_setup_failed_message";
 
     @VisibleForTesting
     DistributeConstants() {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -119,7 +119,7 @@ class DistributeUtils {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + activity.getPackageName();
         url += "&" + PARAMETER_REDIRECT_SCHEME + "=" + "appcenter";
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
-        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
+        url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         AppCenterLog.debug(LOG_TAG, "No token, need to open tester app to url=" + url);
 
         /* Store request id. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -125,7 +125,7 @@ class DistributeUtils {
 
         /* Open the native tester app */
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         activity.startActivity(intent);
     }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -99,12 +99,11 @@ class DistributeUtils {
      * Update setup using native tester app.
      *
      * @param activity    activity from which to start tester app.
-     * @param appSecret   application secret.
      * @param packageInfo package info.
      *
      * @return whether the tester app was opened or not.
      */
-    static boolean updateSetupUsingTesterApp(Activity activity, String appSecret, PackageInfo packageInfo) {
+    static boolean updateSetupUsingTesterApp(Activity activity, PackageInfo packageInfo) {
 
         /* Compute hash. */
         String releaseHash = computeReleaseHash(packageInfo);
@@ -113,8 +112,7 @@ class DistributeUtils {
         String requestId = UUIDUtils.randomUUID().toString();
 
         /* Build URL. */
-        String url = "ms-actesterapp://";
-        url += String.format(UPDATE_SETUP_PATH_FORMAT, appSecret);
+        String url = "ms-actesterapp://update-setup";
         url += "?" + PARAMETER_RELEASE_HASH + "=" + releaseHash;
         url += "&" + PARAMETER_REDIRECT_ID + "=" + activity.getPackageName();
         url += "&" + PARAMETER_REDIRECT_SCHEME + "=" + "appcenter";

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -103,7 +103,7 @@ class DistributeUtils {
      *
      * @return whether the tester app was opened or not.
      */
-    static boolean updateSetupUsingTesterApp(Activity activity, PackageInfo packageInfo) {
+    static void updateSetupUsingTesterApp(Activity activity, PackageInfo packageInfo) {
 
         /* Compute hash. */
         String releaseHash = computeReleaseHash(packageInfo);
@@ -125,13 +125,7 @@ class DistributeUtils {
 
         /* Open the native tester app */
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        try {
-            activity.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
-            AppCenterLog.error(LOG_TAG, "The tester app could not be opened with url=" + url);
-            return false;
-        }
-        return true;
+        activity.startActivity(intent);
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -108,8 +108,6 @@ class DistributeUtils {
      *
      * @param activity    activity from which to start tester app.
      * @param packageInfo package info.
-     *
-     * @return whether the tester app was opened or not.
      */
     static void updateSetupUsingTesterApp(Activity activity, PackageInfo packageInfo) {
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -125,6 +125,7 @@ class DistributeUtils {
 
         /* Open the native tester app */
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         activity.startActivity(intent);
     }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -2,7 +2,6 @@ package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
 import android.app.Notification;
-import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.net.Uri;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import com.microsoft.appcenter.utils.HashUtils;
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -37,6 +38,12 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.UPDATE_SETU
  * Some static util methods to avoid the main file getting too big.
  */
 class DistributeUtils {
+
+    /**
+     * Scheme used to open the native Android tester app.
+     */
+    @VisibleForTesting
+    static final String TESTER_APP_URL_SCHEME = "com.microsoft.hockeyapp.testerapp";
 
     /**
      * Get the intent used to open installation U.I.

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DeepLinkActivityTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DeepLinkActivityTest.java
@@ -95,6 +95,27 @@ public class DeepLinkActivityTest {
     }
 
     @Test
+    public void validWithTesterAppUpdateSetupFailedAndNoTaskRoot() {
+
+         /* Build valid intent. */
+        Intent intent = mock(Intent.class);
+        when(intent.getStringExtra(DistributeConstants.EXTRA_REQUEST_ID)).thenReturn("mock1");
+        when(intent.getStringExtra(DistributeConstants.EXTRA_TESTER_APP_UPDATE_SETUP_FAILED)).thenReturn("mock2");
+        when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
+
+        /* Start activity. */
+        DeepLinkActivity activity = spy(new DeepLinkActivity());
+        when(activity.getIntent()).thenReturn(intent);
+        activity.onCreate(null);
+
+         /* Verify interactions. */
+        verify(activity, never()).startActivity(any(Intent.class));
+        verify(mDistribute, never()).storeRedirectionParameters(anyString(), anyString(), anyString());
+        verify(activity).finish();
+        verify(mDistribute).storeTesterAppUpdateSetupFailedParameter("mock1", "mock2");
+    }
+
+    @Test
     public void validAndNoTaskRoot() {
 
         /* Build valid intent. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -207,6 +207,17 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
     }
 
     @Test
+    public void storeTesterAppUpdateSetupFailedParameterBeforeStart() throws Exception {
+
+        /* Setup mock. */
+        when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn("r");
+        start();
+        Distribute.getInstance().storeTesterAppUpdateSetupFailedParameter("r", "error_message");
+        verifyStatic();
+        PreferencesStorage.putString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY, "error_message");
+    }
+
+    @Test
     public void storeUpdateSetupFailedParameterWithIncorrectRequestIdBeforeStart() throws Exception {
 
         /* Setup mock. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -2,7 +2,6 @@ package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -54,6 +54,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_REQUEST_ID;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TOKEN;
@@ -282,6 +283,9 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
     @Test
     public void postponeBrowserIfNoNetwork() throws Exception {
 
+        /* Setup mock. */
+        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
+
         /* Check browser not opened if no network. */
         when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
         start();
@@ -443,6 +447,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         whenNew(HttpClientNetworkStateHandler.class).withAnyArguments().thenReturn(httpClient);
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
 
         /* Start and resume: open browser. */
@@ -563,6 +568,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         start();
@@ -682,6 +688,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         start();
@@ -734,6 +741,9 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
     @Test
     public void disableBeforeStoreToken() {
+
+        /* Setup mock. */
+        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         UUID requestId = UUID.randomUUID();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -445,7 +445,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
-        when(mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         start();
@@ -481,7 +481,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         whenNew(Intent.class).withArguments(Intent.ACTION_VIEW, Uri.parse(url)).thenReturn(mock(Intent.class));
-        when(mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenReturn(mock(PackageInfo.class));
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenReturn(mock(PackageInfo.class));
 
         /* Start and resume: open tester app. */
         start();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -2,6 +2,7 @@ package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -9,6 +10,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.microsoft.appcenter.channel.Channel;
@@ -283,9 +285,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
     @Test
     public void postponeBrowserIfNoNetwork() throws Exception {
 
-        /* Setup mock. */
-        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
-
         /* Check browser not opened if no network. */
         when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
         start();
@@ -447,7 +446,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         whenNew(HttpClientNetworkStateHandler.class).withAnyArguments().thenReturn(httpClient);
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
-        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
 
         /* Start and resume: open browser. */
@@ -568,7 +566,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
-        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         start();
@@ -688,7 +685,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
-        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         start();
@@ -741,9 +737,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
     @Test
     public void disableBeforeStoreToken() {
-
-        /* Setup mock. */
-        when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
 
         /* Start and resume: open browser. */
         UUID requestId = UUID.randomUUID();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -284,6 +284,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
     @Test
     public void postponeBrowserIfNoNetwork() throws Exception {
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Check browser not opened if no network. */
         when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
@@ -584,6 +585,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         start();
@@ -703,6 +705,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         start();
@@ -822,6 +825,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         start();
@@ -873,7 +877,8 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
     }
 
     @Test
-    public void disableBeforeStoreToken() {
+    public void disableBeforeStoreToken() throws Exception {
+        when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         UUID requestId = UUID.randomUUID();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -439,6 +439,32 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
     }
 
     @Test
+    public void testerAppNotInstalled() throws Exception {
+
+        /* Setup mock. */
+        UUID requestId = UUID.randomUUID();
+        when(UUIDUtils.randomUUID()).thenReturn(requestId);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
+        when(mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0)).thenThrow(new PackageManager.NameNotFoundException());
+
+        /* Start and resume: open browser. */
+        start();
+        Distribute.getInstance().onActivityResumed(mActivity);
+        verifyStatic();
+        String url = DistributeConstants.DEFAULT_INSTALL_URL;
+        url += String.format(UPDATE_SETUP_PATH_FORMAT, "a");
+        url += "?" + PARAMETER_RELEASE_HASH + "=" + TEST_HASH;
+        url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
+        url += "&" + PARAMETER_REDIRECT_SCHEME + "=" + "appcenter";
+        url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
+        url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
+        BrowserUtils.openBrowser(url, mActivity);
+        verifyStatic();
+        PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
+    }
+
+    @Test
     public void happyPathUsingTesterAppUpdateSetup() throws Exception {
 
         /* Setup mock. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -475,6 +475,11 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
+        /* Mock install id from AppCenter. */
+        UUID installId = UUID.randomUUID();
+        when(mAppCenterFuture.get()).thenReturn(installId);
+        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
+
         /* Start and resume: open browser. */
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
@@ -487,6 +492,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
+        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -445,7 +445,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         UUID requestId = UUID.randomUUID();
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
-        when(mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0)).thenThrow(new PackageManager.NameNotFoundException());
+        when(mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenThrow(new PackageManager.NameNotFoundException());
 
         /* Start and resume: open browser. */
         start();
@@ -474,18 +474,18 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         when(UUIDUtils.randomUUID()).thenReturn(requestId);
         when(PreferencesStorage.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn(null);
         when(PreferencesStorage.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
-        whenNew(Intent.class).withArguments(Intent.ACTION_VIEW).thenReturn(mock(Intent.class));
-        when(mContext.getPackageManager().getPackageInfo("com.microsoft.hockeyapp.testerapp", 0)).thenReturn(mock(PackageInfo.class));
-
-        /* Start and resume: open tester app. */
-        start();
-        Distribute.getInstance().onActivityResumed(mActivity);
         String url = "ms-actesterapp://update-setup";
         url += "?" + PARAMETER_RELEASE_HASH + "=" + TEST_HASH;
         url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
         url += "&" + PARAMETER_REDIRECT_SCHEME + "=" + "appcenter";
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        whenNew(Intent.class).withArguments(Intent.ACTION_VIEW, Uri.parse(url)).thenReturn(mock(Intent.class));
+        when(mContext.getPackageManager().getPackageInfo(DistributeUtils.TESTER_APP_URL_SCHEME, 0)).thenReturn(mock(PackageInfo.class));
+
+        /* Start and resume: open tester app. */
+        start();
+        Distribute.getInstance().onActivityResumed(mActivity);
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         verify(mActivity).startActivity(intent);
         verifyStatic();


### PR DESCRIPTION
Apps installed using the native tester app currently aren't able to successfully enable in-app updates, because the cookies stored on install aren't there. This is part of the work to fix that.

When enabling in-app updates, the Android SDK should check if an app with the ms-actesterapp:// scheme (belongs to the App Center tester app) is installed. If it is, then it should try to enable in-app updates by redirecting to that scheme instead of the update-setup page on the install portal. If for some reason enabling in-app updates fails, then the SDK should fall back to attempting to enable in-app updates using the update-setup page. This could happen if someone has the native tester app installed, but for some reason they still install an app from the install portal. The user will see two attempts to enable in-app updates in this case, but hopefully this is rare. We will track telemetry for how often this happens.