### PR TITLE
Add tracking of the distribution group ID to Analytics

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTracker.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTracker.java
@@ -1,0 +1,52 @@
+package com.microsoft.appcenter.distribute.channel;
+
+import android.support.annotation.NonNull;
+
+import com.microsoft.appcenter.channel.AbstractChannelListener;
+import com.microsoft.appcenter.ingestion.models.Log;
+
+/**
+ * Channel listener which adds extra fields to logs.
+ */
+public class DistributeInfoTracker extends AbstractChannelListener {
+
+    /**
+     * Distribution group ID that is added to logs (if exists).
+     */
+    private String mDistributionGroupId;
+
+    /**
+     * Init.
+     *
+     * @param distributionGroupId distribution group ID that is added to logs (if exists).
+     */
+    public DistributeInfoTracker(String distributionGroupId) {
+        mDistributionGroupId = distributionGroupId;
+    }
+
+    @Override
+    synchronized public void onEnqueuingLog(@NonNull Log log, @NonNull String groupName) {
+        if (mDistributionGroupId == null) {
+            return;
+        }
+
+        /* Set current distribution group ID. */
+        log.setDistributionGroupId(mDistributionGroupId);
+    }
+
+    /**
+     * Update the distribution group ID value that is added to logs.
+     *
+     * @param distributionGroupId the distribution group ID value that is added to logs.
+     */
+    synchronized public void updateDistributionGroupId(String distributionGroupId) {
+        mDistributionGroupId = distributionGroupId;
+    }
+
+    /**
+     * Don't add the distribution group ID value to logs.
+     */
+    synchronized public void removeDistributionGroupId() {
+        mDistributionGroupId = null;
+    }
+}

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeAfterDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeAfterDownloadTest.java
@@ -15,6 +15,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
+import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpClientNetworkStateHandler;
 import com.microsoft.appcenter.http.ServiceCall;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.AppCenterHandler;
 import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
@@ -102,6 +103,9 @@ public class AbstractDistributeTest {
     @Mock
     private AppCenterFuture<Boolean> mBooleanAppCenterFuture;
 
+    @Mock
+    DistributeInfoTracker mDistributeInfoTracker;
+
     @Before
     @SuppressLint("ShowToast")
     @SuppressWarnings("ResourceType")
@@ -119,6 +123,7 @@ public class AbstractDistributeTest {
                 return null;
             }
         }).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
+        whenNew(DistributeInfoTracker.class).withAnyArguments().thenReturn(mDistributeInfoTracker);
 
         /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */
         mockStatic(PreferencesStorage.class);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -12,6 +12,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpClientNetworkStateHandler;
 import com.microsoft.appcenter.http.HttpException;
@@ -242,6 +243,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         HashMap<String, String> headers = new HashMap<>();
         headers.put(DistributeConstants.HEADER_API_TOKEN, "some token");
         verify(httpClient).callAsync(anyString(), anyString(), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
@@ -275,6 +277,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         HashMap<String, String> headers = new HashMap<>();
         verify(httpClient).callAsync(anyString(), anyString(), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
@@ -483,6 +486,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         HashMap<String, String> headers = new HashMap<>();
         headers.put(DistributeConstants.HEADER_API_TOKEN, "some token");
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
@@ -508,6 +512,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
 
             @Override
@@ -532,6 +537,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
 
             @Override
@@ -602,6 +608,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         HashMap<String, String> headers = new HashMap<>();
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
 
@@ -626,6 +633,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
 
             @Override
@@ -650,6 +658,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_ID);
         verifyStatic();
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
+        verify(mDistributeInfoTracker).updateDistributionGroupId("g");
         verify(httpClient).callAsync(argThat(new ArgumentMatcher<String>() {
 
             @Override
@@ -1066,6 +1075,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_TOKEN, "some token MC");
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, "some group MC");
+        verify(mDistributeInfoTracker).updateDistributionGroupId("some group MC");
     }
 
     @Test
@@ -1086,5 +1096,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         PreferencesStorage.putString(eq(PREFERENCE_KEY_UPDATE_TOKEN), anyString());
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, "some group MC");
+        verify(mDistributeInfoTracker).updateDistributionGroupId("some group MC");
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTrackerTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTrackerTest.java
@@ -1,0 +1,91 @@
+package com.microsoft.appcenter.distribute.channel;
+
+import android.support.annotation.NonNull;
+
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.ingestion.models.AbstractLog;
+import com.microsoft.appcenter.ingestion.models.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.util.UUID;
+
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+
+@SuppressWarnings("unused")
+@PrepareForTest(DistributeInfoTracker.class)
+public class DistributeInfoTrackerTest {
+
+    private final static String TEST_GROUP = "group_test";
+
+    private Channel mChannel;
+
+    @NonNull
+    private static MockLog newLog() {
+        MockLog log = new MockLog();
+        return log;
+    }
+
+    @Before
+    public void setUp() {
+        mChannel = mock(Channel.class);
+    }
+
+    @Test
+    public void addDistributionGroupIdToLogsTest() {
+        String distributionGroupId = UUID.randomUUID().toString();
+        DistributeInfoTracker distributeInfoTracker = new DistributeInfoTracker(distributionGroupId);
+
+        /* Distribution group ID field is added to logs. */
+        {
+            Log log = newLog();
+            distributeInfoTracker.onEnqueuingLog(log, TEST_GROUP);
+            assertNotNull(log.getDistributionGroupId());
+            assertEquals(distributionGroupId, log.getDistributionGroupId());
+        }
+    }
+
+    @Test
+    public void setNewDistributionGroupIdTest() {
+        String distributionGroupId1 = null;
+        String distributionGroupId2 = UUID.randomUUID().toString();
+        DistributeInfoTracker distributeInfoTracker = new DistributeInfoTracker(distributionGroupId1);
+
+        /* No distribution group ID field is added to logs because value is null. */
+        {
+            Log log = newLog();
+            distributeInfoTracker.onEnqueuingLog(log, TEST_GROUP);
+            assertNull(log.getDistributionGroupId());
+        }
+
+        /* Distribution group ID field is added to logs after the value was fetched and saved. */
+        {
+            distributeInfoTracker.updateDistributionGroupId(distributionGroupId2);
+            Log log = newLog();
+            distributeInfoTracker.onEnqueuingLog(log, TEST_GROUP);
+            assertEquals(distributionGroupId2, log.getDistributionGroupId());
+        }
+
+        /* No distribution group ID field is added after the value was removed. */
+        {
+            distributeInfoTracker.removeDistributionGroupId();
+            Log log = newLog();
+            distributeInfoTracker.onEnqueuingLog(log, TEST_GROUP);
+            assertNull(log.getDistributionGroupId());
+        }
+    }
+
+    private static class MockLog extends AbstractLog {
+
+        @Override
+        public String getType() {
+            return null;
+        }
+    }
+}

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
@@ -33,6 +33,12 @@ public abstract class AbstractLog implements Log {
     static final String SID = "sid";
 
     /**
+     * Distribution group ID property.
+     */
+    @VisibleForTesting
+    static final String DISTRIBUTION_GROUP_ID = "distributionGroupId";
+
+    /**
      * device property.
      */
     @VisibleForTesting
@@ -47,6 +53,11 @@ public abstract class AbstractLog implements Log {
      * The session identifier that was provided when the session was started.
      */
     private UUID sid;
+
+    /**
+     * Optional distribution group ID value.
+     */
+    private String distributionGroupId;
 
     /**
      * Device characteristics associated to this log.
@@ -82,6 +93,24 @@ public abstract class AbstractLog implements Log {
     }
 
     /**
+     * Get the distributionGroupId value.
+     *
+     * @return the distributionGroupId value.
+     */
+    public String getDistributionGroupId() {
+        return this.distributionGroupId;
+    }
+
+    /**
+     * Set the distributionGroupId value.
+     *
+     * @param distributionGroupId the distributionGroupId value to set.
+     */
+    public void setDistributionGroupId(String distributionGroupId) {
+        this.distributionGroupId = distributionGroupId;
+    }
+
+    /**
      * Get the device value.
      *
      * @return the device value
@@ -104,6 +133,7 @@ public abstract class AbstractLog implements Log {
         JSONUtils.write(writer, TYPE, getType());
         writer.key(TIMESTAMP).value(JSONDateUtils.toString(getTimestamp()));
         JSONUtils.write(writer, SID, getSid());
+        JSONUtils.write(writer, DISTRIBUTION_GROUP_ID, getDistributionGroupId());
         if (getDevice() != null) {
             writer.key(DEVICE).object();
             getDevice().write(writer);
@@ -119,6 +149,9 @@ public abstract class AbstractLog implements Log {
         setTimestamp(JSONDateUtils.toDate(object.getString(TIMESTAMP)));
         if (object.has(SID)) {
             setSid(UUID.fromString(object.getString(SID)));
+        }
+        if (object.has(DISTRIBUTION_GROUP_ID)) {
+            setDistributionGroupId(object.getString(DISTRIBUTION_GROUP_ID));
         }
         if (object.has(DEVICE)) {
             Device device = new Device();
@@ -143,6 +176,9 @@ public abstract class AbstractLog implements Log {
         if (sid != null ? !sid.equals(that.sid) : that.sid != null) {
             return false;
         }
+        if (distributionGroupId != null ? !distributionGroupId.equals(that.distributionGroupId) : that.distributionGroupId != null) {
+            return false;
+        }
         return device != null ? device.equals(that.device) : that.device == null;
     }
 
@@ -150,6 +186,7 @@ public abstract class AbstractLog implements Log {
     public int hashCode() {
         int result = timestamp != null ? timestamp.hashCode() : 0;
         result = 31 * result + (sid != null ? sid.hashCode() : 0);
+        result = 31 * result + (distributionGroupId != null ? distributionGroupId.hashCode() : 0);
         result = 31 * result + (device != null ? device.hashCode() : 0);
         return result;
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
@@ -41,6 +41,20 @@ public interface Log extends Model {
     void setSid(UUID sid);
 
     /**
+     * Get the distributionGroupId value.
+     *
+     * @return the distributionGroupId value.
+     */
+    String getDistributionGroupId();
+
+    /**
+     * Set the distributionGroupId value.
+     *
+     * @param distributionGroupId the distributionGroupId value to set.
+     */
+    void setDistributionGroupId(String distributionGroupId);
+
+    /**
      * Get the device value.
      *
      * @return the device value

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
@@ -62,6 +62,16 @@ public class AbstractLogTest {
         b.setSid(sid1);
         checkEquals(a, b);
 
+        /* Distribution group ID. */
+        String distributionGroupId1 = UUID.randomUUID().toString();
+        String distributionGroupId2 = UUID.randomUUID().toString();
+        a.setDistributionGroupId(distributionGroupId1);
+        checkNotEquals(a, b);
+        b.setDistributionGroupId(distributionGroupId2);
+        checkNotEquals(a, b);
+        b.setDistributionGroupId(distributionGroupId1);
+        checkEquals(a, b);
+
         /* Device. */
         Device d1 = new Device();
         d1.setLocale("a");
@@ -87,21 +97,26 @@ public class AbstractLogTest {
     public void readWithoutOptionalPropertiesTest() throws JSONException {
         AbstractLog mockLog = new MockLogWithType();
         UUID uuid = UUID.randomUUID();
+        String distributionGroupId = UUID.randomUUID().toString();
 
         JSONObject mockJsonObject = mock(JSONObject.class);
         when(mockJsonObject.getString(CommonProperties.TYPE)).thenReturn(mockLog.getType());
         when(mockJsonObject.getString(AbstractLog.TIMESTAMP)).thenReturn("2017-07-08T01:17:43.245Z");
         when(mockJsonObject.has(AbstractLog.SID)).thenReturn(false).thenReturn(true);
+        when(mockJsonObject.has(AbstractLog.DISTRIBUTION_GROUP_ID)).thenReturn(false).thenReturn(true);
         when(mockJsonObject.has(AbstractLog.DEVICE)).thenReturn(false).thenReturn(true);
         when(mockJsonObject.getString(AbstractLog.SID)).thenReturn(uuid.toString());
+        when(mockJsonObject.getString(AbstractLog.DISTRIBUTION_GROUP_ID)).thenReturn(distributionGroupId);
         when(mockJsonObject.getJSONObject(AbstractLog.DEVICE)).thenReturn(mock(JSONObject.class));
 
         mockLog.read(mockJsonObject);
         assertNull(mockLog.getSid());
+        assertNull(mockLog.getDistributionGroupId());
         assertNull(mockLog.getDevice());
 
         mockLog.read(mockJsonObject);
         assertEquals(uuid, mockLog.getSid());
+        assertEquals(distributionGroupId, mockLog.getDistributionGroupId());
         assertNotNull(mockLog.getDevice());
     }
 


### PR DESCRIPTION
This PR:
- Adds `distributionGroupId` field to sent logs (if exists).
- Adds a channel listener in the Distribution module which sets the `distributionGroupId` value.