### PR TITLE
Remove unused imports/variables from appcenter-distribute tests

### DIFF
--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeAfterDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeAfterDownloadTest.java
@@ -15,7 +15,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
-import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpClientNetworkStateHandler;
 import com.microsoft.appcenter.http.ServiceCall;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -12,7 +12,6 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import com.microsoft.appcenter.channel.Channel;
-import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpClientNetworkStateHandler;
 import com.microsoft.appcenter.http.HttpException;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTrackerTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/channel/DistributeInfoTrackerTest.java
@@ -2,11 +2,9 @@ package com.microsoft.appcenter.distribute.channel;
 
 import android.support.annotation.NonNull;
 
-import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.AbstractLog;
 import com.microsoft.appcenter.ingestion.models.Log;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
@@ -15,8 +13,6 @@ import java.util.UUID;
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-
 
 @SuppressWarnings("unused")
 @PrepareForTest(DistributeInfoTracker.class)
@@ -24,17 +20,9 @@ public class DistributeInfoTrackerTest {
 
     private final static String TEST_GROUP = "group_test";
 
-    private Channel mChannel;
-
     @NonNull
     private static MockLog newLog() {
-        MockLog log = new MockLog();
-        return log;
-    }
-
-    @Before
-    public void setUp() {
-        mChannel = mock(Channel.class);
+        return new MockLog();
     }
 
     @Test
@@ -53,9 +41,7 @@ public class DistributeInfoTrackerTest {
 
     @Test
     public void setNewDistributionGroupIdTest() {
-        String distributionGroupId1 = null;
-        String distributionGroupId2 = UUID.randomUUID().toString();
-        DistributeInfoTracker distributeInfoTracker = new DistributeInfoTracker(distributionGroupId1);
+        DistributeInfoTracker distributeInfoTracker = new DistributeInfoTracker(null);
 
         /* No distribution group ID field is added to logs because value is null. */
         {
@@ -66,10 +52,11 @@ public class DistributeInfoTrackerTest {
 
         /* Distribution group ID field is added to logs after the value was fetched and saved. */
         {
-            distributeInfoTracker.updateDistributionGroupId(distributionGroupId2);
+            String distributionGroupId = UUID.randomUUID().toString();
+            distributeInfoTracker.updateDistributionGroupId(distributionGroupId);
             Log log = newLog();
             distributeInfoTracker.onEnqueuingLog(log, TEST_GROUP);
-            assertEquals(distributionGroupId2, log.getDistributionGroupId());
+            assertEquals(distributionGroupId, log.getDistributionGroupId());
         }
 
         /* No distribution group ID field is added after the value was removed. */


### PR DESCRIPTION
This PR fixes warnings related to unused imports and the variables to be inlined in appcenter-distribute tests.