### PR TITLE
Log the missing `distributionGroupId` for the first session

### DIFF
--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/DistributeSerializerTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/DistributeSerializerTest.java
@@ -1,0 +1,48 @@
+package com.microsoft.appcenter.distribute;
+
+import com.microsoft.appcenter.distribute.ingestion.models.DistributionStartSessionLog;
+import com.microsoft.appcenter.distribute.ingestion.models.json.DistributionStartSessionLogFactory;
+import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.ingestion.models.LogContainer;
+import com.microsoft.appcenter.ingestion.models.json.DefaultLogSerializer;
+import com.microsoft.appcenter.ingestion.models.json.LogSerializer;
+import com.microsoft.appcenter.utils.UUIDUtils;
+
+import junit.framework.Assert;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@SuppressWarnings("unused")
+public class DistributeSerializerTest {
+
+    @Test
+    public void serialize() throws JSONException {
+        LogContainer expectedContainer = new LogContainer();
+        List<Log> logs = new ArrayList<>();
+        {
+            DistributionStartSessionLog log = new DistributionStartSessionLog();
+            log.setTimestamp(new Date());
+            logs.add(log);
+        }
+        expectedContainer.setLogs(logs);
+        UUID sid = UUIDUtils.randomUUID();
+        for (Log log : logs) {
+            log.setSid(sid);
+        }
+
+        /* Serialize and deserialize logs container. */
+        LogSerializer serializer = new DefaultLogSerializer();
+        serializer.addLogFactory(DistributionStartSessionLog.TYPE, new DistributionStartSessionLogFactory());
+        String payload = serializer.serializeContainer(expectedContainer);
+        LogContainer actualContainer = serializer.deserializeContainer(payload);
+
+        /* Verify that logs container successfully deserialized. */
+        Assert.assertEquals(expectedContainer, actualContainer);
+    }
+}

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -31,8 +31,11 @@ import android.widget.Toast;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
 import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.SessionContext;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
+import com.microsoft.appcenter.distribute.ingestion.models.DistributionStartSessionLog;
+import com.microsoft.appcenter.distribute.ingestion.models.json.DistributionStartSessionLogFactory;
 import com.microsoft.appcenter.http.DefaultHttpClient;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpClientNetworkStateHandler;
@@ -41,6 +44,7 @@ import com.microsoft.appcenter.http.HttpException;
 import com.microsoft.appcenter.http.HttpUtils;
 import com.microsoft.appcenter.http.ServiceCall;
 import com.microsoft.appcenter.http.ServiceCallback;
+import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.AsyncTaskUtils;
@@ -114,6 +118,11 @@ public class Distribute extends AbstractAppCenterService {
      */
     @SuppressLint("StaticFieldLeak")
     private static Distribute sInstance;
+
+    /**
+     * Log factories managed by this service.
+     */
+    private final Map<String, LogFactory> mFactories;
 
     /**
      * Current install base URL.
@@ -271,6 +280,14 @@ public class Distribute extends AbstractAppCenterService {
     private SharedPreferences mMobileCenterPreferenceStorage;
 
     /**
+     * Init.
+     */
+    private Distribute() {
+        mFactories = new HashMap<>();
+        mFactories.put(DistributionStartSessionLog.TYPE, new DistributionStartSessionLogFactory());
+    }
+
+    /**
      * Get shared instance.
      *
      * @return shared instance.
@@ -354,7 +371,7 @@ public class Distribute extends AbstractAppCenterService {
 
     @Override
     protected String getGroupName() {
-        return null;
+        return DISTRIBUTE_GROUP;
     }
 
     @Override
@@ -366,6 +383,21 @@ public class Distribute extends AbstractAppCenterService {
     protected String getLoggerTag() {
         return LOG_TAG;
     }
+
+    @Override
+    protected int getTriggerCount() {
+        return 1;
+    }
+
+    @Override
+    public Map<String, LogFactory> getLogFactories() {
+        return mFactories;
+    }
+
+    /**
+     * Constant marking event of the distribute group.
+     */
+    private static final String DISTRIBUTE_GROUP = "group_distribute";
 
     @Override
     public synchronized void onStarted(@NonNull Context context, @NonNull String appSecret, @NonNull Channel channel) {
@@ -893,6 +925,7 @@ public class Distribute extends AbstractAppCenterService {
             AppCenterLog.debug(LOG_TAG, "Stored redirection parameters.");
             PreferencesStorage.remove(PREFERENCE_KEY_REQUEST_ID);
             mDistributeInfoTracker.updateDistributionGroupId(distributionGroupId);
+            enqueueDistributionStartSessionLog();
             cancelPreviousTasks();
             getLatestReleaseDetails(distributionGroupId, updateToken);
         } else {
@@ -1767,5 +1800,32 @@ public class Distribute extends AbstractAppCenterService {
             cancelNotification();
             PreferencesStorage.putInt(PREFERENCE_KEY_DOWNLOAD_STATE, DOWNLOAD_STATE_INSTALLING);
         }
+    }
+
+    /**
+     * Send distribution start session log after enabling in-app updates (first app launch after installation).
+     */
+    private synchronized void enqueueDistributionStartSessionLog() {
+
+        /*
+         * Session starts before in-app updates setup (using browser) so the first start session log
+         * is sent without distributionGroupId value.
+         *
+         * Send the distribution start session log if start session log without distributionGroupId
+         * value was sent before
+         */
+        SessionContext.SessionInfo lastSession = SessionContext.getInstance().getSessionAt(System.currentTimeMillis());
+        if (lastSession == null || lastSession.getSessionId() == null) {
+            AppCenterLog.debug(DistributeConstants.LOG_TAG, "No sessions were logged before, ignore sending of the distribution start session log.");
+            return;
+        }
+        post(new Runnable() {
+
+            @Override
+            public void run() {
+                DistributionStartSessionLog log = new DistributionStartSessionLog();
+                mChannel.enqueue(log, DISTRIBUTE_GROUP);
+            }
+        });
     }
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ingestion/models/DistributionStartSessionLog.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ingestion/models/DistributionStartSessionLog.java
@@ -1,0 +1,16 @@
+package com.microsoft.appcenter.distribute.ingestion.models;
+
+import com.microsoft.appcenter.ingestion.models.AbstractLog;
+
+/**
+ * Distribution start session log.
+ */
+public class DistributionStartSessionLog extends AbstractLog {
+
+    public static final String TYPE = "distributionStartSession";
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ingestion/models/json/DistributionStartSessionLogFactory.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ingestion/models/json/DistributionStartSessionLogFactory.java
@@ -1,0 +1,12 @@
+package com.microsoft.appcenter.distribute.ingestion.models.json;
+
+import com.microsoft.appcenter.distribute.ingestion.models.DistributionStartSessionLog;
+import com.microsoft.appcenter.ingestion.models.json.LogFactory;
+
+public class DistributionStartSessionLogFactory implements LogFactory {
+
+    @Override
+    public DistributionStartSessionLog create() {
+        return new DistributionStartSessionLog();
+    }
+}

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -98,6 +98,9 @@ public class AbstractDistributeTest {
     AppCenterHandler mAppCenterHandler;
 
     @Mock
+    Channel mChannel;
+
+    @Mock
     SharedPreferences mMobileCenterPreferencesStorage;
 
     @Mock
@@ -253,6 +256,6 @@ public class AbstractDistributeTest {
 
     void start() {
         Distribute.getInstance().onStarting(mAppCenterHandler);
-        Distribute.getInstance().onStarted(mContext, "a", mock(Channel.class));
+        Distribute.getInstance().onStarted(mContext, "a", mChannel);
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -1,0 +1,29 @@
+package com.microsoft.appcenter.distribute;
+
+import com.microsoft.appcenter.distribute.ingestion.models.DistributionStartSessionLog;
+import com.microsoft.appcenter.distribute.ingestion.models.json.DistributionStartSessionLogFactory;
+import com.microsoft.appcenter.ingestion.models.json.LogFactory;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DistributeTest extends AbstractDistributeTest {
+
+    @Test
+    public void singleton() {
+        assertSame(Distribute.getInstance(), Distribute.getInstance());
+    }
+
+    @Test
+    public void checkFactories() {
+        Map<String, LogFactory> factories = Distribute.getInstance().getLogFactories();
+        assertNotNull(factories);
+        assertTrue(factories.remove(DistributionStartSessionLog.TYPE) instanceof DistributionStartSessionLogFactory);
+        assertTrue(factories.isEmpty());
+    }
+}

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/ingestion/models/DistributionStartSessionLogTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/ingestion/models/DistributionStartSessionLogTest.java
@@ -1,0 +1,37 @@
+package com.microsoft.appcenter.distribute.ingestion.models;
+
+import com.microsoft.appcenter.test.TestUtils;
+import com.microsoft.appcenter.utils.UUIDUtils;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static com.microsoft.appcenter.test.TestUtils.checkEquals;
+import static com.microsoft.appcenter.test.TestUtils.checkNotEquals;
+
+@SuppressWarnings("unused")
+public class DistributionStartSessionLogTest {
+
+    @Test
+    public void compareDifferentType() {
+        TestUtils.compareSelfNullClass(new DistributionStartSessionLog());
+    }
+
+    @Test
+    public void compare() {
+
+        /* Empty objects. */
+        DistributionStartSessionLog a = new DistributionStartSessionLog();
+        DistributionStartSessionLog b = new DistributionStartSessionLog();
+        checkEquals(a, b);
+        checkEquals(a.getType(), DistributionStartSessionLog.TYPE);
+
+        /* With session ID. */
+        UUID sid = UUIDUtils.randomUUID();
+        a.setSid(sid);
+        checkNotEquals(a, b);
+        b.setSid(sid);
+        checkEquals(a, b);
+    }
+}


### PR DESCRIPTION
This PR addresses the issue with the first session log which is sent after app installation. The `distributionGroupId` field is missing in the first session log because it's sent before in-app updates are enabled. So this PR:

- Adds sending of distribution start session log after enabling in-app updates (first app launch after installation).
- Adds check to ignore distribution start session logs without session ID to handle cases when Analytics is disabled.
- Implements tests.