### PR TITLE
Update distribution group ID if new ID is sent in the latest release details

### DIFF
--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
@@ -414,6 +414,7 @@ public class ReleaseDetailsTest {
         ReleaseDetails.parse(json);
     }
 
+    @Test
     public void nullDistributionGroupId() throws JSONException {
         String json = "{" +
                 "id: 42," +
@@ -424,8 +425,7 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
-                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
@@ -24,7 +24,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -37,6 +38,7 @@ public class ReleaseDetailsTest {
         assertEquals(Uri.parse("http://download.thinkbroadband.com/1GB.zip"), releaseDetails.getDownloadUrl());
         assertFalse(releaseDetails.isMandatoryUpdate());
         assertEquals("9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60", releaseDetails.getReleaseHash());
+        assertEquals("fd37a4b1-4937-45ef-97fb-b864154371f0", releaseDetails.getDistributionGroupId());
     }
 
     @Test(expected = JSONException.class)
@@ -48,7 +50,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -63,7 +66,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -78,7 +82,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -102,7 +107,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -117,7 +123,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -131,7 +138,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -145,7 +153,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'https://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -170,7 +179,8 @@ public class ReleaseDetailsTest {
                 "short_version: '2.1.5'," +
                 "download_url: 'https://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -197,7 +207,8 @@ public class ReleaseDetailsTest {
                 "short_version: '2.1.5'," +
                 "download_url: 'https://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -221,7 +232,8 @@ public class ReleaseDetailsTest {
                 "release_notes: 'Fix a critical bug, this text was entered in App Center portal.'," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -236,7 +248,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: '19'," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -261,7 +274,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: '4.0.3'," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -274,7 +288,8 @@ public class ReleaseDetailsTest {
                 "short_version: '2.1.5'," +
                 "release_notes: 'Fix a critical bug, this text was entered in App Center portal.'," +
                 "android_min_api_level: 19" +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -289,7 +304,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'someFile'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -304,7 +320,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'ftp://someFile'," +
                 "mandatory_update: false," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -319,7 +336,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: true," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
         assertNotNull(releaseDetails);
@@ -343,7 +361,8 @@ public class ReleaseDetailsTest {
                 "release_notes: 'Fix a critical bug, this text was entered in App Center portal.'," +
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
-                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -358,6 +377,7 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "mandatory_update: false," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'" +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -372,7 +392,8 @@ public class ReleaseDetailsTest {
                 "android_min_api_level: 19," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
-                "package_hashes: []" +
+                "package_hashes: []," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
     }
@@ -388,7 +409,24 @@ public class ReleaseDetailsTest {
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
                 "package_hashes: '9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60'" +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
+    }
+
+    @Test(expected = JSONException.class)
+    public void missingDistributionGroupId() throws JSONException {
+        String json = "{" +
+                "id: 42," +
+                "version: '14'," +
+                "short_version: '2.1.5'," +
+                "release_notes: 'Fix a critical bug, this text was entered in App Center portal.'," +
+                "release_notes_url: 'https://mock/'," +
+                "android_min_api_level: 19," +
+                "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
+                "mandatory_update: false," +
+                "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "}";
+        ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
     }
 }

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
@@ -414,8 +414,7 @@ public class ReleaseDetailsTest {
         ReleaseDetails.parse(json);
     }
 
-    @Test(expected = JSONException.class)
-    public void missingDistributionGroupId() throws JSONException {
+    public void nullDistributionGroupId() throws JSONException {
         String json = "{" +
                 "id: 42," +
                 "version: '14'," +
@@ -426,7 +425,19 @@ public class ReleaseDetailsTest {
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
+        assertNotNull(releaseDetails);
+        assertEquals(42, releaseDetails.getId());
+        assertEquals(14, releaseDetails.getVersion());
+        assertEquals("2.1.5", releaseDetails.getShortVersion());
+        assertEquals("Fix a critical bug, this text was entered in App Center portal.", releaseDetails.getReleaseNotes());
+        assertEquals(Uri.parse("https://mock/"), releaseDetails.getReleaseNotesUrl());
+        assertEquals(19, releaseDetails.getMinApiLevel());
+        assertEquals(Uri.parse("http://download.thinkbroadband.com/1GB.zip"), releaseDetails.getDownloadUrl());
+        assertFalse(releaseDetails.isMandatoryUpdate());
+        assertEquals("9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60", releaseDetails.getReleaseHash());
+        assertNull(releaseDetails.getDistributionGroupId());
     }
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
@@ -196,7 +196,7 @@ class CheckDownloadTask extends AsyncTask<Void, Void, DownloadProgress> {
         }
         String groupId = mReleaseDetails.getDistributionGroupId();
         String releaseHash = mReleaseDetails.getReleaseHash();
-        int releaseId= mReleaseDetails.getId();
+        int releaseId = mReleaseDetails.getId();
         AppCenterLog.debug(LOG_TAG, "Store downloaded group id=" + groupId + " release hash=" + releaseHash + " release id=" + releaseId);
         StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID, groupId);
         StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH, releaseHash);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
@@ -18,6 +18,7 @@ import java.util.NoSuchElementException;
 import static android.content.Context.DOWNLOAD_SERVICE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_ID;
 
@@ -157,15 +158,7 @@ class CheckDownloadTask extends AsyncTask<Void, Void, DownloadProgress> {
                     } else {
                         distribute.completeWorkflow(mReleaseDetails);
                     }
-
-                    /* Add downloaded release hash to report after installation. */
-                    if (mReleaseDetails != null) {
-                        AppCenterLog.debug(LOG_TAG, "Store downloaded release hash and id for later reporting.");
-                        StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH, mReleaseDetails.getReleaseHash());
-                        StorageHelper.PreferencesStorage.putInt(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID, mReleaseDetails.getId());
-                    } else {
-                        AppCenterLog.debug(LOG_TAG, "Release details are missing or broken, will not store release hash and id for reporting.");
-                    }
+                    storeDownloadedReleaseDetails();
                 }
             } finally {
                 cursor.close();
@@ -190,5 +183,23 @@ class CheckDownloadTask extends AsyncTask<Void, Void, DownloadProgress> {
                 }
             });
         }
+    }
+
+    /**
+     * Store details about downloaded release.
+     * After app update and restart, this info is used to report new download and to update group ID (if it's changed).
+     */
+    private void storeDownloadedReleaseDetails() {
+        if (mReleaseDetails == null) {
+            AppCenterLog.debug(LOG_TAG, "Downloaded release details are missing or broken, won't store.");
+            return;
+        }
+        String groupId = mReleaseDetails.getDistributionGroupId();
+        String releaseHash = mReleaseDetails.getReleaseHash();
+        int releaseId= mReleaseDetails.getId();
+        AppCenterLog.debug(LOG_TAG, "Store downloaded group id=" + groupId + " release hash=" + releaseHash + " release id=" + releaseId);
+        StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID, groupId);
+        StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH, releaseHash);
+        StorageHelper.PreferencesStorage.putInt(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID, releaseId);
     }
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1141,7 +1141,7 @@ public class Distribute extends AbstractAppCenterService {
      * @return true if current release was updated.
      */
     private boolean isCurrentReleaseWasUpdated(String lastDownloadedReleaseHash) {
-        if (lastDownloadedReleaseHash == null || mPackageInfo == null) {
+        if (mPackageInfo == null || TextUtils.isEmpty(lastDownloadedReleaseHash)) {
             return false;
         }
         String currentInstalledReleaseHash = computeReleaseHash(mPackageInfo);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1145,10 +1145,7 @@ public class Distribute extends AbstractAppCenterService {
             return false;
         }
         String currentInstalledReleaseHash = computeReleaseHash(mPackageInfo);
-        if (!currentInstalledReleaseHash.equals(lastDownloadedReleaseHash)) {
-            return false;
-        }
-        return true;
+        return currentInstalledReleaseHash.equals(lastDownloadedReleaseHash);
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1122,7 +1122,7 @@ public class Distribute extends AbstractAppCenterService {
             return;
         }
         String currentDistributionGroupId = PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
-        if (lastDownloadedDistributionGroupId.equals(currentDistributionGroupId)) {
+        if (currentDistributionGroupId != null && lastDownloadedDistributionGroupId.equals(currentDistributionGroupId)) {
             return;
         }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -232,6 +232,11 @@ final class DistributeConstants {
     static final String PREFERENCE_KEY_DOWNLOADED_RELEASE_ID = PREFERENCE_PREFIX + "downloaded_release_id";
 
     /**
+     * Preference key to store distribution group identifier of latest downloaded release.
+     */
+    static final String PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID = PREFERENCE_PREFIX + "downloaded_distribution_group_id";
+
+    /**
      * Preference key to store distribution group identifier.
      */
     static final String PREFERENCE_KEY_DISTRIBUTION_GROUP_ID = PREFERENCE_PREFIX + EXTRA_DISTRIBUTION_GROUP_ID;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
@@ -30,6 +30,8 @@ public class ReleaseDetails {
 
     private static final String PACKAGE_HASHES = "package_hashes";
 
+    private static final String DISTRIBUTION_GROUP_ID = "distribution_group_id";
+
     /**
      * ID identifying this unique release.
      */
@@ -80,6 +82,11 @@ public class ReleaseDetails {
     private String releaseHash;
 
     /**
+     * Distribution group identifier.
+     */
+    private String distributionGroupId;
+
+    /**
      * Parse a JSON string describing release details.
      *
      * @param json a string.
@@ -102,6 +109,7 @@ public class ReleaseDetails {
         }
         releaseDetails.mandatoryUpdate = object.getBoolean(MANDATORY_UPDATE);
         releaseDetails.releaseHash = object.getJSONArray(PACKAGE_HASHES).getString(0);
+        releaseDetails.distributionGroupId = object.getString(DISTRIBUTION_GROUP_ID);
         return releaseDetails;
     }
 
@@ -190,5 +198,14 @@ public class ReleaseDetails {
     @NonNull
     String getReleaseHash() {
         return releaseHash;
+    }
+
+    /**
+     * Get the distribution group identifier value.
+     *
+     * @return the distributionGroupId value
+     */
+    String getDistributionGroupId() {
+        return distributionGroupId;
     }
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
@@ -203,7 +203,7 @@ public class ReleaseDetails {
     /**
      * Get the distribution group identifier value.
      *
-     * @return the distributionGroupId value
+     * @return the distributionGroupId value.
      */
     String getDistributionGroupId() {
         return distributionGroupId;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
@@ -109,7 +109,7 @@ public class ReleaseDetails {
         }
         releaseDetails.mandatoryUpdate = object.getBoolean(MANDATORY_UPDATE);
         releaseDetails.releaseHash = object.getJSONArray(PACKAGE_HASHES).getString(0);
-        releaseDetails.distributionGroupId = object.getString(DISTRIBUTION_GROUP_ID);
+        releaseDetails.distributionGroupId = object.isNull(DISTRIBUTION_GROUP_ID) ? null : object.getString(DISTRIBUTION_GROUP_ID);
         return releaseDetails;
     }
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -56,6 +56,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_R
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_REQUEST_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DISTRIBUTION_GROUP_ID;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
@@ -1497,5 +1498,102 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
             }
         };
         verify(httpClient).callAsync(argThat(urlArg), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+    }
+
+    @Test
+    public void shouldChangeDistributionGroupIdIfStoredIdDoesntMatchDownloadedId() throws Exception {
+
+        /* Mock release details. */
+        String downloadedDistributionGroupId = "fake-downloaded-id";
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(downloadedDistributionGroupId);
+
+        /* Trigger call. */
+        start();
+
+        /* Verify group ID. */
+        verifyStatic();
+        PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, downloadedDistributionGroupId);
+        verifyStatic();
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
+    }
+
+    @Test
+    public void shouldChangeDistributionGroupIdIfStoredIdIsNull() throws Exception {
+
+        /* Mock release details. */
+        String downloadedDistributionGroupId = "fake-downloaded-id";
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn(null);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(downloadedDistributionGroupId);
+
+        /* Trigger call. */
+        start();
+
+        /* Verify group ID. */
+        verifyStatic();
+        PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, downloadedDistributionGroupId);
+        verifyStatic();
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
+    }
+
+    @Test
+    public void shouldNotChangeDistributionGroupIdIfStoredIdMatchDownloadedId() throws Exception {
+
+        /* Mock release details. */
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
+
+        /* Trigger call. */
+        start();
+
+        /* Verify group ID. */
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
+        verifyStatic(never());
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
+    }
+
+    @Test
+    public void shouldNotChangeDistributionGroupIdIfAppWasntUpdated() throws Exception {
+
+        /* Mock release details. */
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn(null);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(null);
+
+        /* Trigger call. */
+        start();
+
+        /* Verify group ID. */
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
+        verifyStatic(never());
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
+    }
+
+    @Test
+    public void shouldNotChangeDistributionGroupIdIfCurrentPackageInfoIsNull() throws Exception {
+
+        /* Mock release details. */
+        mockStatic(DistributeUtils.class);
+        when(mPackageManager.getPackageInfo(anyString(), anyInt())).thenReturn(null);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
+
+        /* Verify group ID. */
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
+        verifyStatic(never());
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -1012,6 +1012,21 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
     }
 
+    @Test
+    public void shouldNotChangeDistributionGroupIdIfCurrentPackageInfoIsNull() throws Exception {
+
+        /* Mock release details. */
+        mockStatic(DistributeUtils.class);
+        when(mPackageManager.getPackageInfo(anyString(), anyInt())).thenReturn(null);
+        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
+
+        /* Verify group ID. */
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
+        verifyStatic(never());
+        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
+    }
+
     /**
      * Mock some storage calls.
      */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 
@@ -40,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.microsoft.appcenter.distribute.DistributeConstants.DOWNLOAD_STATE_AVAILABLE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.DOWNLOAD_STATE_COMPLETED;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DISTRIBUTION_GROUP_ID;
-import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
@@ -928,103 +926,6 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH);
         verifyStatic(never());
         PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID);
-    }
-
-    @Test
-    public void shouldChangeDistributionGroupIdIfStoredIdDoesntMatchDownloadedId() throws Exception {
-
-        /* Mock release details. */
-        String downloadedDistributionGroupId = "fake-downloaded-id";
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(downloadedDistributionGroupId);
-
-        /* Trigger call. */
-        start();
-
-        /* Verify group ID. */
-        verifyStatic();
-        PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, downloadedDistributionGroupId);
-        verifyStatic();
-        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
-    }
-
-    @Test
-    public void shouldChangeDistributionGroupIdIfStoredIdIsNull() throws Exception {
-
-        /* Mock release details. */
-        String downloadedDistributionGroupId = "fake-downloaded-id";
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn(null);
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(downloadedDistributionGroupId);
-
-        /* Trigger call. */
-        start();
-
-        /* Verify group ID. */
-        verifyStatic();
-        PreferencesStorage.putString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID, downloadedDistributionGroupId);
-        verifyStatic();
-        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
-    }
-
-    @Test
-    public void shouldNotChangeDistributionGroupIdIfStoredIdMatchDownloadedId() throws Exception {
-
-        /* Mock release details. */
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
-
-        /* Trigger call. */
-        start();
-
-        /* Verify group ID. */
-        verifyStatic(never());
-        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
-        verifyStatic(never());
-        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
-    }
-
-    @Test
-    public void shouldNotChangeDistributionGroupIdIfAppWasntUpdated() throws Exception {
-
-        /* Mock release details. */
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn(null);
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("fake-id");
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID)).thenReturn(null);
-
-        /* Trigger call. */
-        start();
-
-        /* Verify group ID. */
-        verifyStatic(never());
-        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
-        verifyStatic(never());
-        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
-    }
-
-    @Test
-    public void shouldNotChangeDistributionGroupIdIfCurrentPackageInfoIsNull() throws Exception {
-
-        /* Mock release details. */
-        mockStatic(DistributeUtils.class);
-        when(mPackageManager.getPackageInfo(anyString(), anyInt())).thenReturn(null);
-        when(PreferencesStorage.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
-
-        /* Verify group ID. */
-        verifyStatic(never());
-        PreferencesStorage.putString(eq(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID), anyString());
-        verifyStatic(never());
-        PreferencesStorage.remove(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID);
     }
 
     /**

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeDownloadTest.java
@@ -39,6 +39,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.DOWNLOAD_ST
 import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_ID;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_TIME;
@@ -300,6 +301,8 @@ public class DistributeDownloadTest extends AbstractDistributeAfterDownloadTest 
         PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH), anyString());
         verifyStatic(never());
         PreferencesStorage.putInt(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID), anyInt());
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID), anyString());
 
         /* Verify enabling triggers update dialog again. */
         verify(mDialog).show();
@@ -331,6 +334,8 @@ public class DistributeDownloadTest extends AbstractDistributeAfterDownloadTest 
         PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH), anyString());
         verifyStatic();
         PreferencesStorage.putInt(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID), anyInt());
+        verifyStatic();
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID), anyString());
         verifyNoMoreInteractions(mNotificationManager);
         verify(cursor).close();
     }
@@ -395,6 +400,8 @@ public class DistributeDownloadTest extends AbstractDistributeAfterDownloadTest 
         PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH), anyString());
         verifyStatic(never());
         PreferencesStorage.putInt(eq(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID), anyInt());
+        verifyStatic(never());
+        PreferencesStorage.putString(eq(PREFERENCE_KEY_DOWNLOADED_DISTRIBUTION_GROUP_ID), anyString());
         verifyZeroInteractions(mNotificationManager);
     }
 


### PR DESCRIPTION
This PR implements updating of distribution group ID if in-app updated release has different distribution group.

Group ID may change if one user is added to different distribution groups and a new release was distributed to another group.