### PR TITLE
Remove @UiThread and @WorkerThread from public listeners

### DIFF
--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/AbstractCrashesListener.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/AbstractCrashesListener.java
@@ -7,6 +7,7 @@ import com.microsoft.appcenter.crashes.model.ErrorReport;
  * Abstract class with default behaviors for the crashes listener.
  */
 public abstract class AbstractCrashesListener implements CrashesListener {
+
     @Override
     public boolean shouldProcess(ErrorReport report) {
         return true;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/CrashesListener.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/CrashesListener.java
@@ -1,8 +1,5 @@
 package com.microsoft.appcenter.crashes;
 
-import android.support.annotation.UiThread;
-import android.support.annotation.WorkerThread;
-
 import com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog;
 import com.microsoft.appcenter.crashes.model.ErrorReport;
 
@@ -13,56 +10,50 @@ import com.microsoft.appcenter.crashes.model.ErrorReport;
 public interface CrashesListener {
 
     /**
-     * Called to determine whether a crash report should be processed or not.
+     * Called from a worker thread to determine whether a crash report should be processed or not.
      *
      * @param report A crash report that will be sent.
      * @return <code>true</code> if it should be processed and sent, otherwise <code>false</code>.
      */
-    @WorkerThread
     boolean shouldProcess(ErrorReport report);
 
     /**
-     * Called to determine whether it should wait for user confirmation before sending crash reports.
+     * Called from UI thread to determine whether it should wait for user confirmation before sending crash reports.
      *
      * @return <code>true</code> if it requires to be confirmed by a user, otherwise <code>false</code>.
      * If this method returns <code>true</code>, {@link Crashes#notifyUserConfirmation(int)} must be called by yourself.
      */
-    @UiThread
     boolean shouldAwaitUserConfirmation();
 
     /**
-     * Called to get additional information to be sent as separate ErrorAttachmentLog logs
+     * Called from a worker thread to get additional information to be sent as separate ErrorAttachmentLog logs
      * Attachments are optional so this method can also return <code>null</code>.
      *
      * @param report The crash report for additional information.
      * @return instances of {@link ErrorAttachmentLog} to be sent for the specified error report.
      */
-    @WorkerThread
     Iterable<ErrorAttachmentLog> getErrorAttachments(ErrorReport report);
 
     /**
-     * Called right before sending a crash report. The callback can be invoked multiple times based on the number of crash reports.
+     * Called from UI thread right before sending a crash report. The callback can be invoked multiple times based on the number of crash reports.
      *
      * @param report The crash report that will be sent.
      */
-    @UiThread
     void onBeforeSending(ErrorReport report);
 
     /**
-     * Called when sending a crash report failed.
+     * Called from UI thread  when sending a crash report failed.
      * The report failed to send after the maximum retries so it will be discarded and won't be retried.
      *
      * @param report The crash report that failed to send.
      * @param e      An exception that caused failure.
      */
-    @UiThread
     void onSendingFailed(ErrorReport report, Exception e);
 
     /**
-     * Called when a crash report is sent successfully.
+     * Called from UI thread when a crash report is sent successfully.
      *
      * @param report The crash report that was sent successfully.
      */
-    @UiThread
     void onSendingSucceeded(ErrorReport report);
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
@@ -1,7 +1,6 @@
 package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
-import android.support.annotation.UiThread;
 
 /**
  * Listener for the Distribute allowing customization.
@@ -10,7 +9,7 @@ import android.support.annotation.UiThread;
 public interface DistributeListener {
 
     /**
-     * Called whenever a new release is available to download and install.
+     * Called from UI thread whenever a new release is available to download and install.
      * <p>
      * If user does not action the release (either postpone or update), this callback
      * will repeat for every activity change for the same release.
@@ -22,6 +21,5 @@ public interface DistributeListener {
      * @param releaseDetails release details for the update.
      * @return the custom dialog whose visibility will be managed for you if not null.
      */
-    @UiThread
     boolean onReleaseAvailable(Activity activity, ReleaseDetails releaseDetails);
 }

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/PushListener.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/PushListener.java
@@ -1,7 +1,6 @@
 package com.microsoft.appcenter.push;
 
 import android.app.Activity;
-import android.support.annotation.UiThread;
 
 /**
  * Listener for push messages.
@@ -10,7 +9,7 @@ import android.support.annotation.UiThread;
 public interface PushListener {
 
     /**
-     * Called whenever a push notification is either clicked from system notification center or
+     * Called from UI thread whenever a push notification is either clicked from system notification center or
      * when the push is received in foreground.
      *
      * @param activity         current activity when push is received or clicked.
@@ -20,6 +19,5 @@ public interface PushListener {
      *                         If the push is received in foreground,
      *                         no notification has been generated in system notification center.
      */
-    @UiThread
     void onPushNotificationReceived(Activity activity, PushNotification pushNotification);
 }


### PR DESCRIPTION
Setting up a listener in ui thread incorrectly triggers a warning
of not being in a worker thread, it's just an interface but code
analysis makes wrong assumptions. It also cause the same bug vice versa
if you setup a listener from worker thread and get warnings for ui thread.
Setting up a listener is not the same as it being invoked, setting up
is allowed in any thread but code analysis not smart enough.

Plus people that don't have google annotations as a dependency can get
compiler warnings anyway so it was already established not to use
the annotations in public APIs.