### PR TITLE
Fix flacky HttpClientNetworkStateHandler tests

### DIFF
--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientNetworkStateHandlerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientNetworkStateHandlerTest.java
@@ -252,7 +252,7 @@ public class HttpClientNetworkStateHandlerTest {
     }
 
     @Test
-    public void cancelRunningCallByClosing() throws InterruptedException, IOException {
+    public void cancelRunningCallByClosing() throws IOException {
 
         /* Configure mock wrapped API. */
         String url = "http://mock/call";
@@ -261,35 +261,8 @@ public class HttpClientNetworkStateHandlerTest {
         final ServiceCallback callback = mock(ServiceCallback.class);
         final ServiceCall call = mock(ServiceCall.class);
         HttpClient httpClient = mock(HttpClient.class);
-        final AtomicReference<Thread> threadRef = new AtomicReference<>();
-        doAnswer(new Answer<ServiceCall>() {
-
-            @Override
-            public ServiceCall answer(final InvocationOnMock invocationOnMock) throws Throwable {
-                Thread thread = new Thread() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            sleep(200);
-                            ((ServiceCallback) invocationOnMock.getArguments()[4]).onCallSucceeded("mockPayload");
-                        } catch (InterruptedException ignore) {
-                        }
-                    }
-                };
-                thread.start();
-                threadRef.set(thread);
-                return call;
-            }
-        }).when(httpClient).callAsync(eq(url), eq(METHOD_GET), eq(headers), eq(callTemplate), any(ServiceCallback.class));
-        doAnswer(new Answer() {
-
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                threadRef.get().interrupt();
-                return null;
-            }
-        }).when(httpClient).close();
+        when(httpClient.callAsync(eq(url), eq(METHOD_GET), eq(headers), eq(callTemplate), any(ServiceCallback.class)))
+                .thenReturn(call);
 
         /* Simulate network down then becomes up. */
         NetworkStateHelper networkStateHelper = mock(NetworkStateHelper.class);
@@ -298,9 +271,6 @@ public class HttpClientNetworkStateHandlerTest {
         /* Test call. */
         HttpClientNetworkStateHandler decorator = new HttpClientNetworkStateHandler(httpClient, networkStateHelper);
         decorator.callAsync(url, METHOD_GET, headers, callTemplate, callback);
-
-        /* Wait some time. */
-        Thread.sleep(100);
 
         /* Cancel by closing. */
         decorator.close();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientNetworkStateHandlerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientNetworkStateHandlerTest.java
@@ -39,7 +39,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(InvocationOnMock invocationOnMock) {
                 ServiceCallback serviceCallback = (ServiceCallback) invocationOnMock.getArguments()[4];
                 serviceCallback.onCallSucceeded("mockPayload");
                 serviceCallback.onCallSucceeded("duplicateCallbackPayloadToIgnore");
@@ -84,7 +84,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(InvocationOnMock invocationOnMock) {
                 ServiceCallback serviceCallback = (ServiceCallback) invocationOnMock.getArguments()[4];
                 serviceCallback.onCallFailed(new HttpException(503));
                 serviceCallback.onCallFailed(new SocketException());
@@ -121,7 +121,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(InvocationOnMock invocationOnMock) {
                 ((ServiceCallback) invocationOnMock.getArguments()[4]).onCallSucceeded("");
                 return call;
             }
@@ -162,7 +162,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(InvocationOnMock invocationOnMock) {
                 ((ServiceCallback) invocationOnMock.getArguments()[4]).onCallSucceeded("");
                 return call;
             }
@@ -201,7 +201,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(final InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(final InvocationOnMock invocationOnMock) {
                 Thread thread = new Thread() {
 
                     @Override
@@ -221,7 +221,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer() {
 
             @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+            public Object answer(InvocationOnMock invocation) {
                 threadRef.get().interrupt();
                 return null;
             }
@@ -296,7 +296,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer<ServiceCall>() {
 
             @Override
-            public ServiceCall answer(final InvocationOnMock invocationOnMock) throws Throwable {
+            public ServiceCall answer(final InvocationOnMock invocationOnMock) {
                 Thread thread = new Thread() {
 
                     @Override
@@ -316,7 +316,7 @@ public class HttpClientNetworkStateHandlerTest {
         doAnswer(new Answer() {
 
             @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+            public Object answer(InvocationOnMock invocation) {
                 threadRef.get().interrupt();
                 return null;
             }


### PR DESCRIPTION
Since we verify the `cancel();` invocation, there is no need for additional stuff with threads.