### PR TITLE
Revert "Update jacoco, gradle and android gradle plugin versions"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.google.gms:google-services:3.1.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx2g
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# gradlew bintrayUpload fails mysteriously on Bitrise if we don't add this option
+android.enableAapt2=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 02 11:29:45 PDT 2018
+#Fri Sep 29 17:35:51 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -6,7 +6,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     jacoco {
-        toolVersion '0.7.9'
+        toolVersion '0.7.4.201502262128'
     }
 
     //noinspection GroovyAssignabilityCheck


### PR DESCRIPTION
Reverts Microsoft/AppCenter-SDK-Android#653

Cause: cannot run tests from Android Studio.