### PR TITLE
Fix crash reporting when failing to get process name

### DIFF
--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -86,7 +86,7 @@ public class ErrorLogHelper {
     /**
      * Max number of properties.
      */
-    public static final int MAX_PROPERTY_COUNT = 20;
+    private static final int MAX_PROPERTY_COUNT = 20;
 
     /**
      * Max length of properties.
@@ -129,11 +129,22 @@ public class ErrorLogHelper {
         errorLog.setProcessId(Process.myPid());
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         if (activityManager != null) {
-            for (ActivityManager.RunningAppProcessInfo info : activityManager.getRunningAppProcesses()) {
-                if (info.pid == Process.myPid()) {
-                    errorLog.setProcessName(info.processName);
+            List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = activityManager.getRunningAppProcesses();
+            if (runningAppProcesses != null) {
+                for (ActivityManager.RunningAppProcessInfo info : runningAppProcesses) {
+                    if (info.pid == Process.myPid()) {
+                        errorLog.setProcessName(info.processName);
+                    }
                 }
             }
+        }
+
+        /*
+         * Process name is required field for crash processing but cannot always be available,
+         * make sure we send a default value if not found.
+         */
+        if (errorLog.getProcessName() == null) {
+            errorLog.setProcessName("");
         }
 
         /* CPU architecture. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -189,9 +189,6 @@ public class ErrorLogHelperTest {
         /* Mock device. */
         when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenThrow(new DeviceInfoHelper.DeviceInfoException("mock", new PackageManager.NameNotFoundException()));
 
-        /* Mock activity manager to return null active processes. */
-        when(mockContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(mock(ActivityManager.class));
-
         /* Mock architecture. */
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 15);
         TestUtils.setInternalState(Build.class, "CPU_ABI", "armeabi-v7a");
@@ -232,6 +229,11 @@ public class ErrorLogHelperTest {
 
         /* Mock device. */
         when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenThrow(new DeviceInfoHelper.DeviceInfoException("mock", new PackageManager.NameNotFoundException()));
+
+        /* Mock activity manager to return null active processes. */
+        ActivityManager activityManager = mock(ActivityManager.class);
+        when(activityManager.getRunningAppProcesses()).thenReturn(null);
+        when(mockContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(activityManager);
 
         /* Mock architecture. */
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 15);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -82,7 +82,7 @@ public class ErrorLogHelperTest {
         whenNew(Date.class).withArguments(anyLong()).thenAnswer(new Answer<Date>() {
 
             @Override
-            public Date answer(InvocationOnMock invocation) throws Throwable {
+            public Date answer(InvocationOnMock invocation) {
                 return new Date((Long) invocation.getArguments()[0]);
             }
         });
@@ -171,7 +171,7 @@ public class ErrorLogHelperTest {
     }
 
     @Test
-    public void createErrorLogFailOver() throws java.lang.Exception {
+    public void createErrorLogWithFailedDeviceGetAndNoActivityManager() throws java.lang.Exception {
 
         /* Mock base. */
         Context mockContext = mock(Context.class);
@@ -181,7 +181,51 @@ public class ErrorLogHelperTest {
         whenNew(Date.class).withArguments(anyLong()).thenAnswer(new Answer<Date>() {
 
             @Override
-            public Date answer(InvocationOnMock invocation) throws Throwable {
+            public Date answer(InvocationOnMock invocation) {
+                return new Date((Long) invocation.getArguments()[0]);
+            }
+        });
+
+        /* Mock device. */
+        when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenThrow(new DeviceInfoHelper.DeviceInfoException("mock", new PackageManager.NameNotFoundException()));
+
+        /* Mock activity manager to return null active processes. */
+        when(mockContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(mock(ActivityManager.class));
+
+        /* Mock architecture. */
+        TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 15);
+        TestUtils.setInternalState(Build.class, "CPU_ABI", "armeabi-v7a");
+
+        /* Test. */
+        long launchTimeStamp = 2000;
+        ManagedErrorLog errorLog = ErrorLogHelper.createErrorLog(mockContext, java.lang.Thread.currentThread(), new java.lang.Exception(), java.lang.Thread.getAllStackTraces(), launchTimeStamp);
+        assertNotNull(errorLog);
+        assertNotNull(errorLog.getId());
+        assertEquals(logTimestamp, errorLog.getTimestamp());
+        assertNull(errorLog.getDevice());
+        assertEquals(Integer.valueOf(123), errorLog.getProcessId());
+        assertEquals("", errorLog.getProcessName());
+        assertNull(errorLog.getParentProcessId());
+        assertNull(errorLog.getParentProcessName());
+        assertEquals("armeabi-v7a", errorLog.getArchitecture());
+        assertEquals((Long) java.lang.Thread.currentThread().getId(), errorLog.getErrorThreadId());
+        assertEquals(java.lang.Thread.currentThread().getName(), errorLog.getErrorThreadName());
+        assertEquals(Boolean.TRUE, errorLog.getFatal());
+        assertEquals(launchTimeStamp, errorLog.getAppLaunchTimestamp().getTime());
+    }
+
+    @Test
+    public void createErrorLogWithFailedDeviceGetAndNullProcesses() throws java.lang.Exception {
+
+        /* Mock base. */
+        Context mockContext = mock(Context.class);
+        when(Process.myPid()).thenReturn(123);
+        Date logTimestamp = new Date(1000L);
+        whenNew(Date.class).withNoArguments().thenReturn(logTimestamp);
+        whenNew(Date.class).withArguments(anyLong()).thenAnswer(new Answer<Date>() {
+
+            @Override
+            public Date answer(InvocationOnMock invocation) {
                 return new Date((Long) invocation.getArguments()[0]);
             }
         });
@@ -201,7 +245,7 @@ public class ErrorLogHelperTest {
         assertEquals(logTimestamp, errorLog.getTimestamp());
         assertNull(errorLog.getDevice());
         assertEquals(Integer.valueOf(123), errorLog.getProcessId());
-        assertNull(errorLog.getProcessName());
+        assertEquals("", errorLog.getProcessName());
         assertNull(errorLog.getParentProcessId());
         assertNull(errorLog.getParentProcessName());
         assertEquals("armeabi-v7a", errorLog.getArchitecture());


### PR DESCRIPTION
Use a default value instead of crashing during crash saving.