### PR TITLE
 Use add/remove callbacks to manage one collector group lifecycle

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/AbstractChannelListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/AbstractChannelListener.java
@@ -11,6 +11,14 @@ import com.microsoft.appcenter.ingestion.models.Log;
 public class AbstractChannelListener implements Channel.Listener {
 
     @Override
+    public void onGroupAdded(@NonNull String groupName) {
+    }
+
+    @Override
+    public void onGroupRemoved(@NonNull String groupName) {
+    }
+
+    @Override
     public void onEnqueuingLog(@NonNull Log log, @NonNull String groupName) {
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
@@ -94,6 +94,16 @@ public interface Channel {
     interface Listener {
 
         /**
+         * Called whenever a new group is added.
+         */
+        void onGroupAdded(@NonNull String groupName);
+
+        /**
+         * Called whenever a new group is removed.
+         */
+        void onGroupRemoved(@NonNull String groupName);
+
+        /**
          * Called whenever a log is enqueued.
          * This is used to alter some log properties if needed.
          * The channel might alter log furthermore between this event and the next one: {@link #shouldFilter}.
@@ -113,7 +123,7 @@ public interface Channel {
         boolean shouldFilter(@NonNull Log log);
 
         /**
-         * Called when the group is cleared.
+         * Called when a group is cleared.
          *
          * @param groupName The group name.
          */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -173,11 +173,6 @@ public class DefaultChannel implements Channel {
     @Override
     public synchronized void addGroup(final String groupName, int maxLogsPerBatch, long batchTimeInterval, int maxParallelBatches, GroupListener groupListener) {
 
-        /* TODO Remove this check once onGroupAdded callback is implemented. */
-        if (mGroupStates.containsKey(groupName)) {
-            return;
-        }
-
         /* Init group. */
         AppCenterLog.debug(LOG_TAG, "addGroup(" + groupName + ")");
         final GroupState groupState = new GroupState(groupName, maxLogsPerBatch, batchTimeInterval, maxParallelBatches, groupListener);
@@ -188,6 +183,11 @@ public class DefaultChannel implements Channel {
 
         /* Schedule sending any pending log. */
         checkPendingLogs(groupState.mName);
+
+        /* Call listeners so that they can react on group adding. */
+        for (Listener listener : mListeners) {
+            listener.onGroupAdded(groupName);
+        }
     }
 
     @Override
@@ -196,6 +196,11 @@ public class DefaultChannel implements Channel {
         GroupState groupState = mGroupStates.remove(groupName);
         if (groupState != null) {
             cancelTimer(groupState);
+        }
+
+        /* Call listeners so that they can react on group removed. */
+        for (Listener listener : mListeners) {
+            listener.onGroupRemoved(groupName);
         }
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/OneCollectorChannelListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/OneCollectorChannelListener.java
@@ -8,7 +8,7 @@ import com.microsoft.appcenter.ingestion.models.Log;
 /**
  * One Collector channel listener used to redirect selected traffic to One Collector.
  */
-public class OneCollectorChannelListener implements Channel.Listener {
+public class OneCollectorChannelListener extends AbstractChannelListener {
 
     /**
      * Maximum time interval in milliseconds after which a synchronize will be triggered, regardless of queue size.
@@ -34,19 +34,34 @@ public class OneCollectorChannelListener implements Channel.Listener {
     @VisibleForTesting
     static final String ONE_COLLECTOR_GROUP_NAME_SUFFIX = "/one";
 
+    /**
+     * Channel.
+     */
     private Channel mChannel;
 
+    /**
+     * Init with channel.
+     */
     public OneCollectorChannelListener(@NonNull Channel channel) {
         mChannel = channel;
     }
 
     @Override
-    public void onEnqueuingLog(@NonNull Log log, @NonNull String groupName) {
+    public void onGroupAdded(@NonNull String groupName) {
         if (isOneCollectorGroup(groupName)) {
             return;
         }
         String oneCollectorGroupName = getOneCollectorGroupName(groupName);
         mChannel.addGroup(oneCollectorGroupName, ONE_COLLECTOR_TRIGGER_COUNT, ONE_COLLECTOR_TRIGGER_INTERVAL, ONE_COLLECTOR_TRIGGER_MAX_PARALLEL_REQUESTS, null);
+    }
+
+    @Override
+    public void onGroupRemoved(@NonNull String groupName) {
+        if (isOneCollectorGroup(groupName)) {
+            return;
+        }
+        String oneCollectorGroupName = getOneCollectorGroupName(groupName);
+        mChannel.removeGroup(oneCollectorGroupName);
     }
 
     @Override

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1123,7 +1123,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
     public void addRemoveGroupListener() {
         Persistence persistence = mock(Persistence.class);
         Ingestion ingestion = mock(Ingestion.class);
-        Channel.Listener listener = mock(Channel.Listener.class);
+        Channel.Listener listener = spy(new AbstractChannelListener());
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mCoreHandler);
         channel.addListener(listener);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1120,18 +1120,15 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
     }
 
     @Test
-    public void multipleAddTheSameGroup() {
-        Persistence mockPersistence = mock(Persistence.class);
-        IngestionHttp mockIngestion = mock(IngestionHttp.class);
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mCoreHandler);
+    public void addRemoveGroupListener() {
+        Persistence persistence = mock(Persistence.class);
+        Ingestion ingestion = mock(Ingestion.class);
+        Channel.Listener listener = mock(Channel.Listener.class);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mCoreHandler);
+        channel.addListener(listener);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null);
-
-        /* Enqueuing an event. */
-        channel.enqueue(mock(Log.class), TEST_GROUP);
-        assertEquals(1, channel.getCounter(TEST_GROUP));
-
-        /* Verify that group state will not be lost on second add try. */
-        channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null);
-        assertEquals(1, channel.getCounter(TEST_GROUP));
+        verify(listener).onGroupAdded(TEST_GROUP);
+        channel.removeGroup(TEST_GROUP);
+        verify(listener).onGroupRemoved(TEST_GROUP);
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/OneCollectorChannelListenerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/OneCollectorChannelListenerTest.java
@@ -1,7 +1,5 @@
 package com.microsoft.appcenter.channel;
 
-import com.microsoft.appcenter.ingestion.models.Log;
-
 import org.junit.Test;
 
 import static com.microsoft.appcenter.channel.AbstractDefaultChannelTest.TEST_GROUP;
@@ -16,24 +14,39 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class OneCollectorChannelListenerTest {
 
     @Test
-    public void addGroupOnEnqueuingLog() {
+    public void addCorrespondingGroup() {
         Channel channel = mock(Channel.class);
         OneCollectorChannelListener listener = new OneCollectorChannelListener(channel);
 
-        /* Enqueuing an event. */
-        Log log = mock(Log.class);
-        listener.onEnqueuingLog(log, TEST_GROUP);
+        /* Mock group added. */
+        listener.onGroupAdded(TEST_GROUP);
 
-        /* Verify group added. */
+        /* Verify one collector group added. */
         verify(channel).addGroup(TEST_GROUP + ONE_COLLECTOR_GROUP_NAME_SUFFIX, ONE_COLLECTOR_TRIGGER_COUNT, ONE_COLLECTOR_TRIGGER_INTERVAL, ONE_COLLECTOR_TRIGGER_MAX_PARALLEL_REQUESTS, null);
 
-        /* Enqueuing an event to the one collector group. */
-        listener.onEnqueuingLog(log, TEST_GROUP + ONE_COLLECTOR_GROUP_NAME_SUFFIX);
+        /* Mock one collector group added callback, should not loop indefinitely. */
+        listener.onGroupAdded(TEST_GROUP + ONE_COLLECTOR_GROUP_NAME_SUFFIX);
         verifyNoMoreInteractions(channel);
     }
 
     @Test
-    public void clearGroupOnClear() {
+    public void removeCorrespondingGroup() {
+        Channel channel = mock(Channel.class);
+        OneCollectorChannelListener listener = new OneCollectorChannelListener(channel);
+
+        /* Mock group removed. */
+        listener.onGroupRemoved(TEST_GROUP);
+
+        /* Verify one collector group added. */
+        verify(channel).removeGroup(TEST_GROUP + ONE_COLLECTOR_GROUP_NAME_SUFFIX);
+
+        /* Mock one collector group added callback, should not loop indefinitely. */
+        listener.onGroupRemoved(TEST_GROUP + ONE_COLLECTOR_GROUP_NAME_SUFFIX);
+        verifyNoMoreInteractions(channel);
+    }
+
+    @Test
+    public void clearCorrespondingGroup() {
         Channel channel = mock(Channel.class);
         OneCollectorChannelListener listener = new OneCollectorChannelListener(channel);
 


### PR DESCRIPTION
Reflects design change and iOS implementation.
Removing group is specific to Android so needs to be mirrored as well in one collector groups.