### PR TITLE
Fix a crash when disabling a module at the same time logs are sent

### DIFF
--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
@@ -2,15 +2,14 @@ package com.microsoft.appcenter.channel;
 
 import android.content.Context;
 import android.os.Handler;
-import android.os.Looper;
 
 import com.microsoft.appcenter.http.ServiceCallback;
 import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.IdHelper;
-import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.UUIDUtils;
 
 import org.junit.Before;
@@ -29,7 +28,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @SuppressWarnings("WeakerAccess")
 @PrepareForTest({DefaultChannel.class, IdHelper.class, DeviceInfoHelper.class, AppCenterLog.class, HandlerUtils.class})
@@ -45,10 +43,7 @@ public class AbstractDefaultChannelTest {
     public PowerMockRule mPowerMockRule = new PowerMockRule();
 
     @Mock
-    protected Handler mHandler;
-
-    @Mock
-    protected Handler mCoreHandler;
+    protected Handler mAppCenterHandler;
 
     static Answer<String> getGetLogsAnswer() {
         return getGetLogsAnswer(-1);
@@ -59,7 +54,7 @@ public class AbstractDefaultChannelTest {
 
             @Override
             @SuppressWarnings("unchecked")
-            public String answer(InvocationOnMock invocation) throws Throwable {
+            public String answer(InvocationOnMock invocation) {
                 Object[] args = invocation.getArguments();
                 if (args[2] instanceof ArrayList) {
                     ArrayList logs = (ArrayList) args[2];
@@ -80,7 +75,7 @@ public class AbstractDefaultChannelTest {
     static Answer<Object> getSendAsyncAnswer(final Exception e) {
         return new Answer<Object>() {
             @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
+            public Object answer(InvocationOnMock invocation) {
                 Object[] args = invocation.getArguments();
                 if (args[3] instanceof ServiceCallback) {
                     if (e == null)
@@ -99,11 +94,10 @@ public class AbstractDefaultChannelTest {
         mockStatic(IdHelper.class, new Returns(UUIDUtils.randomUUID()));
         mockStatic(DeviceInfoHelper.class);
         when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenReturn(mock(Device.class));
-        whenNew(Handler.class).withParameterTypes(Looper.class).withArguments(Looper.getMainLooper()).thenReturn(mHandler);
-        when(mCoreHandler.post(any(Runnable.class))).then(new Answer<Boolean>() {
+        when(mAppCenterHandler.post(any(Runnable.class))).then(new Answer<Boolean>() {
 
             @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+            public Boolean answer(InvocationOnMock invocation) {
                 ((Runnable) invocation.getArguments()[0]).run();
                 return true;
             }
@@ -112,7 +106,7 @@ public class AbstractDefaultChannelTest {
         doAnswer(new Answer<Void>() {
 
             @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+            public Void answer(InvocationOnMock invocation) {
                 ((Runnable) invocation.getArguments()[0]).run();
                 return null;
             }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelRaceConditionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelRaceConditionTest.java
@@ -36,7 +36,7 @@ import static org.powermock.api.mockito.PowerMockito.doAnswer;
 public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest {
 
     @Test
-    public void disabledWhileSendingLogs() throws Exception {
+    public void disabledWhileSendingLogs() {
 
         /* Set up mocking. */
         final Semaphore beforeCallSemaphore = new Semaphore(0);
@@ -49,7 +49,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         doAnswer(new Answer<Void>() {
 
             @Override
-            public Void answer(final InvocationOnMock invocation) throws Throwable {
+            public Void answer(final InvocationOnMock invocation) {
                 new Thread() {
 
                     @Override
@@ -65,7 +65,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         HandlerUtils.runOnUiThread(any(Runnable.class));
 
         /* Simulate enable module then disable. */
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mCoreHandler);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         Channel.GroupListener listener = mock(Channel.GroupListener.class);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
         channel.setEnabled(false);
@@ -82,7 +82,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
     }
 
     @Test
-    public void disabledWhileHandlingIngestionSuccess() throws Exception {
+    public void disabledWhileHandlingIngestionSuccess() {
 
         /* Set up mocking. */
         final Semaphore beforeCallSemaphore = new Semaphore(0);
@@ -95,7 +95,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
 
             @Override
-            public Object answer(final InvocationOnMock invocation) throws Throwable {
+            public Object answer(final InvocationOnMock invocation) {
                 new Thread() {
 
                     @Override
@@ -110,7 +110,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         });
 
         /* Simulate enable module then disable. */
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mCoreHandler);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         Channel.GroupListener listener = mock(Channel.GroupListener.class);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
         channel.setEnabled(false);
@@ -134,7 +134,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
     }
 
     @Test
-    public void disabledWhileHandlingIngestionFailure() throws Exception {
+    public void disabledWhileHandlingIngestionFailure() {
 
         /* Set up mocking. */
         final Semaphore beforeCallSemaphore = new Semaphore(0);
@@ -148,7 +148,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
 
             @Override
-            public Object answer(final InvocationOnMock invocation) throws Throwable {
+            public Object answer(final InvocationOnMock invocation) {
                 new Thread() {
 
                     @Override
@@ -163,7 +163,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         });
 
         /* Simulate enable module then disable. */
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mCoreHandler);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         Channel.GroupListener listener = mock(Channel.GroupListener.class);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
         channel.setEnabled(false);


### PR DESCRIPTION
Reported by user when calling Analytics.setEnabled(false), the timer task for batching logs can be valid from main thread when timer executes, then we post the task to trigger ingestion in another thread. Channel group can be removed before the task executes and trigger the crash.

We don't need the timer to be in main thread so the solution is to make sure every channel operation is in background thread, including the timer so that if it triggers, the disabling can happen only after. If disable happens before, then timer will be canceled.

The solution actually simplifies the code as we already had the handler for app center background thread.