### PR TITLE
Use only 2 connections max for one collector

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/OneCollectorChannelListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/OneCollectorChannelListener.java
@@ -41,7 +41,7 @@ public class OneCollectorChannelListener extends AbstractChannelListener {
      * Maximum number of requests being sent for the group.
      */
     @VisibleForTesting
-    static final int ONE_COLLECTOR_TRIGGER_MAX_PARALLEL_REQUESTS = 3;
+    static final int ONE_COLLECTOR_TRIGGER_MAX_PARALLEL_REQUESTS = 2;
 
     /**
      * Postfix for One Collector's groups.


### PR DESCRIPTION
This works since we send only events to 1 log group.
In the future we'll also need to tune the executor in http client.