### PR TITLE
Introduce AppCenter.startFromLibrary

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
@@ -1,10 +1,19 @@
 package com.microsoft.appcenter.sasquatch.activities;
 
+import android.os.Bundle;
+
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.Analytics;
 
 import java.util.Map;
 
 public class EventActivity extends LogActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        AppCenter.startFromLibrary(getApplication(), Analytics.class);
+    }
 
     @Override
     protected void trackLog(String name, Map<String, String> properties) {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
@@ -1,10 +1,12 @@
 package com.microsoft.appcenter.sasquatch.activities;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.Analytics;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
 public class EventActivity extends LogActivity {
@@ -12,7 +14,13 @@ public class EventActivity extends LogActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        AppCenter.startFromLibrary(getApplication(), Analytics.class);
+
+        /* TODO remove reflection once API available in jCenter. */
+        try {
+            Method startFromLibrary = AppCenter.class.getMethod("startFromLibrary", Context.class, Class[].class);
+            startFromLibrary.invoke(null, getApplication(), new Class[]{Analytics.class});
+        } catch (Exception ignore) {
+        }
     }
 
     @Override

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -300,6 +300,16 @@ public class SettingsActivity extends AppCompatActivity {
                     return true;
                 }
             });
+
+            /* When changing start type from NONE to other type, we need to trigger a preference change to update the display from null to actual value. */
+            initChangeableSetting(R.string.install_id_key, String.valueOf(AppCenter.getInstallId().get()), new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    preference.setSummary(String.valueOf(AppCenter.getInstallId().get()));
+                    return true;
+                }
+            });
             initClickableSetting(R.string.app_secret_key, MainActivity.sSharedPreferences.getString(APP_SECRET_KEY, getString(R.string.app_secret)), new Preference.OnPreferenceClickListener() {
 
                 @Override
@@ -343,6 +353,9 @@ public class SettingsActivity extends AppCompatActivity {
 
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    if (newValue == null) {
+                        return true;
+                    }
                     String startValue = newValue.toString();
                     setKeyValue(APPCENTER_START_TYPE, startValue);
                     preference.setSummary(MainActivity.sSharedPreferences.getString(APPCENTER_START_TYPE, null));

--- a/apps/sasquatch/src/main/res/values/array.xml
+++ b/apps/sasquatch/src/main/res/values/array.xml
@@ -4,5 +4,6 @@
         <item>APP_SECRET</item>
         <item>TARGET</item>
         <item>BOTH</item>
+        <item>NONE</item>
     </string-array>
 </resources>

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -74,6 +74,7 @@
 
     <string name="appcenter_start_type_key" tools:ignore="MissingTranslation">appcenter_start_type_key</string>
     <string name="appcenter_start_type_title" tools:ignore="MissingTranslation">Start type</string>
+    <string name="appcenter_start_type_changed" tools:ignore="MissingTranslation">Start type updated. Please close the application completely and relaunch again.</string>
 
     <string name="target_id_key" tools:ignore="MissingTranslation">target_id_key</string>
     <string name="target_id_title" tools:ignore="MissingTranslation">Target Id</string>

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -78,6 +78,7 @@
         android:key="@string/application_info_key"
         android:title="@string/application_info_title">
         <Preference
+            android:dependency="@string/appcenter_state_key"
             android:key="@string/install_id_key"
             android:title="@string/install_id_title" />
         <Preference

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -30,7 +30,6 @@ import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -105,7 +104,7 @@ public class CrashesAndroidTest {
         Thread.setDefaultUncaughtExceptionHandler(sDefaultCrashHandler);
     }
 
-    private void startFresh(CrashesListener listener) throws Exception {
+    private void startFresh(CrashesListener listener) {
 
         /* Configure new instance. */
         AppCenterPrivateHelper.unsetInstance();
@@ -118,13 +117,7 @@ public class CrashesAndroidTest {
         AppCenter.setEnabled(true).get();
 
         /* Replace channel. */
-        Method method = AppCenter.class.getDeclaredMethod("getInstance");
-        method.setAccessible(true);
-        AppCenter appCenter = (AppCenter) method.invoke(null);
-        method = AppCenter.class.getDeclaredMethod("setChannel", Channel.class);
-        method.setAccessible(true);
-        method.invoke(appCenter, mChannel);
-
+        AppCenter.getInstance().setChannel(mChannel);
         /* Set listener. */
         Crashes.setListener(listener);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -36,6 +36,7 @@ import com.microsoft.appcenter.utils.storage.StorageHelper;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -745,10 +746,11 @@ public class AppCenter {
     @WorkerThread
     private void sendStartServiceLog(List<String> serviceNames) {
         if (isInstanceEnabled()) {
-            serviceNames.addAll(mStartedServicesNamesToLog);
+            List<String> allServiceNamesToStart = new ArrayList<>(serviceNames);
+            allServiceNamesToStart.addAll(mStartedServicesNamesToLog);
             mStartedServicesNamesToLog.clear();
             StartServiceLog startServiceLog = new StartServiceLog();
-            startServiceLog.setServices(serviceNames);
+            startServiceLog.setServices(allServiceNamesToStart);
             mChannel.enqueue(startServiceLog, CORE_GROUP);
         } else {
             mStartedServicesNamesToLog.addAll(serviceNames);
@@ -847,8 +849,7 @@ public class AppCenter {
 
         /* Send started services. */
         if (!mStartedServicesNamesToLog.isEmpty() && switchToEnabled) {
-            sendStartServiceLog(mStartedServicesNamesToLog);
-            mStartedServicesNamesToLog.clear();
+            sendStartServiceLog(Collections.<String>emptyList());
         }
 
         /* Apply change to services. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -177,7 +177,7 @@ public class AppCenter {
      *
      * @return unique instance.
      */
-    static synchronized AppCenter getInstance() {
+    public static synchronized AppCenter getInstance() {
         if (sInstance == null) {
             sInstance = new AppCenter();
         }
@@ -929,9 +929,8 @@ public class AppCenter {
         return mUncaughtExceptionHandler;
     }
 
-    @SuppressWarnings("SameParameterValue")
     @VisibleForTesting
-    void setChannel(Channel channel) {
+    public void setChannel(Channel channel) {
         mChannel = channel;
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -532,14 +532,14 @@ public class AppCenter {
      */
     private boolean configureAppSecret(String appSecret) {
 
-        /* We don't support overriding the app secret. */
-        if (mAppSecret != null || mTransmissionTargetToken != null) {
-            AppCenterLog.warn(LOG_TAG, "App Center may only be configured once.");
-            return false;
-        }
-
         /* A null secret is still valid since transmission target token can be set later. */
         if (appSecret != null && !appSecret.isEmpty()) {
+
+            /* We don't support overriding the app secret. */
+            if (mAppSecret != null || mTransmissionTargetToken != null) {
+                AppCenterLog.warn(LOG_TAG, "App Center may only be configured once.");
+                return false;
+            }
 
             /* Init parsing, the app secret string can contain other secrets.  */
             String[] pairs = appSecret.split(PAIR_DELIMITER);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
@@ -641,7 +640,7 @@ public class AppCenter {
     }
 
     @SafeVarargs
-    private final synchronized void startServices(boolean startFromApp, Class<? extends AppCenterService>... services) {
+    private final synchronized void startServices(final boolean startFromApp, Class<? extends AppCenterService>... services) {
         if (services == null) {
             AppCenterLog.error(LOG_TAG, "Cannot start services, services array is null. Failed to start services.");
             return;
@@ -693,14 +692,14 @@ public class AppCenter {
 
                 @Override
                 public void run() {
-                    finishStartServices(startedServices);
+                    finishStartServices(startedServices, startFromApp);
                 }
             });
         }
     }
 
     @WorkerThread
-    private void finishStartServices(Iterable<AppCenterService> services) {
+    private void finishStartServices(Iterable<AppCenterService> services, boolean startFromApp) {
         boolean enabled = isInstanceEnabled();
         List<String> serviceNames = new ArrayList<>();
         for (AppCenterService service : services) {
@@ -717,7 +716,11 @@ public class AppCenter {
             AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started.");
             serviceNames.add(service.getServiceName());
         }
-        sendStartServiceLog(serviceNames);
+
+        /* If starting from a library, we will send start service log later when app starts with an app secret. */
+        if (startFromApp) {
+            sendStartServiceLog(serviceNames);
+        }
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -454,14 +454,14 @@ public class AppCenter {
     /**
      * Internal SDK configuration.
      *
-     * @param application application context.
-     * @param appSecret   a unique and secret key used to identify the application.
-     *                    It can be null since a transmission target token can be set later.
+     * @param application  application context.
+     * @param secretString a unique and secret key used to identify the application.
+     *                     It can be null since a transmission target token can be set later.
      * @return true if configuration was successful, false otherwise.
      */
     /* UncaughtExceptionHandler is used by PowerMock but lint does not detect it. */
     @SuppressLint("VisibleForTests")
-    private synchronized boolean instanceConfigure(Application application, String appSecret) {
+    private synchronized boolean instanceConfigure(Application application, String secretString) {
 
         /* Check parameters. */
         if (application == null) {
@@ -474,8 +474,9 @@ public class AppCenter {
             AppCenterLog.setLogLevel(Log.WARN);
         }
 
-        /* Configure app secret. */
-        if (!configureAppSecret(appSecret)) {
+        /* Configure app secret and/or transmission target. */
+        String previousAppSecret = mAppSecret;
+        if (!configureSecretString(secretString)) {
             return false;
         }
 
@@ -483,7 +484,7 @@ public class AppCenter {
         if (mHandler != null) {
 
             /* If app started after library with an app secret, set app secret on channel now. */
-            if (appSecret != null && appSecret.equals(mAppSecret)) {
+            if (mAppSecret != null && !mAppSecret.equals(previousAppSecret)) {
                 mHandler.post(new Runnable() {
 
                     @Override
@@ -532,7 +533,7 @@ public class AppCenter {
      *                  It can be null since a transmission target token can be set later.
      * @return false if app secret already configured or invalid.
      */
-    private boolean configureAppSecret(String appSecret) {
+    private boolean configureSecretString(String appSecret) {
 
         /* A null secret is still valid since transmission target token can be set later. */
         if (appSecret != null && !appSecret.isEmpty()) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/UncaughtExceptionHandler.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/UncaughtExceptionHandler.java
@@ -56,9 +56,7 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
 
                 @Override
                 public void run() {
-                    if (mChannel != null) {
-                        mChannel.shutdown();
-                    }
+                    mChannel.shutdown();
                     AppCenterLog.debug(AppCenter.LOG_TAG, "Channel completed shutdown.");
                     semaphore.release();
                 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/UncaughtExceptionHandler.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/UncaughtExceptionHandler.java
@@ -1,0 +1,100 @@
+package com.microsoft.appcenter;
+
+import android.os.Handler;
+import android.support.annotation.VisibleForTesting;
+
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.utils.AppCenterLog;
+import com.microsoft.appcenter.utils.ShutdownHelper;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Uncaught exception handler of core module, to wait storage operations to finish on crash.
+ */
+class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+    /**
+     * Shutdown timeout in millis.
+     */
+    private static final int SHUTDOWN_TIMEOUT = 5000;
+
+    /**
+     * Handler on App Center background thread.
+     */
+    private final Handler mHandler;
+
+    /**
+     * App Center channel.
+     */
+    private final Channel mChannel;
+
+    /**
+     * Default/previous exception handler for chaining calls.
+     */
+    private Thread.UncaughtExceptionHandler mDefaultUncaughtExceptionHandler;
+
+    /**
+     * Init.
+     *
+     * @param handler handler.
+     * @param channel channel.
+     */
+    UncaughtExceptionHandler(Handler handler, Channel channel) {
+        mHandler = handler;
+        mChannel = channel;
+    }
+
+    @Override
+    public void uncaughtException(Thread thread, Throwable exception) {
+        if (AppCenter.getInstance().isInstanceEnabled()) {
+
+            /* Wait channel to finish saving other logs in background. */
+            final Semaphore semaphore = new Semaphore(0);
+            mHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (mChannel != null) {
+                        mChannel.shutdown();
+                    }
+                    AppCenterLog.debug(AppCenter.LOG_TAG, "Channel completed shutdown.");
+                    semaphore.release();
+                }
+            });
+            try {
+                if (!semaphore.tryAcquire(SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS)) {
+                    AppCenterLog.error(AppCenter.LOG_TAG, "Timeout waiting for looper tasks to complete.");
+                }
+            } catch (InterruptedException e) {
+                AppCenterLog.warn(AppCenter.LOG_TAG, "Interrupted while waiting looper to flush.", e);
+            }
+        }
+        if (mDefaultUncaughtExceptionHandler != null) {
+            mDefaultUncaughtExceptionHandler.uncaughtException(thread, exception);
+        } else {
+            ShutdownHelper.shutdown(10);
+        }
+    }
+
+    @VisibleForTesting
+    Thread.UncaughtExceptionHandler getDefaultUncaughtExceptionHandler() {
+        return mDefaultUncaughtExceptionHandler;
+    }
+
+    /**
+     * Register uncaught exception handler.
+     */
+    void register() {
+        mDefaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(this);
+    }
+
+    /**
+     * Unregister uncaught exception handler.
+     */
+    void unregister() {
+        Thread.setDefaultUncaughtExceptionHandler(mDefaultUncaughtExceptionHandler);
+    }
+}

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
@@ -11,6 +11,14 @@ import com.microsoft.appcenter.ingestion.models.Log;
 public interface Channel {
 
     /**
+     * Set app secret. Intended usage is to use that only if there was no app secret at initialization time.
+     * The behavior is undefined if trying to update app secret a second time.
+     *
+     * @param appSecret app secret.
+     */
+    void setAppSecret(@NonNull String appSecret);
+
+    /**
      * Add a group for logs to be persisted and sent.
      *
      * @param groupName          the name of a group.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -616,7 +616,7 @@ public class DefaultChannel implements Channel {
         if (filteredOut) {
             AppCenterLog.debug(LOG_TAG, "Log of type '" + log.getType() + "' was filtered out by listener(s)");
         } else {
-            if (mAppSecret == null) {
+            if (mAppSecret == null && groupState.mIngestion == mIngestion) {
 
                 /* Log was not filtered out but no app secret has been provided. Do nothing in this case. */
                 AppCenterLog.debug(LOG_TAG, "Log of type '" + log.getType() + "' was not filtered out by listener(s) but no app secret was provided. Not persisting/sending the log.");

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -276,7 +276,7 @@ public class DefaultChannel implements Channel {
      */
     @Override
     public synchronized void clear(String groupName) {
-        if (!mGroupStates.containsKey(groupName) || mGroupStates.get(groupName).mIngestion == null) {
+        if (!mGroupStates.containsKey(groupName)) {
             return;
         }
         AppCenterLog.debug(LOG_TAG, "clear(" + groupName + ")");
@@ -354,9 +354,6 @@ public class DefaultChannel implements Channel {
     }
 
     private void cancelTimer(GroupState groupState) {
-        if (groupState.mIngestion == null) {
-            return;
-        }
         if (groupState.mScheduled) {
             groupState.mScheduled = false;
             mAppCenterHandler.removeCallbacks(groupState.mRunnable);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -200,8 +200,8 @@ public class DefaultChannel implements Channel {
         /* Count pending logs. */
         groupState.mPendingLogCount = mPersistence.countLogs(groupName);
 
-        /* If no app secret, don't resume sending logs from storage. */
-        if (mAppSecret != null) {
+        /* If no app secret, don't resume sending App Center logs from storage. */
+        if (mAppSecret != null && mIngestion == ingestion) {
 
             /* Schedule sending any pending log. */
             checkPendingLogs(groupState.mName);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -134,7 +134,7 @@ public class DefaultChannel implements Channel {
      * @param appCenterHandler App Center looper thread handler.
      */
     @VisibleForTesting
-    DefaultChannel(@NonNull Context context, String appSecret, @NonNull Persistence persistence, Ingestion ingestion, @NonNull Handler appCenterHandler) {
+    DefaultChannel(@NonNull Context context, String appSecret, @NonNull Persistence persistence, @NonNull Ingestion ingestion, @NonNull Handler appCenterHandler) {
         mContext = context;
         mAppSecret = appSecret;
         mInstallId = IdHelper.getInstallId();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -85,7 +85,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 @SuppressWarnings({"unused", "CanBeFinal"})
 @PrepareForTest({
         AppCenter.class,
-        AppCenter.UncaughtExceptionHandler.class,
+        UncaughtExceptionHandler.class,
         DefaultChannel.class,
         Constants.class,
         AppCenterLog.class,
@@ -999,7 +999,7 @@ public class AppCenterTest {
         Thread.UncaughtExceptionHandler defaultUncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
         when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(defaultUncaughtExceptionHandler);
         AppCenter.configure(mApplication, DUMMY_APP_SECRET);
-        AppCenter.UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
+        UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
         assertNotNull(handler);
         assertEquals(defaultUncaughtExceptionHandler, handler.getDefaultUncaughtExceptionHandler());
         verifyStatic();
@@ -1050,7 +1050,7 @@ public class AppCenterTest {
         Thread.UncaughtExceptionHandler defaultUncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
         when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(defaultUncaughtExceptionHandler);
         AppCenter.configure(mApplication, DUMMY_APP_SECRET);
-        AppCenter.UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
+        UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
         assertNotNull(handler);
         assertEquals(defaultUncaughtExceptionHandler, handler.getDefaultUncaughtExceptionHandler());
         verifyStatic();
@@ -1084,7 +1084,7 @@ public class AppCenterTest {
         Thread.UncaughtExceptionHandler defaultUncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
         when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(defaultUncaughtExceptionHandler);
         AppCenter.configure(mApplication, DUMMY_APP_SECRET);
-        AppCenter.UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
+        UncaughtExceptionHandler handler = AppCenter.getInstance().getUncaughtExceptionHandler();
         assertNotNull(handler);
         assertEquals(defaultUncaughtExceptionHandler, handler.getDefaultUncaughtExceptionHandler());
         verifyStatic();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1331,10 +1331,15 @@ public class AppCenterTest {
         services.add(AnotherDummyService.getInstance().getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
 
-        /* Start two services from library. */
+        /* Start two services from 2 libraries. */
         AppCenter.startFromLibrary(mApplication, DummyService.class, AnotherDummyService.class);
+        AppCenter.startFromLibrary(mApplication, AnotherDummyService.class, DummyService.class);
 
-        /* Check nothing changes. */
+        /* We get no warnings as app started those. */
+        verifyStatic(never());
+        AppCenterLog.warn(anyString(), anyString());
+
+        /* Check nothing changes as everything was already initialized by app start. */
         assertEquals(2, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1177,6 +1177,20 @@ public class AppCenterTest {
         }));
     }
 
+    @Test
+    public void startFromLibrary() {
+        AppCenter.startFromLibrary(mApplication, DummyService.class, AnotherDummyService.class);
+
+        /* Verify that dummy service has been loaded and configured */
+        assertEquals(1, AppCenter.getInstance().getServices().size());
+        DummyService service = DummyService.getInstance();
+        assertTrue(AppCenter.getInstance().getServices().contains(service));
+        verify(service).getLogFactories();
+        verify(service).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(mApplication).registerActivityLifecycleCallbacks(service);
+        verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+    }
+
     private static class DummyService extends AbstractAppCenterService {
 
         private static DummyService sharedInstance;

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1022,7 +1022,6 @@ public class AppCenterTest {
         /* Try enabled without default thread handler: should shut down process. */
         when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(null);
         AppCenter.setEnabled(true);
-        AppCenter.getInstance().setChannel(null);
         assertNull(handler.getDefaultUncaughtExceptionHandler());
         handler.uncaughtException(thread, exception);
         verifyStatic();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -356,6 +356,47 @@ public class AppCenterTest {
     }
 
     @Test
+    public void startTargetTokenThenStartWithAppSecretTest() {
+        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
+        AppCenter.start(mApplication, secret, DummyService.class);
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, AnotherDummyService.class);
+
+        /* Verify that single service has been loaded and configured */
+        assertEquals(1, AppCenter.getInstance().getServices().size());
+        DummyService service = DummyService.getInstance();
+        assertTrue(AppCenter.getInstance().getServices().contains(service));
+        verify(service).getLogFactories();
+        verify(service).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(service, never()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(mApplication).registerActivityLifecycleCallbacks(service);
+        verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+        List<String> services = new ArrayList<>();
+        services.add(service.getServiceName());
+        verify(mStartServiceLog).setServices(eq(services));
+    }
+
+    @Test
+    public void startAppSecretThenStartWithTargetTokenTest() {
+        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+        AppCenter.start(mApplication, secret, AnotherDummyService.class);
+
+        /* Verify that single service has been loaded and configured */
+        assertEquals(1, AppCenter.getInstance().getServices().size());
+        DummyService service = DummyService.getInstance();
+        assertTrue(AppCenter.getInstance().getServices().contains(service));
+        verify(service).getLogFactories();
+        verify(service, never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(mApplication).registerActivityLifecycleCallbacks(service);
+        verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+        List<String> services = new ArrayList<>();
+        services.add(service.getServiceName());
+        verify(mStartServiceLog).setServices(eq(services));
+    }
+
+
+    @Test
     public void configureTwiceTest() {
         AppCenter.configure(mApplication, DUMMY_APP_SECRET);
         AppCenter.configure(mApplication, DUMMY_APP_SECRET + "a"); //ignored

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -108,6 +108,8 @@ public class AppCenterTest {
 
     private static final String DUMMY_TRANSMISSION_TARGET_TOKEN = "snfbse234jknf";
 
+    private static final String DUMMY_TARGET_TOKEN_STRING = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
+
     @Rule
     public PowerMockRule mPowerMockRule = new PowerMockRule();
 
@@ -357,8 +359,7 @@ public class AppCenterTest {
 
     @Test
     public void startTargetTokenThenStartWithAppSecretTest() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
-        AppCenter.start(mApplication, secret, DummyService.class);
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class);
         AppCenter.start(mApplication, DUMMY_APP_SECRET, AnotherDummyService.class);
 
         /* Verify that single service has been loaded and configured */
@@ -377,9 +378,8 @@ public class AppCenterTest {
 
     @Test
     public void startAppSecretThenStartWithTargetTokenTest() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
-        AppCenter.start(mApplication, secret, AnotherDummyService.class);
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, AnotherDummyService.class);
 
         /* Verify that single service has been loaded and configured */
         assertEquals(1, AppCenter.getInstance().getServices().size());
@@ -846,7 +846,7 @@ public class AppCenterTest {
 
     @Test
     public void appSecretWithTargetTokenTest() {
-        String secret = DUMMY_APP_SECRET + PAIR_DELIMITER + TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
+        String secret = DUMMY_APP_SECRET + PAIR_DELIMITER + DUMMY_TARGET_TOKEN_STRING;
         AppCenter.start(mApplication, secret, DummyService.class);
         verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
     }
@@ -868,22 +868,21 @@ public class AppCenterTest {
     @Test
     public void keyedAppSecretWithTargetTokenTest() {
         String secret = APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET + PAIR_DELIMITER +
-                TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
+                DUMMY_TARGET_TOKEN_STRING;
         AppCenter.start(mApplication, secret, DummyService.class);
         verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
     }
 
     @Test
     public void targetTokenTest() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
-        AppCenter.start(mApplication, secret, DummyService.class, AnotherDummyService.class);
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class, AnotherDummyService.class);
         verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
         verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
     }
 
     @Test
     public void targetTokenWithAppSecretTest() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN + PAIR_DELIMITER +
+        String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
                 DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
         verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
@@ -891,7 +890,7 @@ public class AppCenterTest {
 
     @Test
     public void targetTokenWithUnKeyedAppSecretTest() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN + PAIR_DELIMITER +
+        String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
                 APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
         verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
@@ -900,7 +899,7 @@ public class AppCenterTest {
     @Test
     public void unknownKeyTest() {
         String secret = DUMMY_APP_SECRET + PAIR_DELIMITER +
-                TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN + PAIR_DELIMITER +
+                DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
                 "unknown" + KEY_VALUE_DELIMITER + "value";
         AppCenter.start(mApplication, secret, DummyService.class);
         assertTrue(AppCenter.isEnabled().get());
@@ -1237,8 +1236,7 @@ public class AppCenterTest {
 
     @Test
     public void addOneCollectorListenerOnStart() {
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
-        AppCenter.start(mApplication, secret, DummyService.class);
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class);
         verify(mChannel).addListener(argThat(new ArgumentMatcher<Channel.Listener>() {
 
             @Override
@@ -1274,7 +1272,7 @@ public class AppCenterTest {
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
 
-        /* Verify onStarted was not called again. */
+        /* Verify onStarted was not called again (e.g. not more than once). */
         verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
@@ -1311,8 +1309,7 @@ public class AppCenterTest {
         verify(mChannel, never()).setAppSecret(anyString());
 
         /* Start two services from app. */
-        String secret = TRANSMISSION_TARGET_TOKEN_KEY + KEY_VALUE_DELIMITER + DUMMY_TRANSMISSION_TARGET_TOKEN;
-        AppCenter.start(mApplication, secret, DummyService.class, AnotherDummyService.class);
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class, AnotherDummyService.class);
 
         /* Verify that the right amount of services have been loaded and configured. */
         assertEquals(1, AppCenter.getInstance().getServices().size());
@@ -1321,7 +1318,7 @@ public class AppCenterTest {
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
 
-        /* Verify onStarted was not called again. */
+        /* Verify onStarted was not called again (e.g. not more than once). */
         verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
@@ -1353,8 +1350,6 @@ public class AppCenterTest {
         /* Verify first service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-
-        /* Verify onStarted was not called again. */
         verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
@@ -1393,6 +1388,56 @@ public class AppCenterTest {
         services = new ArrayList<>();
         services.add(DummyService.getInstance().getServiceName());
         services.add(AnotherDummyService.getInstance().getServiceName());
+        verify(mStartServiceLog).setServices(eq(services));
+
+        /* Verify we didn't update app secret on channel. */
+        verify(mChannel, never()).setAppSecret(anyString());
+    }
+
+    @Test
+    public void startWithTargetTokenThenFromLibrary() {
+
+        /* Start two services from app with a target token. */
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class, AnotherDummyService.class);
+
+        /* Verify that only first service started as the second service requires app secret. */
+        assertEquals(1, AppCenter.getInstance().getServices().size());
+
+        /* Verify first service started. */
+        assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
+        verify(DummyService.getInstance()).getLogFactories();
+        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
+
+        /* Verify second service not started. */
+        assertFalse(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
+        verify(AnotherDummyService.getInstance(), never()).getLogFactories();
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(mApplication, never()).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
+
+        /* Verify start service log is sent with only first service. */
+        verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+        List<String> services = new ArrayList<>();
+        services.add(DummyService.getInstance().getServiceName());
+        verify(mStartServiceLog).setServices(eq(services));
+
+        /* Start two services from 2 libraries. */
+        AppCenter.startFromLibrary(mApplication, DummyService.class, AnotherDummyService.class);
+        AppCenter.startFromLibrary(mApplication, AnotherDummyService.class, DummyService.class);
+
+        /* Check nothing changes as everything was already initialized by app start. */
+        assertEquals(1, AppCenter.getInstance().getServices().size());
+        assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
+        verify(DummyService.getInstance()).getLogFactories();
+        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
+        assertFalse(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
+        verify(AnotherDummyService.getInstance(), never()).getLogFactories();
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(mApplication, never()).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
+        verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+        services = new ArrayList<>();
+        services.add(DummyService.getInstance().getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
 
         /* Verify we didn't update app secret on channel. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1216,8 +1216,8 @@ public class AppCenterTest {
         /* Verify start service log is sent. */
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
-        services.add(DummyService.getInstance().getServiceName());
         services.add(AnotherDummyService.getInstance().getServiceName());
+        services.add(DummyService.getInstance().getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1093,7 +1093,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         /* Check log url. */
         String logUrl = "http://mockUrl";
         channel.setLogUrl(logUrl);
-        verify(ingestion, never()).setLogUrl(logUrl);
+        verify(ingestion).setLogUrl(logUrl);
 
         /* Check enqueue. */
         Log log = mock(Log.class);
@@ -1109,19 +1109,6 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         /* Check shutdown. */
         channel.shutdown();
         verify(persistence).clearPendingLogState();
-    }
-
-    @Test
-    public void withoutIngestion() {
-        Persistence persistence = mock(Persistence.class);
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, null, mAppCenterHandler);
-        channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
-        channel.enqueue(mock(Log.class), TEST_GROUP);
-        channel.enqueue(mock(Log.class), "other");
-        channel.setEnabled(false);
-        channel.setEnabled(true);
-
-        /* No exceptions. */
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1074,20 +1074,17 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     @Test
     public void nullAppSecretProvided() throws Persistence.PersistenceException {
-        testChannelWithoutAppSecret(null);
-    }
 
-    @Test
-    public void emptyAppSecretProvided() throws Persistence.PersistenceException {
-        testChannelWithoutAppSecret("");
-    }
-
-    private void testChannelWithoutAppSecret(String appSecret) throws Persistence.PersistenceException {
+        /*
+         * We don't test empty app secret in channel (and thus in tests) as it's already checked by AppCenter.
+         * If app secret is set in channel, the assumption is that it's a well formed string.
+         * Channel is not meant to be used publicly directly.
+         */
 
         /* Given a mock channel. */
         Persistence persistence = mock(Persistence.class);
         Ingestion ingestion = mock(Ingestion.class);
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), appSecret, persistence, ingestion, mAppCenterHandler);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), null, persistence, ingestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
 
         /* Check log url. */
@@ -1102,9 +1099,9 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.enqueue(mock(Log.class), "other");
         verify(persistence, never()).putLog(anyString(), any(Log.class));
 
-        /* Check clear. */
+        /* Check clear. Even without app secret it works as it could be logs from previous process. */
         channel.clear(TEST_GROUP);
-        verify(persistence, never()).deleteLogs(eq(TEST_GROUP));
+        verify(persistence).deleteLogs(eq(TEST_GROUP));
 
         /* Check shutdown. */
         channel.shutdown();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1252,6 +1252,5 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         /* Verify that now logs are sent when channel is enabled. */
         verify(defaultIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(alternateIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-
     }
 }


### PR DESCRIPTION
The feature is not 100% complete yet but we want to split in multiple PRs if possible or at least start review now before it gets too big.

What works with the feature:

* startFromLibrary before or after the app and track events.
* make sure start service log is sent after the app specifies app secret.

What does not work yet:

* Send start session log if app starts analytics after library (Fixed by #737)
* Preventing multiple calls to AppCenter.start with null appSecret. There is a pending discussion.
