### PR TITLE
Multitenancy: Fix start session / page tracking and static track calls behavior

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -445,7 +445,7 @@ public class Analytics extends AbstractAppCenterService {
         /* If we enabled the service. */
         if (enabled) {
 
-            /* Check if we have an app secret and enable corresponding features. */
+            /* Check if service started at application level and enable corresponding features. */
             startAppLevelFeatures();
         }
 
@@ -506,6 +506,8 @@ public class Analytics extends AbstractAppCenterService {
 
             @Override
             public void run() {
+
+                /* This flag is always read/written in the background thread. */
                 if (mStartedFromApp) {
                     queuePage(name, propertiesCopy);
                 } else {

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -584,7 +584,6 @@ public class Analytics extends AbstractAppCenterService {
 
     @Override
     public void onConfigurationUpdated(String appSecret, String transmissionTargetToken) {
-        super.onConfigurationUpdated(appSecret, transmissionTargetToken);
         mStartedFromApp = true;
         startAppLevelFeatures();
         setDefaultTransmissionTarget(transmissionTargetToken);

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -270,7 +270,7 @@ public class AnalyticsTest {
         analytics.onStarting(mAppCenterHandler);
         analytics.onStarted(mock(Context.class), channel, null, null, false);
 
-        /* There is no default transmission target and no app secret so it must not enqueue. */
+        /* Static track call forbidden if app didn't start Analytics. */
         Analytics.trackEvent("eventName");
         verify(channel, never()).enqueue(isA(EventLog.class), anyString());
 

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -179,7 +179,7 @@ public class AnalyticsTest {
         /* Start. */
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
 
         /* Test resume/pause. */
         analytics.onActivityResumed(activity);
@@ -220,7 +220,7 @@ public class AnalyticsTest {
         assertFalse(Analytics.isAutoPageTrackingEnabled());
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         analytics.onActivityResumed(new MyActivity());
         verify(channel).enqueue(argThat(new ArgumentMatcher<Log>() {
 
@@ -257,7 +257,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         Analytics.trackEvent("eventName");
         verify(channel, times(1)).enqueue(any(Log.class), anyString());
     }
@@ -267,7 +267,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         Analytics.trackEvent("pageName");
         verify(channel, times(1)).enqueue(any(Log.class), anyString());
     }
@@ -285,7 +285,7 @@ public class AnalyticsTest {
         /* Start. */
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         verify(channel).removeGroup(eq(analytics.getGroupName()));
         verify(channel).addGroup(eq(analytics.getGroupName()), anyInt(), anyLong(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
         verify(channel).addListener(isA(SessionTracker.class));
@@ -349,7 +349,7 @@ public class AnalyticsTest {
         /* Start. */
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         verify(channel, never()).removeListener(any(Channel.Listener.class));
         verify(channel, never()).addListener(any(Channel.Listener.class));
     }
@@ -364,7 +364,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         Analytics.setEnabled(false);
 
         /* App in foreground: no log yet, we are disabled. */
@@ -409,7 +409,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         Analytics.setEnabled(false);
 
         /* App in foreground: no log yet, we are disabled. */
@@ -429,7 +429,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), "", null, channel);
+        analytics.onStarted(mock(Context.class), channel, "", null, true);
         final ArgumentCaptor<Channel.GroupListener> captor = ArgumentCaptor.forClass(Channel.GroupListener.class);
         verify(channel).addGroup(anyString(), anyInt(), anyLong(), anyInt(), isNull(Ingestion.class), captor.capture());
         doAnswer(new Answer<Void>() {
@@ -477,7 +477,7 @@ public class AnalyticsTest {
         Analytics analytics = Analytics.getInstance();
         Channel channel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
-        analytics.onStarted(mock(Context.class), null, "token", channel);
+        analytics.onStarted(mock(Context.class), channel, null, "token", true);
         AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("token");
         assertNotNull(target);
 

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -360,9 +360,9 @@ public class Crashes extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
         mContext = context;
-        super.onStarted(context, appSecret, transmissionTargetToken, channel);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
         if (isInstanceEnabled()) {
             processPendingErrors();
         } else {

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -194,7 +194,7 @@ public class CrashesTest {
         crashes.setUncaughtExceptionHandler(mockHandler);
         when(StorageHelper.PreferencesStorage.getBoolean(CRASHES_ENABLED_KEY, true)).thenReturn(false);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Test. */
         assertFalse(Crashes.isEnabled().get());
@@ -248,7 +248,7 @@ public class CrashesTest {
 
         /* Start. */
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mockChannel);
+        crashes.onStarted(mock(Context.class), mockChannel, "", null, true);
         verify(mockChannel).removeGroup(eq(crashes.getGroupName()));
         verify(mockChannel).addGroup(eq(crashes.getGroupName()), anyInt(), anyInt(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
 
@@ -329,7 +329,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         /* Test. */
         verify(mockListener).shouldProcess(report);
@@ -369,7 +369,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         verify(mockListener).shouldProcess(report);
         verify(mockListener, never()).shouldAwaitUserConfirmation();
@@ -418,7 +418,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         verify(mockListener).shouldProcess(report);
         verify(mockListener, never()).shouldAwaitUserConfirmation();
@@ -452,7 +452,7 @@ public class CrashesTest {
 
         Channel channel = mock(Channel.class);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, channel);
+        crashes.onStarted(mock(Context.class), channel, "", null, true);
         verifyZeroInteractions(listener);
         verify(channel, never()).enqueue(any(Log.class), anyString());
     }
@@ -465,7 +465,7 @@ public class CrashesTest {
         Channel channel = mock(Channel.class);
         Crashes crashes = Crashes.getInstance();
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, channel);
+        crashes.onStarted(mock(Context.class), channel, "", null, true);
         verify(channel, never()).enqueue(any(Log.class), anyString());
     }
 
@@ -484,7 +484,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
 
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         verify(mockChannel, never()).enqueue(any(Log.class), anyString());
     }
@@ -506,7 +506,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
 
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         verify(mockChannel, never()).enqueue(any(Log.class), anyString());
 
@@ -532,7 +532,7 @@ public class CrashesTest {
         Crashes crashes = Crashes.getInstance();
         Channel mockChannel = mock(Channel.class);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mockChannel);
+        crashes.onStarted(mock(Context.class), mockChannel, "", null, true);
         Crashes.trackException(EXCEPTION);
         verify(mockChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
 
@@ -632,7 +632,7 @@ public class CrashesTest {
         WrapperSdkExceptionManager.trackException(exception);
         verify(mockChannel, never()).enqueue(any(Log.class), eq(crashes.getGroupName()));
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mockChannel);
+        crashes.onStarted(mock(Context.class), mockChannel, "", null, true);
         WrapperSdkExceptionManager.trackException(exception);
         verify(mockChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
 
@@ -711,7 +711,7 @@ public class CrashesTest {
         Crashes.setListener(crashesListener);
         Crashes crashes = Crashes.getInstance();
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         ArgumentCaptor<ErrorReport> errorReportCaptor = ArgumentCaptor.forClass(ErrorReport.class);
         Channel.GroupListener channelListener = crashes.getChannelListener();
@@ -739,7 +739,7 @@ public class CrashesTest {
         Crashes crashes = Crashes.getInstance();
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         Channel.GroupListener listener = Crashes.getInstance().getChannelListener();
 
@@ -775,7 +775,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         Crashes.notifyUserConfirmation(Crashes.DONT_SEND);
 
@@ -812,7 +812,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         Crashes.notifyUserConfirmation(Crashes.ALWAYS_SEND);
 
@@ -925,7 +925,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         assertNull(Crashes.getLastSessionCrashReport().get());
-        Crashes.getInstance().onStarted(mock(Context.class), "", null, mock(Channel.class));
+        Crashes.getInstance().onStarted(mock(Context.class), mock(Channel.class), "", null, true);
         assertFalse(Crashes.hasCrashedInLastSession().get());
         assertNull(Crashes.getLastSessionCrashReport().get());
         verifyStatic(never());
@@ -980,7 +980,7 @@ public class CrashesTest {
         verify(beforeCallback).accept(null);
 
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
         assertTrue(Crashes.isEnabled().get());
         assertTrue(Crashes.hasCrashedInLastSession().get());
 
@@ -1045,7 +1045,7 @@ public class CrashesTest {
         assertFalse(Crashes.isEnabled().get());
         assertNull(Crashes.getLastSessionCrashReport().get());
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
         assertTrue(Crashes.isEnabled().get());
         assertFalse(Crashes.hasCrashedInLastSession().get());
         assertNull(Crashes.getLastSessionCrashReport().get());
@@ -1065,7 +1065,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{file});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(file);
-        Crashes.getInstance().onStarted(mock(Context.class), "", null, mock(Channel.class));
+        Crashes.getInstance().onStarted(mock(Context.class), mock(Channel.class), "", null, true);
         assertFalse(Crashes.hasCrashedInLastSession().get());
         assertNull(Crashes.getLastSessionCrashReport().get());
     }
@@ -1083,7 +1083,7 @@ public class CrashesTest {
         /* Call twice for multiple callbacks before initialize. */
         Crashes.getLastSessionCrashReport().thenAccept(callback);
         Crashes.getLastSessionCrashReport().thenAccept(callback);
-        Crashes.getInstance().onStarted(mock(Context.class), "", null, mock(Channel.class));
+        Crashes.getInstance().onStarted(mock(Context.class), mock(Channel.class), "", null, true);
         assertFalse(Crashes.hasCrashedInLastSession().get());
         verify(callback, times(2)).accept(null);
     }
@@ -1124,7 +1124,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
 
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         String expectedMessage = "A limit of " + MAX_ATTACHMENT_PER_CRASH + " attachments per error report might be enforced by server.";
         PowerMockito.verifyStatic();
@@ -1169,7 +1169,7 @@ public class CrashesTest {
 
         /* Start crashes. */
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         /* No log queued. */
         verify(mockChannel, never()).enqueue(any(Log.class), eq(crashes.getGroupName()));
@@ -1230,7 +1230,7 @@ public class CrashesTest {
         crashes.setLogSerializer(logSerializer);
         crashes.onStarting(mAppCenterHandler);
         mockChannel = mock(Channel.class);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
         assertTrue(Crashes.isEnabled().get());
         verify(mockChannel, never()).enqueue(any(ManagedErrorLog.class), eq(crashes.getGroupName()));
 
@@ -1273,7 +1273,7 @@ public class CrashesTest {
 
         /* Start crashes. */
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mockContext, "", null, mockChannel);
+        crashes.onStarted(mockContext, mockChannel, "", null, true);
 
         /* No log queued. */
         verify(mockChannel, never()).enqueue(any(Log.class), eq(crashes.getGroupName()));
@@ -1338,7 +1338,7 @@ public class CrashesTest {
         Crashes crashes = Crashes.getInstance();
         crashes.setLogSerializer(logSerializer);
         crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Verify timestamps on the crash log. */
         assertTrue(Crashes.hasCrashedInLastSession().get());

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -141,11 +141,6 @@ public class Distribute extends AbstractAppCenterService {
     private Context mContext;
 
     /**
-     * Application secret.
-     */
-    private String mAppSecret;
-
-    /**
      * Package info.
      */
     private PackageInfo mPackageInfo;
@@ -403,7 +398,6 @@ public class Distribute extends AbstractAppCenterService {
     @Override
     public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
         mContext = context;
-        mAppSecret = appSecret;
         mMobileCenterPreferenceStorage = mContext.getSharedPreferences(PREFERENCES_NAME_MOBILE_CENTER, Context.MODE_PRIVATE);
         try {
             mPackageInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -141,6 +141,11 @@ public class Distribute extends AbstractAppCenterService {
     private Context mContext;
 
     /**
+     * Application secret.
+     */
+    private String mAppSecret;
+
+    /**
      * Package info.
      */
     private PackageInfo mPackageInfo;
@@ -396,8 +401,9 @@ public class Distribute extends AbstractAppCenterService {
     private static final String DISTRIBUTE_GROUP = "group_distribute";
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
         mContext = context;
+        mAppSecret = appSecret;
         mMobileCenterPreferenceStorage = mContext.getSharedPreferences(PREFERENCES_NAME_MOBILE_CENTER, Context.MODE_PRIVATE);
         try {
             mPackageInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
@@ -409,7 +415,7 @@ public class Distribute extends AbstractAppCenterService {
          * Apply enabled state is called by this method, we need fields to be initialized before.
          * So call super method at the end.
          */
-        super.onStarted(context, appSecret, transmissionTargetToken, channel);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
     }
 
     /**

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -256,6 +256,6 @@ public class AbstractDistributeTest {
 
     void start() {
         Distribute.getInstance().onStarting(mAppCenterHandler);
-        Distribute.getInstance().onStarted(mContext, "a", null, mChannel);
+        Distribute.getInstance().onStarted(mContext, mChannel, "a", null, true);
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -362,7 +362,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         HandlerUtils.runOnUiThread(any(Runnable.class));
         Distribute.getInstance().onStarting(mAppCenterHandler);
         Distribute.getInstance().onActivityResumed(mActivity);
-        Distribute.getInstance().onStarted(mContext, "a", null, mock(Channel.class));
+        Distribute.getInstance().onStarted(mContext, mock(Channel.class), "a", null, true);
 
         /* Disable and test async behavior of setEnabled. */
         final CountDownLatch latch = new CountDownLatch(1);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
@@ -46,7 +46,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
     private void start(Distribute distribute) {
         distribute.onStarting(mAppCenterHandler);
-        distribute.onStarted(mContext, "a", null, mock(Channel.class));
+        distribute.onStarted(mContext, mock(Channel.class), "a", null, true);
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeHttpTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeHttpTest.java
@@ -140,7 +140,7 @@ public class DistributeHttpTest extends AbstractDistributeTest {
 
         /* Configure mock HTTP to get an instance of IngestionCallTemplate. */
         Distribute.getInstance().onStarting(mAppCenterHandler);
-        Distribute.getInstance().onStarted(mContext, appSecret, null, mock(Channel.class));
+        Distribute.getInstance().onStarted(mContext, mock(Channel.class), appSecret, null, true);
         final ServiceCall call = mock(ServiceCall.class);
         final AtomicReference<HttpClient.CallTemplate> callTemplate = new AtomicReference<>();
         mockStatic(NetworkStateHelper.class);

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -282,9 +282,9 @@ public class Push extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
         mContext = context;
-        super.onStarted(context, appSecret, transmissionTargetToken, channel);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
         if (FirebaseUtils.isFirebaseAvailable() && !mFirebaseAnalyticsEnabled) {
             AppCenterLog.debug(LOG_TAG, "Disabling Firebase analytics collection by default.");
             setFirebaseAnalyticsEnabled(context, false);

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
@@ -155,7 +155,7 @@ public class PushTest {
 
     private void start(Context contextMock, Push push, Channel channel) {
         push.onStarting(mAppCenterHandler);
-        push.onStarted(contextMock, DUMMY_APP_SECRET, null, channel);
+        push.onStarted(contextMock, channel, DUMMY_APP_SECRET, null, true);
     }
 
     @Test

--- a/sdk/appcenter-rum/src/main/java/com/microsoft/appcenter/rum/RealUserMeasurements.java
+++ b/sdk/appcenter-rum/src/main/java/com/microsoft/appcenter/rum/RealUserMeasurements.java
@@ -192,9 +192,9 @@ public class RealUserMeasurements extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
         mContext = context;
-        super.onStarted(context, appSecret, transmissionTargetToken, channel);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
     }
 
     /**

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
@@ -121,8 +121,8 @@ public class AppCenterAndroidTest {
         }
 
         @Override
-        public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
-            super.onStarted(context, appSecret, transmissionTargetToken, channel);
+        public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+            super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
 
             /* Check no dead lock if we do that. */
             mInstallId = AppCenter.getInstallId().get();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -34,6 +34,11 @@ public abstract class AbstractAppCenterService implements AppCenterService {
     protected Channel mChannel;
 
     /**
+     * App secret.
+     */
+    protected String mAppSecret;
+
+    /**
      * Background thread handler.
      */
     private AppCenterHandler mHandler;
@@ -198,7 +203,13 @@ public abstract class AbstractAppCenterService implements AppCenterService {
             }
         }
         mChannel = channel;
+        mAppSecret = appSecret;
         applyEnabledState(enabled);
+    }
+
+    @Override
+    public void onConfigurationUpdated(String appSecret, String transmissionTargetToken) {
+        mAppSecret = appSecret;
     }
 
     @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -34,11 +34,6 @@ public abstract class AbstractAppCenterService implements AppCenterService {
     protected Channel mChannel;
 
     /**
-     * App secret.
-     */
-    protected String mAppSecret;
-
-    /**
      * Background thread handler.
      */
     private AppCenterHandler mHandler;
@@ -186,7 +181,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
         String groupName = getGroupName();
         boolean enabled = isInstanceEnabled();
         if (groupName != null) {
@@ -203,13 +198,13 @@ public abstract class AbstractAppCenterService implements AppCenterService {
             }
         }
         mChannel = channel;
-        mAppSecret = appSecret;
         applyEnabledState(enabled);
     }
 
     @Override
     public void onConfigurationUpdated(String appSecret, String transmissionTargetToken) {
-        mAppSecret = appSecret;
+
+        /* Nothing to do. */
     }
 
     @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -689,7 +689,7 @@ public class AppCenter {
                         startedServices.add(serviceInstance);
 
                         /* Keep track of services started from a library before the app has started the services. */
-                        if (mAppSecret == null && mTransmissionTargetToken == null && !startFromApp) {
+                        if (!startFromApp) {
                             mServicesStartedFromLibrary.add(serviceInstance);
                         }
                     }
@@ -730,8 +730,13 @@ public class AppCenter {
             if (!enabled && service.isInstanceEnabled()) {
                 service.setInstanceEnabled(false);
             }
-            service.onStarted(mApplication, mChannel, mAppSecret, mTransmissionTargetToken, startFromApp);
-            AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started.");
+            if (startFromApp) {
+                service.onStarted(mApplication, mChannel, mAppSecret, mTransmissionTargetToken, true);
+                AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started from application.");
+            } else {
+                service.onStarted(mApplication, mChannel, null, null, false);
+                AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started from library.");
+            }
         }
 
         /* If starting from a library, we will send start service log later when app starts with an app secret. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -730,7 +730,7 @@ public class AppCenter {
             if (!enabled && service.isInstanceEnabled()) {
                 service.setInstanceEnabled(false);
             }
-            service.onStarted(mApplication, mAppSecret, mTransmissionTargetToken, mChannel);
+            service.onStarted(mApplication, mChannel, mAppSecret, mTransmissionTargetToken, startFromApp);
             AppCenterLog.info(LOG_TAG, service.getClass().getSimpleName() + " service started.");
         }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
@@ -65,12 +65,13 @@ public interface AppCenterService extends Application.ActivityLifecycleCallbacks
      * Called when the service is started (disregarding if enabled or disabled).
      *
      * @param context                 application context.
+     * @param channel                 channel.
      * @param appSecret               application secret.
      * @param transmissionTargetToken transmission target token.
-     * @param channel                 channel.
+     * @param startFromApp            true if starting from app, false if starting from a library.
      */
     @WorkerThread
-    void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel);
+    void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp);
 
     /**
      * Called when service started from library without any secret and then the app starts the service again

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
@@ -71,4 +71,14 @@ public interface AppCenterService extends Application.ActivityLifecycleCallbacks
      */
     @WorkerThread
     void onStarted(@NonNull Context context, String appSecret, String transmissionTargetToken, @NonNull Channel channel);
+
+    /**
+     * Called when service started from library without any secret and then the app starts the service again
+     * with either an app secret or transmission target or both.
+     *
+     * @param appSecret               application secret.
+     * @param transmissionTargetToken transmission target token.
+     */
+    @WorkerThread
+    void onConfigurationUpdated(String appSecret, String transmissionTargetToken);
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterServiceTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterServiceTest.java
@@ -17,6 +17,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.microsoft.appcenter.utils.PrefStorageConstants.KEY_ENABLED;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -270,5 +271,11 @@ public class AbstractAppCenterServiceTest {
         mService.setInstanceEnabled(false);
         mService.setInstanceEnabled(true);
         verifyZeroInteractions(channel);
+    }
+
+    @Test
+    public void updateConfiguration() {
+        mService.onConfigurationUpdated("secret", "token");
+        assertEquals("secret", mService.mAppSecret);
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterServiceTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterServiceTest.java
@@ -17,7 +17,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.microsoft.appcenter.utils.PrefStorageConstants.KEY_ENABLED;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -135,7 +134,7 @@ public class AbstractAppCenterServiceTest {
             }
         }).when(appCenterHandler).post(any(Runnable.class), any(Runnable.class));
         mService.onStarting(appCenterHandler);
-        mService.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        mService.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Enabled at first. */
         assertTrue(mService.isInstanceEnabledAsync().get());
@@ -189,7 +188,7 @@ public class AbstractAppCenterServiceTest {
             }
         }).when(appCenterHandler).post(any(Runnable.class), any(Runnable.class));
         mService.onStarting(appCenterHandler);
-        mService.onStarted(mock(Context.class), "", null, mock(Channel.class));
+        mService.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Whatever we do it stays disabled. */
         assertFalse(mService.isInstanceEnabledAsync().get());
@@ -209,7 +208,7 @@ public class AbstractAppCenterServiceTest {
     @Test
     public void onChannelReadyEnabledThenDisable() {
         Channel channel = mock(Channel.class);
-        mService.onStarted(mock(Context.class), "", null, channel);
+        mService.onStarted(mock(Context.class), channel, "", null, true);
         verify(channel).removeGroup(mService.getGroupName());
         verify(channel).addGroup(mService.getGroupName(), mService.getTriggerCount(), mService.getTriggerInterval(), mService.getTriggerMaxParallelRequests(), null, mService.getChannelListener());
         verifyNoMoreInteractions(channel);
@@ -224,7 +223,7 @@ public class AbstractAppCenterServiceTest {
     @Test
     public void onChannelReadyDisabledThenEnable() {
         Channel channel = mock(Channel.class);
-        mService.onStarted(mock(Context.class), "", null, channel);
+        mService.onStarted(mock(Context.class), channel, "", null, true);
         verify(channel).removeGroup(mService.getGroupName());
         verify(channel).addGroup(eq(mService.getGroupName()), anyInt(), anyLong(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
         mService.setInstanceEnabled(false);
@@ -267,15 +266,9 @@ public class AbstractAppCenterServiceTest {
             }
         };
         Channel channel = mock(Channel.class);
-        mService.onStarted(mock(Context.class), "", null, channel);
+        mService.onStarted(mock(Context.class), channel, "", null, true);
         mService.setInstanceEnabled(false);
         mService.setInstanceEnabled(true);
         verifyZeroInteractions(channel);
-    }
-
-    @Test
-    public void updateConfiguration() {
-        mService.onConfigurationUpdated("secret", "token");
-        assertEquals("secret", mService.mAppSecret);
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -810,13 +810,36 @@ public class AppCenterTest {
     @Test
     public void nullAppSecretTest() {
         AppCenter.start(mApplication, null, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
+        testNullOrEmptySecretString();
     }
 
     @Test
     public void emptyAppSecretTest() {
         AppCenter.start(mApplication, "", DummyService.class);
+        testNullOrEmptySecretString();
+    }
+
+    private void testNullOrEmptySecretString() {
+
+        /* App Center is configured that way. */
+        assertTrue(AppCenter.isConfigured());
+
+        /* Verify service started with null secrets from application. */
         verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
+
+        /* We must not be able to reconfigure app secret from null/empty state. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class, AnotherDummyService.class);
+        AppCenter.start(mApplication, null, DummyService.class, AnotherDummyService.class);
+        AppCenter.start(mApplication, "", DummyService.class, AnotherDummyService.class);
+
+        /* Verify start not called again (1 total call). */
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
+
+        /* And not updated either. */
+        verify(DummyService.getInstance(), never()).onConfigurationUpdated(anyString(), anyString());
+
+        /* Verify the second service was not started as was part of second secret configuration. */
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -279,7 +279,7 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -330,7 +330,7 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -348,8 +348,8 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
-        verify(service, never()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET + "a"), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
+        verify(service, never()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET + "a"), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -367,8 +367,8 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
-        verify(service, never()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
+        verify(service, never()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -386,8 +386,8 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service, never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service, never()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -407,8 +407,8 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
-        verify(service, never()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET + "a"), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
+        verify(service, never()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET + "a"), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -426,13 +426,13 @@ public class AppCenterTest {
         /* Verify first service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance()).getLogFactories();
-        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent. */
@@ -453,13 +453,13 @@ public class AppCenterTest {
         {
             assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
             verify(DummyService.getInstance()).getLogFactories();
-            verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         }
         {
             assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
             verify(AnotherDummyService.getInstance()).getLogFactories();
-            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         }
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
@@ -480,13 +480,13 @@ public class AppCenterTest {
         {
             assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
             verify(DummyService.getInstance()).getLogFactories();
-            verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         }
         {
             assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
             verify(AnotherDummyService.getInstance()).getLogFactories();
-            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         }
         verify(mChannel, times(2)).enqueue(any(StartServiceLog.class), eq(CORE_GROUP));
@@ -507,13 +507,13 @@ public class AppCenterTest {
         {
             assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
             verify(DummyService.getInstance()).getLogFactories();
-            verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         }
         {
             assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
             verify(AnotherDummyService.getInstance()).getLogFactories();
-            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         }
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
@@ -534,13 +534,13 @@ public class AppCenterTest {
         {
             assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
             verify(DummyService.getInstance()).getLogFactories();
-            verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         }
         {
             assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
             verify(AnotherDummyService.getInstance()).getLogFactories();
-            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+            verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
             verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         }
         verify(mChannel, times(2)).enqueue(any(StartServiceLog.class), eq(CORE_GROUP));
@@ -564,7 +564,7 @@ public class AppCenterTest {
         DummyService service = DummyService.getInstance();
         assertTrue(AppCenter.getInstance().getServices().contains(service));
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
 
         /* Start twice, this call is ignored. */
@@ -573,7 +573,7 @@ public class AppCenterTest {
         /* Verify that single service has been loaded and configured (only once interaction). */
         assertEquals(1, AppCenter.getInstance().getServices().size());
         verify(service).getLogFactories();
-        verify(service).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         List<String> services = new ArrayList<>();
@@ -676,9 +676,9 @@ public class AppCenterTest {
 
         /* Check factories / channel only once interactions. */
         verify(dummyService).getLogFactories();
-        verify(dummyService).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(dummyService).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(anotherDummyService).getLogFactories();
-        verify(anotherDummyService).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(anotherDummyService).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
     }
 
     @Test
@@ -793,13 +793,13 @@ public class AppCenterTest {
 
         /* First verify start from application. */
         AppCenter.start(null, DUMMY_APP_SECRET, DummyService.class);
-        verify(DummyService.getInstance(), never()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
         PowerMockito.verifyStatic();
         AppCenterLog.error(eq(LOG_TAG), anyString());
 
         /* Then verify start from library. */
         AppCenter.startFromLibrary(null, DummyService.class);
-        verify(DummyService.getInstance(), never()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
         PowerMockito.verifyStatic(times(2));
         AppCenterLog.error(eq(LOG_TAG), anyString());
     }
@@ -807,62 +807,62 @@ public class AppCenterTest {
     @Test
     public void nullAppSecretTest() {
         AppCenter.start(mApplication, null, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
     }
 
     @Test
     public void emptyAppSecretTest() {
         AppCenter.start(mApplication, "", DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
     }
 
     @Test
     public void appSecretKeyWithoutAppSecretTest() {
         String secret = APP_SECRET_KEY + KEY_VALUE_DELIMITER;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
     }
 
     @Test
     public void appSecretWithKeyValueDelimiter() {
         String secret = KEY_VALUE_DELIMITER + DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(true));
     }
 
     @Test
     public void appSecretWithPairDelimiterAfter() {
         String secret = DUMMY_APP_SECRET + PAIR_DELIMITER;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
     }
 
     @Test
     public void appSecretWithPairDelimiterBefore() {
         String secret = PAIR_DELIMITER + DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
     }
 
     @Test
     public void appSecretWithTargetTokenTest() {
         String secret = DUMMY_APP_SECRET + PAIR_DELIMITER + DUMMY_TARGET_TOKEN_STRING;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
     public void keyedAppSecretTest() {
         String secret = APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
     }
 
     @Test
     public void keyedAppSecretWithDelimiterTest() {
         String secret = APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET + PAIR_DELIMITER;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
     }
 
     @Test
@@ -870,14 +870,14 @@ public class AppCenterTest {
         String secret = APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET + PAIR_DELIMITER +
                 DUMMY_TARGET_TOKEN_STRING;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
     public void targetTokenTest() {
         AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class, AnotherDummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
-        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
@@ -885,7 +885,7 @@ public class AppCenterTest {
         String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
                 DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
@@ -893,7 +893,7 @@ public class AppCenterTest {
         String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
                 APP_SECRET_KEY + KEY_VALUE_DELIMITER + DUMMY_APP_SECRET;
         AppCenter.start(mApplication, secret, DummyService.class);
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
@@ -903,7 +903,7 @@ public class AppCenterTest {
                 "unknown" + KEY_VALUE_DELIMITER + "value";
         AppCenter.start(mApplication, secret, DummyService.class);
         assertTrue(AppCenter.isEnabled().get());
-        verify(DummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
     }
 
     @Test
@@ -911,7 +911,7 @@ public class AppCenterTest {
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class, DummyService.class);
 
         /* Verify that only one service has been loaded and configured. */
-        verify(DummyService.getInstance()).onStarted(notNull(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(notNull(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         assertEquals(1, AppCenter.getInstance().getServices().size());
     }
 
@@ -1257,7 +1257,7 @@ public class AppCenterTest {
         assertEquals(1, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         verify(mChannel, never()).setAppSecret(anyString());
@@ -1273,13 +1273,13 @@ public class AppCenterTest {
 
         /* Verify previous behaviors happened only once, thus not again. */
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance()).getLogFactories();
-        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent. */
@@ -1303,7 +1303,7 @@ public class AppCenterTest {
         assertEquals(1, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         verify(mChannel, never()).setAppSecret(anyString());
@@ -1319,13 +1319,13 @@ public class AppCenterTest {
 
         /* Verify previous behaviors happened only once, thus not again. */
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
         assertFalse(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance(), never()).getLogFactories();
-        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication, never()).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent. */
@@ -1349,7 +1349,7 @@ public class AppCenterTest {
         assertEquals(1, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         verify(mChannel, never()).setAppSecret(anyString());
@@ -1366,13 +1366,13 @@ public class AppCenterTest {
 
         /* Verify previous behaviors happened only once, thus not again. */
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), isNull(String.class), eq(false));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance()).getLogFactories();
-        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent. */
@@ -1398,13 +1398,13 @@ public class AppCenterTest {
         /* Verify first service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance()).getLogFactories();
-        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent. */
@@ -1426,11 +1426,11 @@ public class AppCenterTest {
         assertEquals(2, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         assertTrue(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance()).getLogFactories();
-        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), eq(DUMMY_APP_SECRET), isNull(String.class), any(Channel.class));
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         services = new ArrayList<>();
@@ -1454,13 +1454,13 @@ public class AppCenterTest {
         /* Verify first service started. */
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service not started. */
         assertFalse(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance(), never()).getLogFactories();
-        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication, never()).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
 
         /* Verify start service log is sent with only first service. */
@@ -1477,11 +1477,11 @@ public class AppCenterTest {
         assertEquals(1, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
         verify(DummyService.getInstance()).getLogFactories();
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         assertFalse(AppCenter.getInstance().getServices().contains(AnotherDummyService.getInstance()));
         verify(AnotherDummyService.getInstance(), never()).getLogFactories();
-        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), any(Channel.class));
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), isNull(String.class), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
         verify(mApplication, never()).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         services = new ArrayList<>();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1268,12 +1268,12 @@ public class AppCenterTest {
         /* Verify that the right amount of services have been loaded and configured. */
         assertEquals(2, AppCenter.getInstance().getServices().size());
 
-        /* Verify first service started. */
-        assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
-        verify(DummyService.getInstance()).getLogFactories();
+        /* Verify first service updated. */
+        verify(DummyService.getInstance()).onConfigurationUpdated(DUMMY_APP_SECRET, null);
 
-        /* Verify onStarted was not called again (e.g. not more than once). */
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        /* Verify previous behaviors happened only once, thus not again. */
+        verify(DummyService.getInstance()).getLogFactories();
+        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
@@ -1314,12 +1314,12 @@ public class AppCenterTest {
         /* Verify that the right amount of services have been loaded and configured. */
         assertEquals(1, AppCenter.getInstance().getServices().size());
 
-        /* Verify first service started. */
-        assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
-        verify(DummyService.getInstance()).getLogFactories();
+        /* Verify first service updated. */
+        verify(DummyService.getInstance()).onConfigurationUpdated(null, DUMMY_TRANSMISSION_TARGET_TOKEN);
 
-        /* Verify onStarted was not called again (e.g. not more than once). */
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        /* Verify previous behaviors happened only once, thus not again. */
+        verify(DummyService.getInstance()).getLogFactories();
+        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */
@@ -1361,12 +1361,12 @@ public class AppCenterTest {
         /* Verify that the right amount of services have been loaded and configured. */
         assertEquals(2, AppCenter.getInstance().getServices().size());
 
-        /* Verify first service started. */
-        assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
-        verify(DummyService.getInstance()).getLogFactories();
+        /* Verify first service updated. */
+        verify(DummyService.getInstance()).onConfigurationUpdated(DUMMY_APP_SECRET, DUMMY_TRANSMISSION_TARGET_TOKEN);
 
-        /* Verify onStarted was not called again (e.g. not more than once). */
-        verify(DummyService.getInstance()).onStarted(any(Context.class), anyString(), anyString(), any(Channel.class));
+        /* Verify previous behaviors happened only once, thus not again. */
+        verify(DummyService.getInstance()).getLogFactories();
+        verify(DummyService.getInstance()).onStarted(any(Context.class), isNull(String.class), isNull(String.class), any(Channel.class));
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
 
         /* Verify second service started. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1503,6 +1503,29 @@ public class AppCenterTest {
         verify(mChannel, never()).setAppSecret(anyString());
     }
 
+    @Test
+    public void startFromLibraryDoesNotStartFromApp() {
+
+        /* Start one service from app with both secrets. */
+        String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER + DUMMY_APP_SECRET;
+        AppCenter.start(mApplication, secret, AnotherDummyService.class);
+
+        /* Start another from library. */
+        AppCenter.startFromLibrary(mApplication, DummyService.class);
+
+        /* Verify second service started without secrets with library flag. */
+        verify(DummyService.getInstance()).onStarted(mApplication, mChannel, null, null, false);
+
+        /* Now start from app. */
+        AppCenter.start(DummyService.class);
+
+        /* It should update. */
+        verify(DummyService.getInstance()).onConfigurationUpdated(DUMMY_APP_SECRET, DUMMY_TRANSMISSION_TARGET_TOKEN);
+
+        /* And not call onStarted again (verify 1 total call). */
+        verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
+    }
+
     private static class DummyService extends AbstractAppCenterService {
 
         private static DummyService sharedInstance;

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -414,6 +414,9 @@ public class AppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+
+        /* We don't support updating app secret that way. */
+        verify(service, never()).onConfigurationUpdated(anyString(), anyString());
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1253,6 +1253,10 @@ public class AppCenterTest {
         AppCenter.startFromLibrary(mApplication, DummyService.class, AnotherDummyService.class);
         AppCenter.startFromLibrary(mApplication, AnotherDummyService.class, DummyService.class);
 
+        /* Verify App Center is configured and enabled. */
+        assertTrue(AppCenter.isConfigured());
+        assertTrue(AppCenter.isEnabled().get());
+
         /* Verify only dummy service has been started once, as the other one doesn't support start from library. */
         assertEquals(1, AppCenter.getInstance().getServices().size());
         assertTrue(AppCenter.getInstance().getServices().contains(DummyService.getInstance()));
@@ -1261,6 +1265,10 @@ public class AppCenterTest {
         verify(mApplication).registerActivityLifecycleCallbacks(DummyService.getInstance());
         verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         verify(mChannel, never()).setAppSecret(anyString());
+
+        /* Verify state. */
+        assertTrue(DummyService.isEnabled().get());
+        assertFalse(AnotherDummyService.isEnabled().get());
 
         /* Start two services from app. */
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class, AnotherDummyService.class);
@@ -1281,6 +1289,9 @@ public class AppCenterTest {
         verify(AnotherDummyService.getInstance()).getLogFactories();
         verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(AnotherDummyService.getInstance());
+
+        /* And enabled. */
+        assertTrue(AnotherDummyService.isEnabled().get());
 
         /* Verify start service log is sent. */
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));


### PR DESCRIPTION
* Improve #736 
* Fixes sending start session if library starts Analytics then app starts Analytics (sent when app starts).
* Fixes automatic page tracking the same way as previous point.
* If Crashes started at app level with app secret, and Analytics started only from library, make sure we don't allow static trackEvent/trackPage calls (only AnalyticsTransmissionTarget calls are allowed for libraries).