### PR TITLE
Prevent starting Push (or other modules) from library

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -585,9 +585,9 @@ public class Analytics extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
-        mStartedFromApp = startFromApp;
-        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
+        mStartedFromApp = startedFromApp;
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
         setDefaultTransmissionTarget(transmissionTargetToken);
     }
 

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -360,9 +360,9 @@ public class Crashes extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
-        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
         if (isInstanceEnabled()) {
             processPendingErrors();
         } else {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -401,7 +401,7 @@ public class Distribute extends AbstractAppCenterService {
     private static final String DISTRIBUTE_GROUP = "group_distribute";
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
         mAppSecret = appSecret;
         mMobileCenterPreferenceStorage = mContext.getSharedPreferences(PREFERENCES_NAME_MOBILE_CENTER, Context.MODE_PRIVATE);
@@ -415,7 +415,7 @@ public class Distribute extends AbstractAppCenterService {
          * Apply enabled state is called by this method, we need fields to be initialized before.
          * So call super method at the end.
          */
-        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
     }
 
     /**

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -282,9 +282,9 @@ public class Push extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
-        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
         if (FirebaseUtils.isFirebaseAvailable() && !mFirebaseAnalyticsEnabled) {
             AppCenterLog.debug(LOG_TAG, "Disabling Firebase analytics collection by default.");
             setFirebaseAnalyticsEnabled(context, false);

--- a/sdk/appcenter-rum/src/main/java/com/microsoft/appcenter/rum/RealUserMeasurements.java
+++ b/sdk/appcenter-rum/src/main/java/com/microsoft/appcenter/rum/RealUserMeasurements.java
@@ -192,9 +192,9 @@ public class RealUserMeasurements extends AbstractAppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
-        super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+        super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
     }
 
     /**

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
@@ -121,8 +121,8 @@ public class AppCenterAndroidTest {
         }
 
         @Override
-        public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
-            super.onStarted(context, channel, appSecret, transmissionTargetToken, startFromApp);
+        public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
+            super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
 
             /* Check no dead lock if we do that. */
             mInstallId = AppCenter.getInstallId().get();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -181,7 +181,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
     }
 
     @Override
-    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp) {
+    public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         String groupName = getGroupName();
         boolean enabled = isInstanceEnabled();
         if (groupName != null) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -687,8 +687,6 @@ public class AppCenter {
                         }
                     } else if (shouldDisable(serviceInstance.getServiceName())) {
                         AppCenterLog.debug(LOG_TAG, "Instrumentation variable to disable service has been set; not starting service " + service.getName() + ".");
-                    } else if (mAppSecret == null && serviceInstance.isAppSecretRequired()) {
-                        AppCenterLog.error(LOG_TAG, "App Center was started without app secret, but the service requires it; not starting service " + service.getName() + ".");
                     } else if (!startFromApp && serviceInstance.isAppSecretRequired()) {
 
                         /*
@@ -696,6 +694,8 @@ public class AppCenter {
                          * also requires being started from application and are not supported by libraries.
                          */
                         AppCenterLog.error(LOG_TAG, "This service cannot be started from a library: " + service.getName() + ".");
+                    } else if (mAppSecret == null && serviceInstance.isAppSecretRequired()) {
+                        AppCenterLog.error(LOG_TAG, "App Center was started without app secret, but the service requires it; not starting service " + service.getName() + ".");
                     } else {
 
                         /* Share handler now with service while starting. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -688,7 +688,14 @@ public class AppCenter {
                     } else if (shouldDisable(serviceInstance.getServiceName())) {
                         AppCenterLog.debug(LOG_TAG, "Instrumentation variable to disable service has been set; not starting service " + service.getName() + ".");
                     } else if (mAppSecret == null && serviceInstance.isAppSecretRequired()) {
-                        AppCenterLog.warn(LOG_TAG, "App Center was started without app secret, but the service requires it; not starting service " + service.getName() + ".");
+                        AppCenterLog.error(LOG_TAG, "App Center was started without app secret, but the service requires it; not starting service " + service.getName() + ".");
+                    } else if (!startFromApp && serviceInstance.isAppSecretRequired()) {
+
+                        /*
+                         * We use the same app secret required check as services requiring app secret
+                         * also requires being started from application and are not supported by libraries.
+                         */
+                        AppCenterLog.error(LOG_TAG, "This service cannot be started from a library: " + service.getName() + ".");
                     } else {
 
                         /* Share handler now with service while starting. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenterService.java
@@ -68,10 +68,10 @@ public interface AppCenterService extends Application.ActivityLifecycleCallbacks
      * @param channel                 channel.
      * @param appSecret               application secret.
      * @param transmissionTargetToken transmission target token.
-     * @param startFromApp            true if starting from app, false if starting from a library.
+     * @param startedFromApp          true if started from app, false if started from a library.
      */
     @WorkerThread
-    void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startFromApp);
+    void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp);
 
     /**
      * Called when service started from library without any secret and then the app starts the service again

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -1552,6 +1552,26 @@ public class AppCenterTest {
         verify(DummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
     }
 
+    @Test
+    public void startFromAppDoesNotEnableStartingUnsupportedServicesFromLibrary() {
+
+        /* Start one service from app with both secrets. */
+        String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER + DUMMY_APP_SECRET;
+        AppCenter.start(mApplication, secret, DummyService.class);
+
+        /* Start another from library that does not support that mode. */
+        AppCenter.startFromLibrary(mApplication, AnotherDummyService.class);
+
+        /* Verify second service not started. */
+        verify(AnotherDummyService.getInstance(), never()).onStarted(any(Context.class), any(Channel.class), anyString(), anyString(), anyBoolean());
+
+        /* Now start from app instead. */
+        AppCenter.start(AnotherDummyService.class);
+
+        /* It should work now. */
+        verify(AnotherDummyService.getInstance()).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), eq(DUMMY_TRANSMISSION_TARGET_TOKEN), eq(true));
+    }
+
     private static class DummyService extends AbstractAppCenterService {
 
         private static DummyService sharedInstance;


### PR DESCRIPTION
It was working earlier by starting Analytics from app first.
Also renamed a parameter.