### PR TITLE
Nesting is/setEnabled in Analytics transmissions

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -543,17 +543,22 @@ public class Analytics extends AbstractAppCenterService {
 
             @Override
             public void run() {
-                EventLog eventLog = new EventLog();
-                eventLog.setId(UUIDUtils.randomUUID());
-                eventLog.setName(name);
-                eventLog.setProperties(propertiesCopy);
                 AnalyticsTransmissionTarget aTransmissionTarget = (transmissionTarget == null) ? mDefaultTransmissionTarget : transmissionTarget;
+                EventLog eventLog = new EventLog();
                 if (aTransmissionTarget != null) {
-                    eventLog.addTransmissionTarget(aTransmissionTarget.getTransmissionTargetToken());
+                    if (aTransmissionTarget.isEnabled()) {
+                        eventLog.addTransmissionTarget(aTransmissionTarget.getTransmissionTargetToken());
+                    } else {
+                        AppCenterLog.error(LOG_TAG, "This transmission target is disabled.");
+                        return;
+                    }
                 } else if (!mStartedFromApp) {
                     AppCenterLog.error(LOG_TAG, "Cannot track event using Analytics.trackEvent if not started from app, please start from the application or use Analytics.getTransmissionTarget.");
                     return;
                 }
+                eventLog.setId(UUIDUtils.randomUUID());
+                eventLog.setName(name);
+                eventLog.setProperties(propertiesCopy);
                 mChannel.enqueue(eventLog, ANALYTICS_GROUP);
             }
         });

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -24,6 +24,7 @@ import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.UUIDUtils;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
+import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -320,7 +321,7 @@ public class Analytics extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Returning transmission target found with token " + transmissionTargetToken);
                 return transmissionTarget;
             }
-            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken);
+            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null);
             AppCenterLog.debug(LOG_TAG, "Created transmission target with token " + transmissionTargetToken);
             mTransmissionTargets.put(transmissionTargetToken, transmissionTarget);
             return transmissionTarget;
@@ -604,5 +605,31 @@ public class Analytics extends AbstractAppCenterService {
     @WorkerThread
     private void setDefaultTransmissionTarget(String transmissionTargetToken) {
         mDefaultTransmissionTarget = getInstanceTransmissionTarget(transmissionTargetToken);
+    }
+
+    /**
+     * Post a command.
+     *
+     * @param runnable                    command.
+     * @param future                      future to hold result.
+     * @param valueIfDisabledOrNotStarted result to set in future if AppCenter or Analytics disabled or not started.
+     * @param <T>                         result type.
+     */
+    <T> void postCommand(Runnable runnable, DefaultAppCenterFuture<T> future, T valueIfDisabledOrNotStarted) {
+
+        /*
+         * For the purpose of the commands used for this method,
+         * it turns out the non get operations use the same flow as get.
+         */
+        postAsyncGetter(runnable, future, valueIfDisabledOrNotStarted);
+    }
+
+    /**
+     * Get preference storage key prefix for this service.
+     *
+     * @return storage key.
+     */
+    String getEnabledPreferenceKeyPrefix() {
+        return getEnabledPreferenceKey() + "/";
     }
 }

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
@@ -161,7 +161,7 @@ public class AnalyticsTransmissionTarget {
     @WorkerThread
     private boolean areAncestorsEnabled() {
         for (AnalyticsTransmissionTarget target = mParentTarget; target != null; target = target.mParentTarget) {
-            if (!mParentTarget.isEnabledInStorage()) {
+            if (!target.isEnabledInStorage()) {
                 return false;
             }
         }

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
@@ -90,6 +90,12 @@ public class AnalyticsTransmissionTarget {
         return childTarget;
     }
 
+    /**
+     * Check whether this target is enabled or not.
+     *
+     * @return future with result being <code>true</code> if enabled, <code>false</code> otherwise.
+     * @see AppCenterFuture
+     */
     public AppCenterFuture<Boolean> isEnabledAsync() {
         final DefaultAppCenterFuture<Boolean> future = new DefaultAppCenterFuture<>();
         Analytics.getInstance().postCommand(new Runnable() {
@@ -102,6 +108,13 @@ public class AnalyticsTransmissionTarget {
         return future;
     }
 
+    /**
+     * Enable or disable this target. The state is applied on all descendant targets.
+     * The state is not changed if one ancestor target or Analytics module or AppCenter is disabled.
+     *
+     * @param enabled <code>true</code> to enable, <code>false</code> to disable.
+     * @return future with null result to monitor when the operation completes.
+     */
     public AppCenterFuture<Void> setEnabledAsync(final boolean enabled) {
         final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
         Analytics.getInstance().postCommand(new Runnable() {

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
@@ -1,0 +1,86 @@
+package com.microsoft.appcenter.analytics;
+
+import android.os.SystemClock;
+
+import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.AppCenterHandler;
+import com.microsoft.appcenter.utils.AppCenterLog;
+import com.microsoft.appcenter.utils.HandlerUtils;
+import com.microsoft.appcenter.utils.PrefStorageConstants;
+import com.microsoft.appcenter.utils.async.AppCenterFuture;
+import com.microsoft.appcenter.utils.storage.StorageHelper;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, AppCenterLog.class, AppCenter.class, HandlerUtils.class})
+abstract class AbstractAnalyticsTest {
+
+    static final String ANALYTICS_ENABLED_KEY = PrefStorageConstants.KEY_ENABLED + "_" + Analytics.getInstance().getServiceName();
+    @Mock
+    AppCenterHandler mAppCenterHandler;
+    @Mock
+    private AppCenterFuture<Boolean> mCoreEnabledFuture;
+
+    @Before
+    public void setUp() {
+        Analytics.unsetInstance();
+        mockStatic(SystemClock.class);
+        mockStatic(AppCenterLog.class);
+        mockStatic(AppCenter.class);
+        when(AppCenter.isEnabled()).thenReturn(mCoreEnabledFuture);
+        when(mCoreEnabledFuture.get()).thenReturn(true);
+        Answer<Void> runNow = new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+            }
+        };
+        doAnswer(runNow).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
+        mockStatic(HandlerUtils.class);
+        doAnswer(runNow).when(HandlerUtils.class);
+        HandlerUtils.runOnUiThread(any(Runnable.class));
+
+        /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */
+        mockStatic(StorageHelper.PreferencesStorage.class);
+        when(StorageHelper.PreferencesStorage.getBoolean(anyString(), eq(true))).thenReturn(true);
+
+        /* Then simulate further changes to state. */
+        PowerMockito.doAnswer(new Answer<Object>() {
+
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+
+                /* Whenever the new state is persisted, make further calls return the new state. */
+                String key = (String) invocation.getArguments()[0];
+                boolean enabled = (Boolean) invocation.getArguments()[1];
+                when(StorageHelper.PreferencesStorage.getBoolean(eq(key), eq(true))).thenReturn(enabled);
+                return null;
+            }
+        }).when(StorageHelper.PreferencesStorage.class);
+        StorageHelper.PreferencesStorage.putBoolean(anyString(), anyBoolean());
+
+        /* Pretend automatic page tracking is enabled by default, this will be the case if service becomes public. */
+        // TODO remove that after service is public
+        assertFalse(Analytics.isAutoPageTrackingEnabled());
+        Analytics.setAutoPageTrackingEnabled(true);
+    }
+}

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -64,7 +63,7 @@ abstract class AbstractAnalyticsTest {
         when(StorageHelper.PreferencesStorage.getBoolean(anyString(), eq(true))).thenReturn(true);
 
         /* Then simulate further changes to state. */
-        PowerMockito.doAnswer(new Answer<Object>() {
+        doAnswer(new Answer<Object>() {
 
             @Override
             public Object answer(InvocationOnMock invocation) {
@@ -79,7 +78,7 @@ abstract class AbstractAnalyticsTest {
         StorageHelper.PreferencesStorage.putBoolean(anyString(), anyBoolean());
 
         /* Pretend automatic page tracking is enabled by default, this will be the case if service becomes public. */
-        // TODO remove that after service is public
+        // TODO remove that after that feature becomes public and thus a default.
         assertFalse(Analytics.isAutoPageTrackingEnabled());
         Analytics.setAutoPageTrackingEnabled(true);
     }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -1,10 +1,8 @@
 package com.microsoft.appcenter.analytics;
 
 import android.content.Context;
-import android.os.SystemClock;
 
 import com.microsoft.appcenter.AppCenter;
-import com.microsoft.appcenter.AppCenterHandler;
 import com.microsoft.appcenter.analytics.channel.AnalyticsListener;
 import com.microsoft.appcenter.analytics.channel.AnalyticsValidator;
 import com.microsoft.appcenter.analytics.channel.SessionTracker;
@@ -21,24 +19,15 @@ import com.microsoft.appcenter.ingestion.Ingestion;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
-import com.microsoft.appcenter.utils.HandlerUtils;
-import com.microsoft.appcenter.utils.PrefStorageConstants;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
-import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.storage.StorageHelper;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +41,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
@@ -68,65 +56,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-@SuppressWarnings("unused")
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, AppCenterLog.class, AppCenter.class, HandlerUtils.class})
-public class AnalyticsTest {
-
-    private static final String ANALYTICS_ENABLED_KEY = PrefStorageConstants.KEY_ENABLED + "_" + Analytics.getInstance().getServiceName();
-
-    @Mock
-    private AppCenterFuture<Boolean> mCoreEnabledFuture;
-
-    @Mock
-    private AppCenterHandler mAppCenterHandler;
-
-    @Before
-    public void setUp() {
-        Analytics.unsetInstance();
-        mockStatic(SystemClock.class);
-        mockStatic(AppCenterLog.class);
-        mockStatic(AppCenter.class);
-        when(AppCenter.isEnabled()).thenReturn(mCoreEnabledFuture);
-        when(mCoreEnabledFuture.get()).thenReturn(true);
-        Answer<Void> runNow = new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-                ((Runnable) invocation.getArguments()[0]).run();
-                return null;
-            }
-        };
-        doAnswer(runNow).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
-        mockStatic(HandlerUtils.class);
-        doAnswer(runNow).when(HandlerUtils.class);
-        HandlerUtils.runOnUiThread(any(Runnable.class));
-
-        /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */
-        mockStatic(StorageHelper.PreferencesStorage.class);
-        when(StorageHelper.PreferencesStorage.getBoolean(ANALYTICS_ENABLED_KEY, true)).thenReturn(true);
-
-        /* Then simulate further changes to state. */
-        PowerMockito.doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) {
-
-                /* Whenever the new state is persisted, make further calls return the new state. */
-                boolean enabled = (Boolean) invocation.getArguments()[1];
-                when(StorageHelper.PreferencesStorage.getBoolean(ANALYTICS_ENABLED_KEY, true)).thenReturn(enabled);
-                return null;
-            }
-        }).when(StorageHelper.PreferencesStorage.class);
-        StorageHelper.PreferencesStorage.putBoolean(eq(ANALYTICS_ENABLED_KEY), anyBoolean());
-
-        /* Pretend automatic page tracking is enabled by default, this will be the case if service becomes public. */
-        // TODO remove that after service is public
-        assertFalse(Analytics.isAutoPageTrackingEnabled());
-        Analytics.setAutoPageTrackingEnabled(true);
-    }
+public class AnalyticsTest extends AbstractAnalyticsTest {
 
     @Test
     public void singleton() {

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -147,4 +147,21 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         assertTrue(parentTarget.isEnabledAsync().get());
         assertTrue(childTarget.isEnabledAsync().get());
     }
+
+    @Test
+    public void createChildrenAfterDisabling() {
+
+        /* Disable grandparent. */
+        AnalyticsTransmissionTarget grandParentTarget = Analytics.getTransmissionTarget("grandParent");
+        grandParentTarget.setEnabledAsync(false);
+
+        /* Create a parent and child after. */
+        AnalyticsTransmissionTarget parentTarget = grandParentTarget.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget childTarget = parentTarget.getTransmissionTarget("child");
+
+        /* Check everything is disabled. */
+        assertFalse(grandParentTarget.isEnabledAsync().get());
+        assertFalse(parentTarget.isEnabledAsync().get());
+        assertFalse(childTarget.isEnabledAsync().get());
+    }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -59,6 +59,13 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
     }
 
     private void testTrackEventWithTransmissionTarget(final String defaultToken, boolean startFromApp) {
+
+        /* Overwrite setup for this test. */
+        Analytics.unsetInstance();
+        Analytics analytics = Analytics.getInstance();
+        mChannel = mock(Channel.class);
+        analytics.onStarting(mAppCenterHandler);
+        analytics.onStarted(mock(Context.class), mChannel, null, defaultToken, startFromApp);
         AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("token");
         assertNotNull(target);
 

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -1,0 +1,150 @@
+package com.microsoft.appcenter.analytics;
+
+import android.content.Context;
+
+import com.microsoft.appcenter.analytics.ingestion.models.EventLog;
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.ingestion.models.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+
+public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
+
+    @Mock
+    private Channel mChannel;
+
+    @Before
+    public void setUp() {
+
+        /* Start. */
+        super.setUp();
+        Analytics analytics = Analytics.getInstance();
+        analytics.onStarting(mAppCenterHandler);
+        analytics.onStarted(mock(Context.class), mChannel, null, null, false);
+    }
+
+    @Test
+    public void setEnabled() {
+
+        /* Create a transmission target and assert that it's enabled by default. */
+        AnalyticsTransmissionTarget transmissionTarget = Analytics.getTransmissionTarget("test");
+        assertTrue(transmissionTarget.isEnabledAsync().get());
+        transmissionTarget.trackEvent("eventName1");
+        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    return eventLog.getName().equals("eventName1");
+                }
+                return false;
+            }
+        }), anyString());
+
+        /* Set enabled to false and assert that it cannot track event. */
+        transmissionTarget.setEnabledAsync(false);
+        assertFalse(transmissionTarget.isEnabledAsync().get());
+        transmissionTarget.trackEvent("eventName2");
+        verify(mChannel, never()).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    return eventLog.getName().equals("eventName2");
+                }
+                return false;
+            }
+        }), anyString());
+    }
+
+    @Test
+    public void setEnabledOnParent() {
+
+        /* Create a transmission target and its child. */
+        AnalyticsTransmissionTarget parentTransmissionTarget = Analytics.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget childTransmissionTarget = parentTransmissionTarget.getTransmissionTarget("child");
+
+        /* Set enabled to false on parent and child should also have set enabled to false. */
+        parentTransmissionTarget.setEnabledAsync(false);
+        assertFalse(parentTransmissionTarget.isEnabledAsync().get());
+        assertFalse(childTransmissionTarget.isEnabledAsync().get());
+        childTransmissionTarget.trackEvent("eventName1");
+        verify(mChannel, never()).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    return eventLog.getName().equals("eventName1");
+                }
+                return false;
+            }
+        }), anyString());
+
+        /* Set enabled to true on parent. Verify that child can track event. */
+        parentTransmissionTarget.setEnabledAsync(true);
+        childTransmissionTarget.trackEvent("eventName2");
+        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    return eventLog.getName().equals("eventName2");
+                }
+                return false;
+            }
+        }), anyString());
+    }
+
+    @Test
+    public void setEnabledOnChild() {
+
+        /* Create a transmission target and its child. */
+        AnalyticsTransmissionTarget parentTransmissionTarget = Analytics.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget childTransmissionTarget = parentTransmissionTarget.getTransmissionTarget("child");
+
+        /* Set enabled to false on parent. When try to set enabled to true on child, it should stay false. */
+        parentTransmissionTarget.setEnabledAsync(false);
+        childTransmissionTarget.setEnabledAsync(true);
+        assertFalse(childTransmissionTarget.isEnabledAsync().get());
+        childTransmissionTarget.trackEvent("eventName");
+        verify(mChannel, never()).enqueue(any(Log.class), anyString());
+    }
+
+    @Test
+    public void disableAnalytics() {
+
+        /* Set analytics to disabled. */
+        Analytics.setEnabled(false);
+
+        /* Create grand parent, parent and child transmission targets and verify that they're all disabled. */
+        AnalyticsTransmissionTarget grandParentTarget = Analytics.getTransmissionTarget("grandParent");
+        AnalyticsTransmissionTarget parentTarget = grandParentTarget.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget childTarget = parentTarget.getTransmissionTarget("child");
+        assertFalse(grandParentTarget.isEnabledAsync().get());
+        assertFalse(parentTarget.isEnabledAsync().get());
+        assertFalse(childTarget.isEnabledAsync().get());
+
+        /* Enable analytics and verify that they're now all enabled. */
+        Analytics.setEnabled(true);
+        assertTrue(grandParentTarget.isEnabledAsync().get());
+        assertTrue(parentTarget.isEnabledAsync().get());
+        assertTrue(childTarget.isEnabledAsync().get());
+    }
+}

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-
 public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
 
     @Mock
@@ -56,7 +55,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         }), anyString());
 
         /* Set enabled to false and assert that it cannot track event. */
-        transmissionTarget.setEnabledAsync(false);
+        transmissionTarget.setEnabledAsync(false).get();
         assertFalse(transmissionTarget.isEnabledAsync().get());
         transmissionTarget.trackEvent("eventName2");
         verify(mChannel, never()).enqueue(argThat(new ArgumentMatcher<Log>() {
@@ -80,7 +79,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         AnalyticsTransmissionTarget childTransmissionTarget = parentTransmissionTarget.getTransmissionTarget("child");
 
         /* Set enabled to false on parent and child should also have set enabled to false. */
-        parentTransmissionTarget.setEnabledAsync(false);
+        parentTransmissionTarget.setEnabledAsync(false).get();
         assertFalse(parentTransmissionTarget.isEnabledAsync().get());
         assertFalse(childTransmissionTarget.isEnabledAsync().get());
         childTransmissionTarget.trackEvent("eventName1");
@@ -120,7 +119,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         AnalyticsTransmissionTarget childTransmissionTarget = parentTransmissionTarget.getTransmissionTarget("child");
 
         /* Set enabled to false on parent. When try to set enabled to true on child, it should stay false. */
-        parentTransmissionTarget.setEnabledAsync(false);
+        parentTransmissionTarget.setEnabledAsync(false).get();
         childTransmissionTarget.setEnabledAsync(true);
         assertFalse(childTransmissionTarget.isEnabledAsync().get());
         childTransmissionTarget.trackEvent("eventName");
@@ -153,7 +152,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
 
         /* Disable grandparent. */
         AnalyticsTransmissionTarget grandParentTarget = Analytics.getTransmissionTarget("grandParent");
-        grandParentTarget.setEnabledAsync(false);
+        grandParentTarget.setEnabledAsync(false).get();
 
         /* Create a parent and child after. */
         AnalyticsTransmissionTarget parentTarget = grandParentTarget.getTransmissionTarget("parent");


### PR DESCRIPTION
First PR for nesting.
TODO: delete logs for disabled targets but this first PR can already be merged.