### PR TITLE
Override Common Schema Part A properties

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -310,7 +310,7 @@ public class Analytics extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Returning transmission target found with token " + transmissionTargetToken);
                 return transmissionTarget;
             }
-            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null);
+            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null, mChannel);
             AppCenterLog.debug(LOG_TAG, "Created transmission target with token " + transmissionTargetToken);
             mTransmissionTargets.put(transmissionTargetToken, transmissionTarget);
             return transmissionTarget;

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
@@ -3,6 +3,7 @@ package com.microsoft.appcenter.analytics;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
+import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
@@ -29,7 +30,7 @@ public class AnalyticsTransmissionTarget {
     /**
      * Parent target if any.
      */
-    private final AnalyticsTransmissionTarget mParentTarget;
+    protected final AnalyticsTransmissionTarget mParentTarget;
 
     /**
      * Children targets for nesting.
@@ -42,14 +43,26 @@ public class AnalyticsTransmissionTarget {
     private final Map<String, String> mEventProperties = new HashMap<>();
 
     /**
+     * Property configurator used to override Common Schema Part A properties.
+     */
+    private PropertyConfigurator mPropertyConfigurator;
+
+    /**
+     * Channel used for Property Configurator.
+     */
+    private Channel mChannel;
+
+    /**
      * Create a new instance.
      *
      * @param transmissionTargetToken The token for this transmission target.
      * @param parentTarget            Parent transmission target.
      */
-    AnalyticsTransmissionTarget(@NonNull String transmissionTargetToken, final AnalyticsTransmissionTarget parentTarget) {
+    AnalyticsTransmissionTarget(@NonNull String transmissionTargetToken, final AnalyticsTransmissionTarget parentTarget, Channel channel) {
         mTransmissionTargetToken = transmissionTargetToken;
         mParentTarget = parentTarget;
+        mChannel = channel;
+        mPropertyConfigurator = new PropertyConfigurator(channel, this);
     }
 
     /**
@@ -140,7 +153,7 @@ public class AnalyticsTransmissionTarget {
         /* Reuse instance if a child with the same token has already been created. */
         AnalyticsTransmissionTarget childTarget = mChildrenTargets.get(transmissionTargetToken);
         if (childTarget == null) {
-            childTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, this);
+            childTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, this, mChannel);
             mChildrenTargets.put(transmissionTargetToken, childTarget);
         }
         return childTarget;
@@ -215,6 +228,15 @@ public class AnalyticsTransmissionTarget {
      */
     String getTransmissionTargetToken() {
         return mTransmissionTargetToken;
+    }
+
+    /**
+     * Getter for property configurator to override Common Schema Part A properties.
+     *
+     * @return  the Property Configurator
+     */
+    public PropertyConfigurator getPropertyConfigurator() {
+        return mPropertyConfigurator;
     }
 
     @NonNull

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
@@ -57,6 +57,7 @@ public class AnalyticsTransmissionTarget {
      *
      * @param transmissionTargetToken The token for this transmission target.
      * @param parentTarget            Parent transmission target.
+     * @param channel                 The channel for this transmission target.
      */
     AnalyticsTransmissionTarget(@NonNull String transmissionTargetToken, final AnalyticsTransmissionTarget parentTarget, Channel channel) {
         mTransmissionTargetToken = transmissionTargetToken;

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -1,51 +1,57 @@
 package com.microsoft.appcenter.analytics;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
-import android.util.Property;
 
-import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
-import com.microsoft.appcenter.analytics.ingestion.models.one.json.CommonSchemaEventLogFactory;
 import com.microsoft.appcenter.channel.AbstractChannelListener;
 import com.microsoft.appcenter.channel.Channel;
-import com.microsoft.appcenter.channel.OneCollectorChannelListener;
-import com.microsoft.appcenter.ingestion.models.CustomPropertiesLog;
 import com.microsoft.appcenter.ingestion.models.Log;
-import com.microsoft.appcenter.ingestion.models.StartServiceLog;
-import com.microsoft.appcenter.ingestion.models.json.CustomPropertiesLogFactory;
-import com.microsoft.appcenter.ingestion.models.json.DefaultLogSerializer;
-import com.microsoft.appcenter.ingestion.models.json.LogSerializer;
-import com.microsoft.appcenter.ingestion.models.json.StartServiceLogFactory;
 import com.microsoft.appcenter.ingestion.models.one.AppExtension;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
-import com.microsoft.appcenter.ingestion.models.one.SdkExtension;
-import com.microsoft.appcenter.utils.AppCenterLog;
-import com.microsoft.appcenter.utils.UUIDUtils;
-
-import java.util.Collection;
-
-import static com.microsoft.appcenter.utils.AppCenterLog.LOG_TAG;
 
 /**
  * Allow overriding Part A properties.
  */
 public class PropertyConfigurator extends AbstractChannelListener {
 
+    /**
+     * App name to override common schema part A 'app.name'.
+     */
     private String mAppName;
 
+    /**
+     * App name to override common schema part A 'app.ver'.
+     */
     private String mAppVersion;
 
+    /**
+     * App name to override common schema part A 'app.locale'.
+     */
     private String mAppLocale;
 
+    /**
+     * The transmission target which this configurator belongs to.
+     */
     private AnalyticsTransmissionTarget mTransmissionTarget;
 
+    /**
+     * Create a new property configurator.
+     *
+     * @param channel            The channel for this listener.
+     * @param transmissionTarget The tranmission target of the configurator.
+     */
     PropertyConfigurator(Channel channel, AnalyticsTransmissionTarget transmissionTarget) {
         mTransmissionTarget = transmissionTarget;
         if (channel != null) {
             channel.addListener(this);
         }
     }
-    
+
+    /**
+     * Override or inherit common schema properties while preparing log.
+     *
+     * @param log       A log.
+     * @param groupName The group name.
+     */
     @Override
     public void onPreparingLog(@NonNull Log log, @NonNull String groupName) {
         if (log instanceof CommonSchemaLog && mTransmissionTarget.isEnabled()) {
@@ -55,14 +61,12 @@ public class PropertyConfigurator extends AbstractChannelListener {
             if (mAppName != null) {
                 app.setId(mAppName);
             } else {
-                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
-                while (parent != null) {
-                    String parentAppName = parent.getPropertyConfigurator().getAppName();
+                for (AnalyticsTransmissionTarget target = mTransmissionTarget.mParentTarget; target != null; target = target.mParentTarget) {
+                    String parentAppName = target.getPropertyConfigurator().getAppName();
                     if (parentAppName != null) {
                         app.setId(parentAppName);
                         break;
                     }
-                    parent = parent.mParentTarget;
                 }
             }
 
@@ -70,14 +74,12 @@ public class PropertyConfigurator extends AbstractChannelListener {
             if (mAppVersion != null) {
                 app.setVer(mAppVersion);
             } else {
-                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
-                while (parent != null) {
-                    String parentAppVersion = parent.getPropertyConfigurator().getAppVersion();
+                for (AnalyticsTransmissionTarget target = mTransmissionTarget.mParentTarget; target != null; target = target.mParentTarget) {
+                    String parentAppVersion = target.getPropertyConfigurator().getAppVersion();
                     if (parentAppVersion != null) {
                         app.setVer(parentAppVersion);
                         break;
                     }
-                    parent = parent.mParentTarget;
                 }
             }
 
@@ -85,55 +87,68 @@ public class PropertyConfigurator extends AbstractChannelListener {
             if (mAppLocale != null) {
                 app.setLocale(mAppLocale);
             } else {
-                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
-                while (parent != null) {
-                    String parentAppLocale = parent.getPropertyConfigurator().getAppLocale();
+                for (AnalyticsTransmissionTarget target = mTransmissionTarget.mParentTarget; target != null; target = target.mParentTarget) {
+                    String parentAppLocale = target.getPropertyConfigurator().getAppLocale();
                     if (parentAppLocale != null) {
                         app.setLocale(parentAppLocale);
                         break;
                     }
-                    parent = parent.mParentTarget;
                 }
             }
         }
     }
 
     /**
+     * Get app name. Used for checking parents for property inheritance.
+     *
+     * @return App name
+     */
+    private String getAppName() {
+        return mAppName;
+    }
+
+    /**
      * Override common schema Part A property App.Name.
      *
-     * @param appName   App name
+     * @param appName App name
      */
     public void setAppName(String appName) {
         mAppName = appName;
     }
 
-    protected String getAppName() {
-        return mAppName;
+    /**
+     * Get app version. Used for checking parents for property inheritance.
+     *
+     * @return App version
+     */
+    private String getAppVersion() {
+        return mAppVersion;
     }
 
     /**
      * Override common schema Part A property App.Version.
      *
-     * @param appVersion    App version
+     * @param appVersion App version
      */
     public void setAppVersion(String appVersion) {
         mAppVersion = appVersion;
     }
 
-    protected String getAppVersion() {
-        return mAppVersion;
+    /**
+     * Get app locale. Used for checking parents for property inheritance.
+     *
+     * @return App locale
+     */
+    private String getAppLocale() {
+        return mAppLocale;
     }
 
     /**
      * Override common schema Part A property App.Locale.
      *
-     * @param appLocale     App Locale
+     * @param appLocale App Locale
      */
     public void setAppLocale(String appLocale) {
         mAppLocale = appLocale;
-    }
-
-    protected String getAppLocale() {
-        return mAppLocale;
     }
 }

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -59,12 +59,12 @@ public class PropertyConfigurator extends AbstractChannelListener {
 
             /* Override app name if not null, else use the name of the nearest parent. */
             if (mAppName != null) {
-                app.setId(mAppName);
+                app.setName(mAppName);
             } else {
                 for (AnalyticsTransmissionTarget target = mTransmissionTarget.mParentTarget; target != null; target = target.mParentTarget) {
                     String parentAppName = target.getPropertyConfigurator().getAppName();
                     if (parentAppName != null) {
-                        app.setId(parentAppName);
+                        app.setName(parentAppName);
                         break;
                     }
                 }

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -1,0 +1,120 @@
+package com.microsoft.appcenter.analytics;
+
+import android.support.annotation.NonNull;
+import android.util.Property;
+
+import com.microsoft.appcenter.channel.AbstractChannelListener;
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.ingestion.models.one.AppExtension;
+import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
+
+/**
+ * Allow overriding Part A properties.
+ */
+public class PropertyConfigurator extends AbstractChannelListener {
+
+    private String mAppName;
+
+    private String mAppVersion;
+
+    private String mAppLocale;
+
+    private AnalyticsTransmissionTarget mTransmissionTarget;
+
+    PropertyConfigurator(Channel channel, AnalyticsTransmissionTarget transmissionTarget) {
+        mTransmissionTarget = transmissionTarget;
+        channel.addListener(PropertyConfigurator.class);
+    }
+
+    @Override
+    public void onPreparingLog(@NonNull Log log, @NonNull String groupName) {
+        if (log instanceof CommonSchemaLog) {
+            AppExtension app = ((CommonSchemaLog) log).getExt().getApp();
+
+            /* Override app name if not null, else use the name of the nearest parent. */
+            if (mAppName != null) {
+                app.setId(mAppName);
+            } else {
+                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
+                while (parent != null) {
+                    String parentAppName = parent.getPropertyConfigurator().getAppName();
+                    if (parentAppName != null) {
+                        app.setId(parentAppName);
+                        break;
+                    }
+                    parent = parent.mParentTarget;
+                }
+            }
+
+            /* Override app version if not null, else use the version of the nearest parent. */
+            if (mAppVersion != null) {
+                app.setVer(mAppVersion);
+            } else {
+                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
+                while (parent != null) {
+                    String parentAppVersion = parent.getPropertyConfigurator().getAppVersion();
+                    if (parentAppVersion != null) {
+                        app.setVer(parentAppVersion);
+                        break;
+                    }
+                    parent = parent.mParentTarget;
+                }
+            }
+
+            /* Override app locale if not null, else use the locale of the nearest parent. */
+            if (mAppLocale != null) {
+                app.setLocale(mAppLocale);
+            } else {
+                AnalyticsTransmissionTarget parent = mTransmissionTarget.mParentTarget;
+                while (parent != null) {
+                    String parentAppLocale = parent.getPropertyConfigurator().getAppLocale();
+                    if (parentAppLocale != null) {
+                        app.setLocale(parentAppLocale);
+                        break;
+                    }
+                    parent = parent.mParentTarget;
+                }
+            }
+        }
+    }
+
+    /**
+     * Override common schema Part A property App.Name.
+     *
+     * @param appName   App name
+     */
+    public void setAppName(String appName) {
+        mAppName = appName;
+    }
+
+    protected String getAppName() {
+        return mAppName;
+    }
+
+    /**
+     * Override common schema Part A property App.Version.
+     *
+     * @param appVersion    App version
+     */
+    public void setAppVersion(String appVersion) {
+        mAppVersion = appVersion;
+    }
+
+    protected String getAppVersion() {
+        return mAppVersion;
+    }
+
+    /**
+     * Override common schema Part A property App.Locale.
+     *
+     * @param appLocale     App Locale
+     */
+    public void setAppLocale(String appLocale) {
+        mAppLocale = appLocale;
+    }
+
+    protected String getAppLocale() {
+        return mAppLocale;
+    }
+}

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -45,12 +45,7 @@ public class PropertyConfigurator extends AbstractChannelListener {
             channel.addListener(this);
         }
     }
-
-    /**
-     *
-     * @param log
-     * @param groupName
-     */
+    
     @Override
     public void onPreparingLog(@NonNull Log log, @NonNull String groupName) {
         if (log instanceof CommonSchemaLog && mTransmissionTarget.isEnabled()) {

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -3,15 +3,9 @@ package com.microsoft.appcenter.analytics;
 import android.content.Context;
 
 import com.microsoft.appcenter.analytics.ingestion.models.EventLog;
-import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.Log;
-import com.microsoft.appcenter.ingestion.models.one.AppExtension;
-import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
-import com.microsoft.appcenter.ingestion.models.one.Extensions;
 
-import org.hamcrest.core.CombinableMatcher;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,7 +18,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -166,7 +159,6 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         /* Another child transmission target with the same token should be the same instance. */
         assertSame(childTarget, target.getTransmissionTarget("token3"));
     }
-
 
     @Test
     public void setEnabled() {
@@ -442,99 +434,5 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         expectedProperties.put("f", "6666");
         expectedProperties.put("g", "7777");
         assertEquals(expectedProperties, log.getProperties());
-    }
-
-    /* Property Configurator tests */
-    @Test
-    public void setCommonSchemaProperties() {
-        CommonSchemaLog log = new CommonSchemaEventLog();
-        log.setExt(new Extensions());
-        log.getExt().setApp(new AppExtension());
-
-        /* Get property configurator and set properties. */
-        PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
-        pc.setAppVersion("appVersion");
-        pc.setAppName("appName");
-        pc.setAppLocale("appLocale");
-        pc.onPreparingLog(log, "groupName");
-
-        /* Assert properties set on common schema. */
-        assertEquals("appVersion", log.getExt().getApp().getVer());
-        assertEquals("appName", log.getExt().getApp().getId());
-        assertEquals("appLocale", log.getExt().getApp().getLocale());
-    }
-
-    @Test
-    public void commonSchemaPropertiesNotSetWhenDisabled() {
-        CommonSchemaLog log = new CommonSchemaEventLog();
-        log.setExt(new Extensions());
-        log.getExt().setApp(new AppExtension());
-
-        /* Get target, disable it, and set properties. */
-        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-        target.setEnabledAsync(false);
-        target.getPropertyConfigurator().setAppVersion("appVersion");
-        target.getPropertyConfigurator().setAppName("appName");
-        target.getPropertyConfigurator().setAppLocale("appLocale");
-        target.getPropertyConfigurator().onPreparingLog(log, "groupName");
-
-        /* Assert properties are null. */
-        assertNull(log.getExt().getApp().getVer());
-        assertNull(log.getExt().getApp().getId());
-        assertNull(log.getExt().getApp().getLocale());
-    }
-
-    @Test
-    public void inheritCommonSchemaPropertiesFromGrandparent() {
-        CommonSchemaLog log = new CommonSchemaEventLog();
-        log.setExt(new Extensions());
-        log.getExt().setApp(new AppExtension());
-
-        /* Set properties on parent to override unset properties on child */
-        AnalyticsTransmissionTarget grandparent = Analytics.getTransmissionTarget("grandparent");
-        grandparent.getPropertyConfigurator().setAppVersion("appVersion");
-        grandparent.getPropertyConfigurator().setAppName("appName");
-        grandparent.getPropertyConfigurator().setAppLocale("appLocale");
-
-        AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
-        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
-        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
-
-        /* Assert properties set on common schema. */
-        assertEquals("appVersion", log.getExt().getApp().getVer());
-        assertEquals("appName", log.getExt().getApp().getId());
-        assertEquals("appLocale", log.getExt().getApp().getLocale());
-    }
-
-    @Test
-    public void grandparentsHaveNoPropertiesSet() {
-        CommonSchemaLog log = new CommonSchemaEventLog();
-        log.setExt(new Extensions());
-        log.getExt().setApp(new AppExtension());
-
-        /* Set up empty chain of parents. */
-        AnalyticsTransmissionTarget grandparent = Analytics.getTransmissionTarget("grandparent");
-        AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
-        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
-        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
-
-        /* Assert properties set on common schema. */
-        assertNull(log.getExt().getApp().getVer());
-        assertNull(log.getExt().getApp().getId());
-        assertNull(log.getExt().getApp().getLocale());
-    }
-
-    @Test
-    public void appCenterLogDoesNotOverride() {
-        Log log = new EventLog();
-
-        /* Get property configurator and set properties. */
-        PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
-        pc.setAppVersion("appVersion");
-        pc.setAppName("appName");
-        pc.setAppLocale("appLocale");
-        pc.onPreparingLog(log, "groupName");
-
-        verify(mChannel, never()).enqueue(isA(EventLog.class), anyString());
     }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -3,9 +3,15 @@ package com.microsoft.appcenter.analytics;
 import android.content.Context;
 
 import com.microsoft.appcenter.analytics.ingestion.models.EventLog;
+import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.ingestion.models.one.AppExtension;
+import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
+import com.microsoft.appcenter.ingestion.models.one.Extensions;
 
+import org.hamcrest.core.CombinableMatcher;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -435,5 +441,88 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         expectedProperties.put("f", "6666");
         expectedProperties.put("g", "7777");
         assertEquals(expectedProperties, log.getProperties());
+    }
+
+    /* Property Configurator tests */
+    @Test
+    public void setCommonSchemaProperties() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Get property configurator and set properties. */
+        PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
+        pc.setAppVersion("appVersion");
+        pc.setAppName("appName");
+        pc.setAppLocale("appLocale");
+        pc.onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertEquals("appVersion", log.getExt().getApp().getVer());
+        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appLocale", log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void inheritCommonSchemaProperties() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Set properties on parent to override unset properties on child */
+        AnalyticsTransmissionTarget parent = Analytics.getTransmissionTarget("parent");
+        parent.getPropertyConfigurator().setAppVersion("appVersion");
+        parent.getPropertyConfigurator().setAppName("appName");
+        parent.getPropertyConfigurator().setAppLocale("appLocale");
+
+        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
+        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertEquals("appVersion", log.getExt().getApp().getVer());
+        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appLocale", log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void commonSchemaPropertiesNotSetWhenDisabled() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Get target, disable it, and set properties. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+        target.setEnabledAsync(false);
+        target.getPropertyConfigurator().setAppVersion("appVersion");
+        target.getPropertyConfigurator().setAppName("appName");
+        target.getPropertyConfigurator().setAppLocale("appLocale");
+        target.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert default values for properties */
+        assertNull(log.getExt().getApp().getVer());
+        assertNull(log.getExt().getApp().getId());
+        assertNull(log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void inheritCommonSchemaPropertiesFromGrandparent() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Set properties on parent to override unset properties on child */
+        AnalyticsTransmissionTarget grandparent = Analytics.getTransmissionTarget("grandparent");
+        grandparent.getPropertyConfigurator().setAppVersion("appVersion");
+        grandparent.getPropertyConfigurator().setAppName("appName");
+        grandparent.getPropertyConfigurator().setAppLocale("appLocale");
+
+        AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
+        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertEquals("appVersion", log.getExt().getApp().getVer());
+        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appLocale", log.getExt().getApp().getLocale());
     }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -49,7 +49,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Assert properties set on common schema. */
         assertEquals("appVersion", log.getExt().getApp().getVer());
-        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appName", log.getExt().getApp().getName());
         assertEquals("appLocale", log.getExt().getApp().getLocale());
     }
 
@@ -61,7 +61,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Get target, disable it, and set properties. */
         AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-        target.setEnabledAsync(false);
+        target.setEnabledAsync(false).get();
         target.getPropertyConfigurator().setAppVersion("appVersion");
         target.getPropertyConfigurator().setAppName("appName");
         target.getPropertyConfigurator().setAppLocale("appLocale");
@@ -69,7 +69,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Assert properties are null. */
         assertNull(log.getExt().getApp().getVer());
-        assertNull(log.getExt().getApp().getId());
+        assertNull(log.getExt().getApp().getName());
         assertNull(log.getExt().getApp().getLocale());
     }
 
@@ -91,7 +91,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Assert properties set on common schema. */
         assertEquals("appVersion", log.getExt().getApp().getVer());
-        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appName", log.getExt().getApp().getName());
         assertEquals("appLocale", log.getExt().getApp().getLocale());
     }
 
@@ -109,7 +109,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Assert properties set on common schema. */
         assertNull(log.getExt().getApp().getVer());
-        assertNull(log.getExt().getApp().getId());
+        assertNull(log.getExt().getApp().getName());
         assertNull(log.getExt().getApp().getLocale());
     }
 

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -1,0 +1,130 @@
+package com.microsoft.appcenter.analytics;
+
+import android.content.Context;
+
+import com.microsoft.appcenter.analytics.ingestion.models.EventLog;
+import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.ingestion.models.one.AppExtension;
+import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
+import com.microsoft.appcenter.ingestion.models.one.Extensions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
+
+    @Mock
+    private Channel mChannel;
+
+    @Before
+    public void setUp() {
+
+        /* Start. */
+        super.setUp();
+        Analytics analytics = Analytics.getInstance();
+        analytics.onStarting(mAppCenterHandler);
+        analytics.onStarted(mock(Context.class), mChannel, null, null, false);
+    }
+
+    @Test
+    public void setCommonSchemaProperties() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Get property configurator and set properties. */
+        PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
+        pc.setAppVersion("appVersion");
+        pc.setAppName("appName");
+        pc.setAppLocale("appLocale");
+        pc.onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertEquals("appVersion", log.getExt().getApp().getVer());
+        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appLocale", log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void commonSchemaPropertiesNotSetWhenDisabled() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Get target, disable it, and set properties. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+        target.setEnabledAsync(false);
+        target.getPropertyConfigurator().setAppVersion("appVersion");
+        target.getPropertyConfigurator().setAppName("appName");
+        target.getPropertyConfigurator().setAppLocale("appLocale");
+        target.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert properties are null. */
+        assertNull(log.getExt().getApp().getVer());
+        assertNull(log.getExt().getApp().getId());
+        assertNull(log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void inheritCommonSchemaPropertiesFromGrandparent() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Set properties on parent to override unset properties on child */
+        AnalyticsTransmissionTarget grandparent = Analytics.getTransmissionTarget("grandparent");
+        grandparent.getPropertyConfigurator().setAppVersion("appVersion");
+        grandparent.getPropertyConfigurator().setAppName("appName");
+        grandparent.getPropertyConfigurator().setAppLocale("appLocale");
+
+        AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
+        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertEquals("appVersion", log.getExt().getApp().getVer());
+        assertEquals("appName", log.getExt().getApp().getId());
+        assertEquals("appLocale", log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void grandparentsHaveNoPropertiesSet() {
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+
+        /* Set up empty chain of parents. */
+        AnalyticsTransmissionTarget grandparent = Analytics.getTransmissionTarget("grandparent");
+        AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
+        child.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Assert properties set on common schema. */
+        assertNull(log.getExt().getApp().getVer());
+        assertNull(log.getExt().getApp().getId());
+        assertNull(log.getExt().getApp().getLocale());
+    }
+
+    @Test
+    public void appCenterLogDoesNotOverride() {
+        Log log = mock(EventLog.class);
+
+        /* Get property configurator and set properties. */
+        PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
+        pc.setAppVersion("appVersion");
+        pc.setAppName("appName");
+        pc.setAppLocale("appLocale");
+        pc.onPreparingLog(log, "groupName");
+
+        /* Verify no interactions with the log. */
+        verifyNoMoreInteractions(log);
+    }
+}

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
@@ -18,6 +18,11 @@ public class AppExtension implements Model {
     private static final String ID = "id";
 
     /**
+     * Name property.
+     */
+    private static final String NAME = "name";
+
+    /**
      * Version property.
      */
     private static final String VER = "ver";
@@ -31,6 +36,11 @@ public class AppExtension implements Model {
      * Application identifier.
      */
     private String id;
+
+    /**
+     * Application name.
+     */
+    private String name;
 
     /**
      * Application version.
@@ -58,6 +68,24 @@ public class AppExtension implements Model {
      */
     public void setId(String id) {
         this.id = id;
+    }
+
+    /**
+     * Get application name.
+     *
+     * @return application name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set application name.
+     *
+     * @param name application name.
+     */
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -100,6 +128,7 @@ public class AppExtension implements Model {
     @Override
     public void read(JSONObject object) {
         setId(object.optString(ID, null));
+        setName(object.optString(NAME, null));
         setVer(object.optString(VER, null));
         setLocale(object.optString(LOCALE, null));
     }
@@ -107,6 +136,7 @@ public class AppExtension implements Model {
     @Override
     public void write(JSONStringer writer) throws JSONException {
         JSONUtils.write(writer, ID, getId());
+        JSONUtils.write(writer, NAME, getName());
         JSONUtils.write(writer, VER, getVer());
         JSONUtils.write(writer, LOCALE, getLocale());
     }
@@ -120,6 +150,7 @@ public class AppExtension implements Model {
         AppExtension that = (AppExtension) o;
 
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (ver != null ? !ver.equals(that.ver) : that.ver != null) return false;
         return locale != null ? locale.equals(that.locale) : that.locale == null;
     }
@@ -127,6 +158,7 @@ public class AppExtension implements Model {
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (ver != null ? ver.hashCode() : 0);
         result = 31 * result + (locale != null ? locale.hashCode() : 0);
         return result;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
@@ -18,14 +18,14 @@ public class AppExtension implements Model {
     private static final String ID = "id";
 
     /**
-     * Name property.
-     */
-    private static final String NAME = "name";
-
-    /**
      * Version property.
      */
     private static final String VER = "ver";
+
+    /**
+     * Name property.
+     */
+    private static final String NAME = "name";
 
     /**
      * Locale property.
@@ -38,14 +38,14 @@ public class AppExtension implements Model {
     private String id;
 
     /**
-     * Application name.
-     */
-    private String name;
-
-    /**
      * Application version.
      */
     private String ver;
+
+    /**
+     * Application name.
+     */
+    private String name;
 
     /**
      * Application locale.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/AppExtension.java
@@ -128,16 +128,16 @@ public class AppExtension implements Model {
     @Override
     public void read(JSONObject object) {
         setId(object.optString(ID, null));
-        setName(object.optString(NAME, null));
         setVer(object.optString(VER, null));
+        setName(object.optString(NAME, null));
         setLocale(object.optString(LOCALE, null));
     }
 
     @Override
     public void write(JSONStringer writer) throws JSONException {
         JSONUtils.write(writer, ID, getId());
-        JSONUtils.write(writer, NAME, getName());
         JSONUtils.write(writer, VER, getVer());
+        JSONUtils.write(writer, NAME, getName());
         JSONUtils.write(writer, LOCALE, getLocale());
     }
 
@@ -150,16 +150,16 @@ public class AppExtension implements Model {
         AppExtension that = (AppExtension) o;
 
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (ver != null ? !ver.equals(that.ver) : that.ver != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
         return locale != null ? locale.equals(that.locale) : that.locale == null;
     }
 
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (ver != null ? ver.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (locale != null ? locale.hashCode() : 0);
         return result;
     }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/AppExtensionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/AppExtensionTest.java
@@ -38,6 +38,14 @@ public class AppExtensionTest {
         b.setVer("a2");
         checkEquals(a, b);
 
+        /* Name. */
+        a.setName("a2");
+        checkNotEquals(a, b);
+        b.setName("b2");
+        checkNotEquals(a, b);
+        b.setName("a2");
+        checkEquals(a, b);
+
         /* Locale. */
         a.setLocale("a3");
         checkNotEquals(a, b);


### PR DESCRIPTION
This change adds a `PropertyConfigurator` to `AnalyticsTransmissionTarget`, which is used to override common schema properties.  Properties are inherited in the same way that event properties are.