### PR TITLE
Moving set/removeEventProperty to PropertyConfigurator

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
@@ -88,6 +88,8 @@ public class EventPropertiesActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+
+        /* TODO remove reflection after overriding common schema properties feature is released. */
         AnalyticsTransmissionTarget target = getSelectedTarget();
         Object configurator;
         Method method;
@@ -140,6 +142,8 @@ public class EventPropertiesActivity extends AppCompatActivity {
     }
 
     private void updatePropertyList() {
+
+        /* TODO remove reflection after overriding common schema properties feature is released. */
         AnalyticsTransmissionTarget target = getSelectedTarget();
         Object configurator;
         Method method;
@@ -201,6 +205,8 @@ public class EventPropertiesActivity extends AppCompatActivity {
 
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
+
+            /* TODO remove reflection after overriding common schema properties feature is released. */
             AnalyticsTransmissionTarget target = getSelectedTarget();
             Object configurator;
             Method method;
@@ -213,10 +219,9 @@ public class EventPropertiesActivity extends AppCompatActivity {
                 method = null;
             }
 
+            /* Set key and value strings to the view. */
             View rowView;
             if (method != null) {
-
-                /* Set key and value strings to the view. */
                 final Object finalConfigurator = configurator;
                 final Method finalMethod = method;
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
@@ -19,6 +19,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.microsoft.appcenter.analytics.AnalyticsTransmissionTarget;
+import com.microsoft.appcenter.analytics.PropertyConfigurator;
 import com.microsoft.appcenter.sasquatch.R;
 import com.microsoft.appcenter.sasquatch.util.EventActivityUtil;
 
@@ -101,7 +102,7 @@ public class EventPropertiesActivity extends AppCompatActivity {
                         CharSequence key = keyView.getText();
                         CharSequence value = valueView.getText();
                         if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
-                            getSelectedTarget().setEventProperty(key.toString(), value.toString());
+                            getSelectedTarget().getPropertyConfigurator().setEventProperty(key.toString(), value.toString());
                             updatePropertyList();
                         }
                         mAddPropertyLayout.setVisibility(View.GONE);
@@ -120,10 +121,10 @@ public class EventPropertiesActivity extends AppCompatActivity {
     }
 
     private void updatePropertyList() {
-        AnalyticsTransmissionTarget target = getSelectedTarget();
+        PropertyConfigurator configurator = getSelectedTarget().getPropertyConfigurator();
         Field field;
         try {
-            field = target.getClass().getDeclaredField("mEventProperties");
+            field = configurator.getClass().getDeclaredField("mEventProperties");
         } catch (Exception e) {
             field = null;
         }
@@ -132,7 +133,7 @@ public class EventPropertiesActivity extends AppCompatActivity {
                 field.setAccessible(true);
 
                 //noinspection unchecked
-                Map<String, String> map = (Map<String, String>) field.get(target);
+                Map<String, String> map = (Map<String, String>) field.get(configurator);
                 mPropertyListAdapter.mList.clear();
                 for (Map.Entry<String, String> entry : map.entrySet()) {
                     mPropertyListAdapter.mList.add(new Pair<>(entry.getKey(), entry.getValue()));
@@ -199,7 +200,7 @@ public class EventPropertiesActivity extends AppCompatActivity {
                 @Override
                 public void onClick(View v) {
                     mList.remove(item);
-                    getSelectedTarget().removeEventProperty(item.first);
+                    getSelectedTarget().getPropertyConfigurator().removeEventProperty(item.first);
                     notifyDataSetChanged();
                 }
             });

--- a/apps/sasquatch/src/projectDependency/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
+++ b/apps/sasquatch/src/projectDependency/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
@@ -1,0 +1,233 @@
+package com.microsoft.appcenter.sasquatch.activities;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+import android.util.Pair;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.microsoft.appcenter.analytics.AnalyticsTransmissionTarget;
+import com.microsoft.appcenter.sasquatch.R;
+import com.microsoft.appcenter.sasquatch.util.EventActivityUtil;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class EventPropertiesActivity extends AppCompatActivity {
+
+    public final static String EXTRA_TARGET_SELECTED = "TARGET_SELECTED";
+
+    private Spinner mTransmissionTargetSpinner;
+
+    private ListView mListView;
+
+    private LinearLayout mAddPropertyLayout;
+
+    private PropertyListAdapter mPropertyListAdapter;
+
+    private List<AnalyticsTransmissionTarget> mTransmissionTargets = new ArrayList<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_event_properties);
+
+        /* Initialize spinner for transmission targets. */
+        mTransmissionTargetSpinner = findViewById(R.id.transmission_target);
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, getResources().getStringArray(R.array.target_id_names));
+        mTransmissionTargetSpinner.setAdapter(adapter);
+        mTransmissionTargetSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                updatePropertyList();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+        mTransmissionTargetSpinner.setSelection(getIntent().getIntExtra(EXTRA_TARGET_SELECTED, 0));
+
+        /* Initialize layout for a new property. */
+        mAddPropertyLayout = findViewById(R.id.add_property);
+
+        /* Initialize list view. */
+        mListView = findViewById(R.id.list);
+        mPropertyListAdapter = new PropertyListAdapter(new ArrayList<Pair<String, String>>());
+
+        /*
+         * Initialize analytics transmission targets.
+         * The first element is a placeholder for default transmission.
+         * The second one is the parent transmission target, the third one is a child,
+         * the forth is a grandchild, etc...
+         */
+        mTransmissionTargets = EventActivityUtil.getAnalyticTransmissionTargetList(this);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.add, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final AnalyticsTransmissionTarget target = getSelectedTarget();
+        if (target != null) {
+            switch (item.getItemId()) {
+                case R.id.action_add:
+                    final TextView keyView = mAddPropertyLayout.findViewById(R.id.key);
+                    final TextView valueView = mAddPropertyLayout.findViewById(R.id.value);
+                    keyView.setText("");
+                    valueView.setText("");
+                    mAddPropertyLayout.setVisibility(View.VISIBLE);
+                    mAddPropertyLayout.findViewById(R.id.add_button).setOnClickListener(new View.OnClickListener() {
+
+                        @Override
+                        public void onClick(View v) {
+                            CharSequence key = keyView.getText();
+                            CharSequence value = valueView.getText();
+                            if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
+                                try {
+                                    target.getPropertyConfigurator().setEventProperty(key.toString(), value.toString());
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                                updatePropertyList();
+                            }
+                            mAddPropertyLayout.setVisibility(View.GONE);
+                        }
+                    });
+                    mAddPropertyLayout.findViewById(R.id.cancel_button).setOnClickListener(new View.OnClickListener() {
+
+                        @Override
+                        public void onClick(View v) {
+                            mAddPropertyLayout.setVisibility(View.GONE);
+                        }
+                    });
+                    break;
+            }
+        }
+        return true;
+    }
+
+    private void updatePropertyList() {
+        Field field = null;
+        try {
+            if (getSelectedTarget() != null) {
+                field = getSelectedTarget().getPropertyConfigurator().getClass().getDeclaredField("mEventProperties");
+            }
+        } catch (NoSuchFieldException ignore) {
+        }
+        if (field != null) {
+            field.setAccessible(true);
+
+            //noinspection unchecked
+            Map<String, String> map = null;
+            try {
+                map = (Map<String, String>) field.get(getSelectedTarget().getPropertyConfigurator());
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            mPropertyListAdapter.mList.clear();
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                mPropertyListAdapter.mList.add(new Pair<>(entry.getKey(), entry.getValue()));
+            }
+            mListView.setAdapter(mPropertyListAdapter);
+            mPropertyListAdapter.notifyDataSetChanged();
+        }
+    }
+
+    private AnalyticsTransmissionTarget getSelectedTarget() {
+        return mTransmissionTargets.get(mTransmissionTargetSpinner.getSelectedItemPosition());
+    }
+
+    private class PropertyListAdapter extends BaseAdapter {
+
+        private final static String KEY_VALUE_PAIR_FORMAT = "\"%s\":\"%s\"";
+
+        private final List<Pair<String, String>> mList;
+
+        private PropertyListAdapter(List<Pair<String, String>> list) {
+            mList = list;
+        }
+
+        @Override
+        public int getCount() {
+            return mList.size();
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return mList.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+
+            /* Set key and value strings to the view. */
+            View rowView;
+
+            //noinspection unchecked
+            final Pair<String, String> item = (Pair<String, String>) getItem(position);
+            ViewHolder holder;
+            if (convertView != null && convertView.getTag() != null) {
+                holder = (ViewHolder) convertView.getTag();
+                rowView = convertView;
+            } else {
+                rowView = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_view_property, parent, false);
+                TextView textView = rowView.findViewById(R.id.property);
+                ImageButton imageButton = rowView.findViewById(R.id.delete_button);
+                holder = new ViewHolder(textView, imageButton);
+                rowView.setTag(holder);
+            }
+            holder.mTextView.setText(String.format(KEY_VALUE_PAIR_FORMAT, item.first, item.second));
+            holder.mImageButton.setOnClickListener(new View.OnClickListener() {
+
+                @Override
+                public void onClick(View v) {
+                    AnalyticsTransmissionTarget target = getSelectedTarget();
+                    if (target != null) {
+                        mList.remove(item);
+                        target.getPropertyConfigurator().removeEventProperty(item.first);
+                        notifyDataSetChanged();
+                    }
+                }
+            });
+            return rowView;
+        }
+
+        private class ViewHolder {
+
+            private final TextView mTextView;
+
+            private final ImageButton mImageButton;
+
+            private ViewHolder(TextView textView, ImageButton imageButton) {
+                mTextView = textView;
+                mImageButton = imageButton;
+            }
+        }
+    }
+}

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTarget.java
@@ -38,11 +38,6 @@ public class AnalyticsTransmissionTarget {
     private final Map<String, AnalyticsTransmissionTarget> mChildrenTargets = new HashMap<>();
 
     /**
-     * Common event properties for this target. Inherited by children.
-     */
-    private final Map<String, String> mEventProperties = new HashMap<>();
-
-    /**
      * Property configurator used to override Common Schema Part A properties.
      */
     private PropertyConfigurator mPropertyConfigurator;
@@ -88,7 +83,7 @@ public class AnalyticsTransmissionTarget {
         /* Merge common properties. More specific target wins conflicts. */
         Map<String, String> mergedProperties = new HashMap<>();
         for (AnalyticsTransmissionTarget target = this; target != null; target = target.mParentTarget) {
-            target.mergeEventProperties(mergedProperties);
+            target.getPropertyConfigurator().mergeEventProperties(mergedProperties);
         }
 
         /* Override with parameter. */
@@ -106,41 +101,6 @@ public class AnalyticsTransmissionTarget {
 
         /* Track event with merged properties. */
         Analytics.trackEvent(name, mergedProperties, this);
-    }
-
-    /**
-     * Extracted method to synchronize on each level at once while reading properties.
-     * Nesting synchronize between parent/child could lead to deadlocks.
-     */
-    private synchronized void mergeEventProperties(Map<String, String> mergedProperties) {
-        for (Map.Entry<String, String> property : mEventProperties.entrySet()) {
-            String key = property.getKey();
-            if (!mergedProperties.containsKey(key)) {
-                mergedProperties.put(key, property.getValue());
-            }
-        }
-    }
-
-    /**
-     * Add or overwrite the given key for the common event properties. Properties will be inherited
-     * by children of this transmission target.
-     *
-     * @param key   The property key.
-     * @param value The property value.
-     */
-    @SuppressWarnings("WeakerAccess")
-    public synchronized void setEventProperty(String key, String value) {
-        mEventProperties.put(key, value);
-    }
-
-    /**
-     * Removes the given key from the common event properties.
-     *
-     * @param key The property key to be removed.
-     */
-    @SuppressWarnings("WeakerAccess")
-    public synchronized void removeEventProperty(String key) {
-        mEventProperties.remove(key);
     }
 
     /**

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -182,7 +182,7 @@ public class PropertyConfigurator extends AbstractChannelListener {
         mEventProperties.remove(key);
     }
 
-    /**
+    /*
      * Extracted method to synchronize on each level at once while reading properties.
      * Nesting synchronize between parent/child could lead to deadlocks.
      */

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -186,7 +186,7 @@ public class PropertyConfigurator extends AbstractChannelListener {
      * Extracted method to synchronize on each level at once while reading properties.
      * Nesting synchronize between parent/child could lead to deadlocks.
      */
-    protected synchronized void mergeEventProperties(Map<String, String> mergedProperties) {
+    synchronized void mergeEventProperties(Map<String, String> mergedProperties) {
         for (Map.Entry<String, String> property : mEventProperties.entrySet()) {
             String key = property.getKey();
             if (!mergedProperties.containsKey(key)) {

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -8,15 +8,11 @@ import com.microsoft.appcenter.ingestion.models.Log;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -287,152 +283,5 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         assertFalse(grandParentTarget.isEnabledAsync().get());
         assertFalse(parentTarget.isEnabledAsync().get());
         assertFalse(childTarget.isEnabledAsync().get());
-    }
-
-    @Test
-    public void setCommonEventProperties() {
-
-        /* Create transmission target and add property. */
-        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-        target.setEventProperty("key", "value");
-
-        /* Track event without property. */
-        target.trackEvent("eventName");
-        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
-
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof EventLog) {
-                    EventLog eventLog = (EventLog) item;
-                    Map<String, String> expectedProperties = new HashMap<>();
-                    expectedProperties.put("key", "value");
-                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
-                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
-                    return nameAndPropertiesMatch && tokenMatch;
-                }
-                return false;
-            }
-        }), anyString());
-    }
-
-    @Test
-    public void setAndRemoveCommonEventPropertiesWithMerge() {
-
-        /* Create transmission target and add 2 properties (1 overwritten). */
-        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-        target.setEventProperty("key1", "value1");
-        target.setEventProperty("key2", "ignore");
-        target.setEventProperty("remove", "ignore");
-
-        /* Remove some properties. */
-        target.removeEventProperty("remove");
-        target.removeEventProperty("notFound");
-
-        /* Prepare properties. */
-        Map<String, String> properties = new HashMap<>();
-        properties.put("key2", "value2");
-        properties.put("key3", "value3");
-
-        /* Track event with extra properties. */
-        target.trackEvent("eventName", properties);
-        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
-
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof EventLog) {
-                    EventLog eventLog = (EventLog) item;
-                    Map<String, String> expectedProperties = new HashMap<>();
-                    expectedProperties.put("key1", "value1");
-                    expectedProperties.put("key2", "value2");
-                    expectedProperties.put("key3", "value3");
-                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
-                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
-                    return nameAndPropertiesMatch && tokenMatch;
-                }
-                return false;
-            }
-        }), anyString());
-    }
-
-    @Test
-    public void trackEventWithEmptyProperties() {
-
-        /* Create transmission target. */
-        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-
-        /* Track event with empty properties. */
-        target.trackEvent("eventName", Collections.<String, String>emptyMap());
-        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
-
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof EventLog) {
-                    EventLog eventLog = (EventLog) item;
-                    Map<String, String> expectedProperties = Collections.emptyMap();
-                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
-                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
-                    return nameAndPropertiesMatch && tokenMatch;
-                }
-                return false;
-            }
-        }), anyString());
-    }
-
-    @Test
-    public void eventPropertiesCascading() {
-
-        /* Create transmission target hierarchy. */
-        AnalyticsTransmissionTarget grandParent = Analytics.getTransmissionTarget("grandParent");
-        AnalyticsTransmissionTarget parent = grandParent.getTransmissionTarget("parent");
-        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
-
-        /* Set common properties across hierarchy with some overrides. */
-        grandParent.setEventProperty("a", "1");
-        grandParent.setEventProperty("b", "2");
-        grandParent.setEventProperty("c", "3");
-
-        /* Override some. */
-        parent.setEventProperty("a", "11");
-        parent.setEventProperty("b", "22");
-
-        /* And a new one. */
-        parent.setEventProperty("d", "44");
-
-        /* Just to show we still get value from grandParent if we remove an override. */
-        parent.setEventProperty("c", "33");
-        parent.removeEventProperty("c");
-
-        /* Overrides in child. */
-        child.setEventProperty("d", "444");
-
-        /* New in child. */
-        child.setEventProperty("e", "555");
-        child.setEventProperty("f", "666");
-
-        /* Track event in child. Override properties in trackEvent. */
-        Map<String, String> properties = new HashMap<>();
-        properties.put("f", "6666");
-        properties.put("g", "7777");
-        child.trackEvent("eventName", properties);
-
-        /* Verify log that was sent. */
-        ArgumentCaptor<EventLog> logArgumentCaptor = ArgumentCaptor.forClass(EventLog.class);
-        verify(mChannel).enqueue(logArgumentCaptor.capture(), anyString());
-        EventLog log = logArgumentCaptor.getValue();
-        assertNotNull(log);
-        assertEquals("eventName", log.getName());
-        assertEquals(1, log.getTransmissionTargetTokens().size());
-        assertTrue(log.getTransmissionTargetTokens().contains("child"));
-
-        /* Verify properties. */
-        Map<String, String> expectedProperties = new HashMap<>();
-        expectedProperties.put("a", "11");
-        expectedProperties.put("b", "22");
-        expectedProperties.put("c", "3");
-        expectedProperties.put("d", "444");
-        expectedProperties.put("e", "555");
-        expectedProperties.put("f", "6666");
-        expectedProperties.put("g", "7777");
-        assertEquals(expectedProperties, log.getProperties());
     }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -171,14 +171,13 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Create transmission target and add 2 properties (1 overwritten). */
         AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
-        PropertyConfigurator configurator = target.getPropertyConfigurator();
-        configurator.setEventProperty("key1", "value1");
-        configurator.setEventProperty("key2", "ignore");
-        configurator.setEventProperty("remove", "ignore");
+        target.getPropertyConfigurator().setEventProperty("key1", "value1");
+        target.getPropertyConfigurator().setEventProperty("key2", "ignore");
+        target.getPropertyConfigurator().setEventProperty("remove", "ignore");
 
         /* Remove some properties. */
-        configurator.removeEventProperty("remove");
-        configurator.removeEventProperty("notFound");
+        target.getPropertyConfigurator().removeEventProperty("remove");
+        target.getPropertyConfigurator().removeEventProperty("notFound");
 
         /* Prepare properties. */
         Map<String, String> properties = new HashMap<>();

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -12,11 +12,22 @@ import com.microsoft.appcenter.ingestion.models.one.Extensions;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
@@ -126,5 +137,154 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Verify no interactions with the log. */
         verifyNoMoreInteractions(log);
+    }
+
+
+    @Test
+    public void setCommonEventProperties() {
+
+        /* Create transmission target and add property. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+        target.getPropertyConfigurator().setEventProperty("key", "value");
+
+        /* Track event without property. */
+        target.trackEvent("eventName");
+        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    Map<String, String> expectedProperties = new HashMap<>();
+                    expectedProperties.put("key", "value");
+                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
+                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
+                    return nameAndPropertiesMatch && tokenMatch;
+                }
+                return false;
+            }
+        }), anyString());
+    }
+
+    @Test
+    public void setAndRemoveCommonEventPropertiesWithMerge() {
+
+        /* Create transmission target and add 2 properties (1 overwritten). */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+        PropertyConfigurator configurator = target.getPropertyConfigurator();
+        configurator.setEventProperty("key1", "value1");
+        configurator.setEventProperty("key2", "ignore");
+        configurator.setEventProperty("remove", "ignore");
+
+        /* Remove some properties. */
+        configurator.removeEventProperty("remove");
+        configurator.removeEventProperty("notFound");
+
+        /* Prepare properties. */
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key2", "value2");
+        properties.put("key3", "value3");
+
+        /* Track event with extra properties. */
+        target.trackEvent("eventName", properties);
+        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    Map<String, String> expectedProperties = new HashMap<>();
+                    expectedProperties.put("key1", "value1");
+                    expectedProperties.put("key2", "value2");
+                    expectedProperties.put("key3", "value3");
+                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
+                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
+                    return nameAndPropertiesMatch && tokenMatch;
+                }
+                return false;
+            }
+        }), anyString());
+    }
+
+    @Test
+    public void trackEventWithEmptyProperties() {
+
+        /* Create transmission target. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+
+        /* Track event with empty properties. */
+        target.trackEvent("eventName", Collections.<String, String>emptyMap());
+        verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
+
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof EventLog) {
+                    EventLog eventLog = (EventLog) item;
+                    Map<String, String> expectedProperties = Collections.emptyMap();
+                    boolean nameAndPropertiesMatch = eventLog.getName().equals("eventName") && expectedProperties.equals(eventLog.getProperties());
+                    boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("test");
+                    return nameAndPropertiesMatch && tokenMatch;
+                }
+                return false;
+            }
+        }), anyString());
+    }
+
+    @Test
+    public void eventPropertiesCascading() {
+
+        /* Create transmission target hierarchy. */
+        AnalyticsTransmissionTarget grandParent = Analytics.getTransmissionTarget("grandParent");
+        AnalyticsTransmissionTarget parent = grandParent.getTransmissionTarget("parent");
+        AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
+
+        /* Set common properties across hierarchy with some overrides. */
+        grandParent.getPropertyConfigurator().setEventProperty("a", "1");
+        grandParent.getPropertyConfigurator().setEventProperty("b", "2");
+        grandParent.getPropertyConfigurator().setEventProperty("c", "3");
+
+        /* Override some. */
+        parent.getPropertyConfigurator().setEventProperty("a", "11");
+        parent.getPropertyConfigurator().setEventProperty("b", "22");
+
+        /* And a new one. */
+        parent.getPropertyConfigurator().setEventProperty("d", "44");
+
+        /* Just to show we still get value from grandParent if we remove an override. */
+        parent.getPropertyConfigurator().setEventProperty("c", "33");
+        parent.getPropertyConfigurator().removeEventProperty("c");
+
+        /* Overrides in child. */
+        child.getPropertyConfigurator().setEventProperty("d", "444");
+
+        /* New in child. */
+        child.getPropertyConfigurator().setEventProperty("e", "555");
+        child.getPropertyConfigurator().setEventProperty("f", "666");
+
+        /* Track event in child. Override properties in trackEvent. */
+        Map<String, String> properties = new HashMap<>();
+        properties.put("f", "6666");
+        properties.put("g", "7777");
+        child.trackEvent("eventName", properties);
+
+        /* Verify log that was sent. */
+        ArgumentCaptor<EventLog> logArgumentCaptor = ArgumentCaptor.forClass(EventLog.class);
+        verify(mChannel).enqueue(logArgumentCaptor.capture(), anyString());
+        EventLog log = logArgumentCaptor.getValue();
+        assertNotNull(log);
+        assertEquals("eventName", log.getName());
+        assertEquals(1, log.getTransmissionTargetTokens().size());
+        assertTrue(log.getTransmissionTargetTokens().contains("child"));
+
+        /* Verify properties. */
+        Map<String, String> expectedProperties = new HashMap<>();
+        expectedProperties.put("a", "11");
+        expectedProperties.put("b", "22");
+        expectedProperties.put("c", "3");
+        expectedProperties.put("d", "444");
+        expectedProperties.put("e", "555");
+        expectedProperties.put("f", "6666");
+        expectedProperties.put("g", "7777");
+        assertEquals(expectedProperties, log.getProperties());
     }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -139,7 +139,6 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         verifyNoMoreInteractions(log);
     }
 
-
     @Test
     public void setCommonEventProperties() {
 


### PR DESCRIPTION
Since they behave generally the same way as other properties, they are being moved to the `PropertyConfigurator`.