### PR TITLE
Remove obsolete push code now that firebase is mandatory dependency

### DIFF
--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/TokenService.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/TokenService.java
@@ -1,67 +1,15 @@
 package com.microsoft.appcenter.push;
 
-import android.app.Service;
-import android.content.Context;
-import android.content.Intent;
-import android.os.IBinder;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
-
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.FirebaseInstanceIdService;
 
 /**
  * A service to handle the creation, rotation, and updating of registration tokens.
  */
-public class TokenService extends Service {
-
-    private final FirebaseInstanceIdService mFirebaseInstanceIdService;
-
-    @VisibleForTesting
-    class FirebaseInstanceIdServiceWrapper extends FirebaseInstanceIdService {
-
-        @Override
-        public Context getApplicationContext() {
-            return TokenService.this.getApplicationContext();
-        }
-
-        @Override
-        public void onTokenRefresh() {
-
-            /* Firebase presence already tested, avoid try/catch by using API directly. */
-            Push.getInstance().onTokenRefresh(FirebaseInstanceId.getInstance().getToken());
-        }
-    }
-
-    public TokenService() {
-
-        /* If Firebase not present, this service would crash, so that's why we wrap it. */
-        if (FirebaseUtils.isFirebaseAvailable()) {
-            mFirebaseInstanceIdService = new FirebaseInstanceIdServiceWrapper();
-        } else {
-            mFirebaseInstanceIdService = null;
-        }
-    }
-
-    @Nullable
-    @Override
-    public IBinder onBind(Intent intent) {
-        if (mFirebaseInstanceIdService != null) {
-            return mFirebaseInstanceIdService.onBind(intent);
-        }
-        return null;
-    }
+public class TokenService extends FirebaseInstanceIdService {
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        if (mFirebaseInstanceIdService != null) {
-            return mFirebaseInstanceIdService.onStartCommand(intent, flags, startId);
-        }
-        return super.onStartCommand(intent, flags, startId);
-    }
-
-    @VisibleForTesting
-    FirebaseInstanceIdService getFirebaseInstanceIdService() {
-        return mFirebaseInstanceIdService;
+    public void onTokenRefresh() {
+        Push.getInstance().onTokenRefresh(FirebaseInstanceId.getInstance().getToken());
     }
 }

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/TokenServiceTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/TokenServiceTest.java
@@ -1,10 +1,6 @@
 package com.microsoft.appcenter.push;
 
-import android.content.Context;
-import android.content.Intent;
-
 import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -13,15 +9,10 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @SuppressWarnings("unused")
 @PrepareForTest({
@@ -51,53 +42,12 @@ public class TokenServiceTest {
     @Test
     public void onTokenRefresh() {
         TokenService service = new TokenService();
-        FirebaseInstanceIdService firebaseInstanceIdService = service.getFirebaseInstanceIdService();
-        assertNotNull(firebaseInstanceIdService);
         when(mFirebaseInstanceId.getToken()).thenReturn(null);
-        firebaseInstanceIdService.onTokenRefresh();
+        service.onTokenRefresh();
         verify(mPush).onTokenRefresh(null);
         String testToken = "TEST";
         when(mFirebaseInstanceId.getToken()).thenReturn(testToken);
-        firebaseInstanceIdService.onTokenRefresh();
+        service.onTokenRefresh();
         verify(mPush).onTokenRefresh(eq(testToken));
-    }
-
-    @Test
-    public void getApplicationContext() {
-        final Context context = mock(Context.class);
-        TokenService service = new TokenService() {
-
-            @Override
-            public Context getApplicationContext() {
-                return context;
-            }
-        };
-        assertSame(context, service.getFirebaseInstanceIdService().getApplicationContext());
-    }
-
-    @Test
-    public void wrapperCallPassing() throws Exception {
-
-        /* Just check service public method calls are passed to Firebase. */
-        TokenService.FirebaseInstanceIdServiceWrapper wrapper = mock(TokenService.FirebaseInstanceIdServiceWrapper.class);
-        whenNew(TokenService.FirebaseInstanceIdServiceWrapper.class).withNoArguments().thenReturn(wrapper);
-        TokenService service = new TokenService();
-        assertSame(wrapper, service.getFirebaseInstanceIdService());
-        Intent intent = mock(Intent.class);
-        service.onBind(intent);
-        verify(wrapper).onBind(intent);
-        service.onStartCommand(intent, 0, 1);
-        verify(wrapper).onStartCommand(intent, 0, 1);
-    }
-
-    @Test
-    public void firebaseUnavailable() {
-
-        /* Just check it does not crash when no firebase. */
-        when(FirebaseInstanceId.getInstance()).thenReturn(null);
-        TokenService service = new TokenService();
-        service.onBind(mock(Intent.class));
-        service.onStartCommand(mock(Intent.class), 0, 1);
-        assertNull(service.getFirebaseInstanceIdService());
     }
 }


### PR DESCRIPTION
Will also be useful for an experiment to investigate an unexplained issue on Xamarin, to the very least to rule out the wrapper code as a cause.