### PR TITLE
Compile/target Android 9

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -4,7 +4,7 @@ ext {
     versionCode = 38
     versionName = '1.8.1'
     minSdkVersion = 15
-    targetSdkVersion = 27
-    compileSdkVersion = 27
+    targetSdkVersion = 28
+    compileSdkVersion = 28
     supportLibVersion = '27.1.1'
 }


### PR DESCRIPTION
No incidence on SDK library consumers, this mostly impacts test app.
Could not do it before as Android 9 was not supported in App Center build.