### PR TITLE
Set max storage size

### DIFF
--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -233,7 +233,7 @@ public class DatabasePersistenceAndroidTest {
     public void putLargeLogFailsToRead() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();
@@ -342,7 +342,7 @@ public class DatabasePersistenceAndroidTest {
     public void deleteLogs() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -233,7 +233,7 @@ public class DatabasePersistenceAndroidTest {
     public void putLargeLogFailsToRead() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();
@@ -283,7 +283,8 @@ public class DatabasePersistenceAndroidTest {
     public void putTooManyLogs() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 2, DatabasePersistence.SCHEMA, MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 2, DatabasePersistence.SCHEMA);
+        assertTrue(persistence.setMaxStorageSize(MAX_STORAGE_SIZE_IN_BYTES));
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();
@@ -346,7 +347,7 @@ public class DatabasePersistenceAndroidTest {
     public void deleteLogs() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -62,7 +62,7 @@ public class DatabasePersistenceAndroidTest {
     /**
      * Maximum storage size in bytes for unit test case.
      */
-    private static final int MAX_STORAGE_SIZE_IN_BYTES = 16385;
+    private static final int MAX_STORAGE_SIZE_IN_BYTES = 20480;
 
     /**
      * Context instance.

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -88,6 +88,13 @@ public class DatabasePersistenceAndroidTest {
         sContext.deleteDatabase(DatabasePersistence.DATABASE);
     }
 
+    @After
+    public void tearDown() {
+
+        /* Clean up database. */
+        sContext.deleteDatabase("test-persistence");
+    }
+
     private static int getIteratorSize(Iterator iterator) {
         int count = 0;
         for (; iterator.hasNext(); iterator.next())
@@ -124,8 +131,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(log, outputLogs.get(0));
             assertEquals(1, persistence.countLogs("test-p1"));
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -182,8 +187,6 @@ public class DatabasePersistenceAndroidTest {
             assertFalse(file.exists());
             assertFalse(file.getParentFile().exists());
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -223,8 +226,6 @@ public class DatabasePersistenceAndroidTest {
             /* Make sure database entry has been removed. */
             assertEquals(0, persistence.countLogs("test-p1"));
         } finally {
-
-            /* Close. */
             persistence.close();
 
             /* Restore path. */
@@ -276,8 +277,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(0, outputLogs.size());
             assertEquals(0, persistence.countLogs("test-p1"));
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -408,7 +407,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(0, persistence.countLogs("test-p1"));
         } finally {
 
-            /* Close. */
             //noinspection ThrowFromFinallyBlock
             persistence.close();
         }
@@ -430,8 +428,6 @@ public class DatabasePersistenceAndroidTest {
             Log log = AndroidTestUtils.generateMockLog();
             persistence.putLog("test-p1", log);
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -522,8 +518,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(1, persistence.countLogs("test-p3"));
 
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -585,8 +579,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(1, persistence.countLogs("test-p2"));
             assertEquals(0, persistence.countLogs("test-p3"));
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -634,7 +626,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(0, persistence.countLogs("test"));
         } finally {
 
-            /* Close. */
             //noinspection ThrowFromFinallyBlock
             persistence.close();
         }
@@ -695,8 +686,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(numberOfLogs / 2, outputLogs.size());
             assertEquals(2, persistence.mDatabaseStorage.size());
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -734,8 +723,6 @@ public class DatabasePersistenceAndroidTest {
             contentValues.put(DatabasePersistence.COLUMN_LOG, logSerializer.serializeLog(oldLog));
             databaseStorage.put(contentValues);
         } finally {
-
-            /* Close. */
             databaseStorage.close();
         }
 
@@ -764,8 +751,6 @@ public class DatabasePersistenceAndroidTest {
             /* Put new data with token. */
             persistence.putLog("test/one", commonSchemaLog);
         } finally {
-
-            /* Close. */
             persistence.close();
         }
 
@@ -788,8 +773,6 @@ public class DatabasePersistenceAndroidTest {
             assertNotEquals("test-guid", token);
             assertEquals("test-guid", CryptoUtils.getInstance(sContext).decrypt(token, false).getDecryptedData());
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -28,6 +28,7 @@ import com.microsoft.appcenter.utils.storage.StorageHelper;
 import com.microsoft.appcenter.utils.storage.StorageHelper.DatabaseStorage.DatabaseScanner;
 
 import org.json.JSONException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -322,8 +323,6 @@ public class DatabasePersistenceAndroidTest {
                 assertEquals(0, persistence.countLogs("test-p1"));
             }
         } finally {
-
-            /* Close. */
             persistence.close();
         }
     }
@@ -364,7 +363,6 @@ public class DatabasePersistenceAndroidTest {
             assertEquals(expectedLogs, outputLogs);
         } finally {
 
-            /* Close. */
             //noinspection ThrowFromFinallyBlock
             persistence.close();
         }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -233,7 +233,7 @@ public class DatabasePersistenceAndroidTest {
     public void putLargeLogFailsToRead() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();
@@ -342,7 +342,7 @@ public class DatabasePersistenceAndroidTest {
     public void deleteLogs() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/DatabasePersistenceAndroidTest.java
@@ -233,7 +233,7 @@ public class DatabasePersistenceAndroidTest {
     public void putLargeLogFailsToRead() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_CAPACITY);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();
@@ -342,7 +342,7 @@ public class DatabasePersistenceAndroidTest {
     public void deleteLogs() throws PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_CAPACITY);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
 
         /* Set a mock log serializer. */
         LogSerializer logSerializer = new DefaultLogSerializer();

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
@@ -44,7 +44,7 @@ public class PersistenceAndroidTest {
     public void missingLogSerializer() throws Persistence.PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA);
 
         //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
         try {

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
@@ -44,7 +44,7 @@ public class PersistenceAndroidTest {
     public void missingLogSerializer() throws Persistence.PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_CAPACITY);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
 
         //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
         try {

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
@@ -44,7 +44,7 @@ public class PersistenceAndroidTest {
     public void missingLogSerializer() throws Persistence.PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
         try {

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/persistence/PersistenceAndroidTest.java
@@ -44,7 +44,7 @@ public class PersistenceAndroidTest {
     public void missingLogSerializer() throws Persistence.PersistenceException {
 
         /* Initialize database persistence. */
-        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
+        DatabasePersistence persistence = new DatabasePersistence(sContext, 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
 
         //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
         try {

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
@@ -280,7 +280,8 @@ public class StorageHelperAndroidTest {
         assertEquals(2, databaseStorage.getScanner("COL_STRING_NULL", null).getCount());
 
         /* Update. */
-        assertTrue(databaseStorage.update(value1Id, value3));
+        // TODO We removed this method so we need to fix the rest of the test
+        //assertTrue(databaseStorage.update(value1Id, value3));
         ContentValues value3FromDatabase = databaseStorage.get(value1Id);
         assertContentValuesEquals(value3, value3FromDatabase);
 

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
@@ -779,7 +779,7 @@ public class StorageHelperAndroidTest {
         Log.i(TAG, "Testing Database Storage set maximum size");
 
         /* Get instance to access database. */
-        DatabaseStorage databaseStorage = DatabaseStorage.getDatabaseStorage("test-setMaximumSize", "test.setMaximumSize", 1, mSchema, MAX_SIZE_IN_BYTES, new DatabaseManager.Listener() {
+        DatabaseStorage databaseStorage = DatabaseStorage.getDatabaseStorage("test-setMaximumSize", "test.setMaximumSize", 1, mSchema, new DatabaseManager.Listener() {
 
             @Override
             public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
@@ -795,15 +795,12 @@ public class StorageHelperAndroidTest {
         //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
         try {
 
-            /* Check initial size. */
+            /* Test to change to an exact size as its multiple of 4KB. */
+            assertTrue(databaseStorage.setMaxStorageSize(MAX_SIZE_IN_BYTES));
             assertEquals(MAX_SIZE_IN_BYTES, databaseStorage.getMaxSize());
 
-            /* Test to change to an exact size as its multiple of 4KB. */
-            assertTrue(databaseStorage.setMaxStorageSize(MAX_SIZE_IN_BYTES * 2));
-            assertEquals(MAX_SIZE_IN_BYTES * 2, databaseStorage.getMaxSize());
-
             /* Test inexact value, it will use next multiple of 4KB. */
-            long desiredSize = MAX_SIZE_IN_BYTES * 3 + 1;
+            long desiredSize = MAX_SIZE_IN_BYTES * 2 + 1;
             assertTrue(databaseStorage.setMaxStorageSize(desiredSize));
             assertEquals(desiredSize - 1 + ALLOWED_SIZE_MULTIPLE, databaseStorage.getMaxSize());
 

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
@@ -279,12 +279,6 @@ public class StorageHelperAndroidTest {
         assertEquals(0, databaseStorage.getScanner("COL_STRING", null).getCount());
         assertEquals(2, databaseStorage.getScanner("COL_STRING_NULL", null).getCount());
 
-        /* Update. */
-        // TODO We removed this method so we need to fix the rest of the test
-        //assertTrue(databaseStorage.update(value1Id, value3));
-        ContentValues value3FromDatabase = databaseStorage.get(value1Id);
-        assertContentValuesEquals(value3, value3FromDatabase);
-
         /* Delete. */
         databaseStorage.delete(value1Id);
         assertNull(databaseStorage.get(value1Id));
@@ -680,49 +674,6 @@ public class StorageHelperAndroidTest {
         } finally {
 
             /* Close. */
-            databaseStorage.close();
-        }
-    }
-
-    @Test
-    public void putTooManyLogs() {
-        Log.i(TAG, "Testing Database Storage Capacity");
-
-        /* Get instance to access database. */
-        final int capacity = 2;
-        DatabaseStorage databaseStorage = DatabaseStorage.getDatabaseStorage("test-putTooManyLogs", "putTooManyLogs", 1, mSchema, capacity, new DatabaseManager.Listener() {
-
-            @Override
-            public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-                return false;
-            }
-
-            @Override
-            public void onError(String operation, RuntimeException e) {
-                throw e;
-            }
-        });
-
-        //noinspection TryFinallyCanBeTryWithResources (try with resources statement is API >= 19)
-        try {
-            ContentValues value1 = generateContentValues();
-            ContentValues value2 = generateContentValues();
-            ContentValues value3 = generateContentValues();
-
-            /* Put. */
-            Long value1Id = databaseStorage.put(value1);
-            Long value2Id = databaseStorage.put(value2);
-            Long value3Id = databaseStorage.put(value3);
-
-            assertNotNull(value1Id);
-            assertNotNull(value2Id);
-            assertNotNull(value3Id);
-
-            assertEquals(capacity, databaseStorage.size());
-        } finally {
-
-            /* Close. */
-            //noinspection ThrowFromFinallyBlock
             databaseStorage.close();
         }
     }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/StorageHelperAndroidTest.java
@@ -788,6 +788,7 @@ public class StorageHelperAndroidTest {
 
             @Override
             public void onError(String operation, RuntimeException e) {
+
                 /* Do not handle any errors. This is simulating errors so this is expected. */
             }
         });

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -56,7 +56,14 @@ public class AppCenter {
     /**
      * Default maximum storage size for SQLite database.
      */
-    private static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+    @VisibleForTesting
+    static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+
+    /**
+     * Minimum size allowed for set maximum size.
+     */
+    @VisibleForTesting
+    static final long MINIMUM_STORAGE_SIZE = 16385;
 
     /**
      * Group for sending logs.
@@ -497,17 +504,17 @@ public class AppCenter {
     private synchronized AppCenterFuture<Boolean> setInstanceStorageSizeAsync(long storageSizeInBytes) {
         DefaultAppCenterFuture<Boolean> setMaxStorageSizeFuture = new DefaultAppCenterFuture<>();
         if (mConfiguredFromApp) {
-            AppCenterLog.warn(LOG_TAG, "setStorageSize may not be called after App Center has been configured.");
+            AppCenterLog.error(LOG_TAG, "setStorageSize may not be called after App Center has been configured.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
-        if (storageSizeInBytes <= 0) {
-            AppCenterLog.error(LOG_TAG, "Storage size must be greater than 0.");
+        if (storageSizeInBytes < MINIMUM_STORAGE_SIZE) {
+            AppCenterLog.error(LOG_TAG, "Storage size must be greater than " + MINIMUM_STORAGE_SIZE + " bytes.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
         if (mSetMaxStorageSizeFuture != null) {
-            AppCenterLog.warn(LOG_TAG, "setStorageSize may only be called once per app launch.");
+            AppCenterLog.error(LOG_TAG, "setStorageSize may only be called once per app launch.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
@@ -709,9 +716,13 @@ public class AppCenter {
         mLogSerializer.addLogFactory(CustomPropertiesLog.TYPE, new CustomPropertiesLogFactory());
         mChannel = new DefaultChannel(mApplication, mAppSecret, mLogSerializer, mHandler);
 
-        /* Complete set maximum storage size future. */
+        /* Complete set maximum storage size future if starting from app. */
         if (configureFromApp) {
             applyStorageMaxSize();
+        } else {
+
+            /* If from library, we apply storage size only later, we have to try using the default value in the mean time. */
+            mChannel.setMaxStorageSize(DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
         }
         mChannel.setEnabled(enabled);
         mChannel.addGroup(CORE_GROUP, DEFAULT_TRIGGER_COUNT, DEFAULT_TRIGGER_INTERVAL, DEFAULT_TRIGGER_MAX_PARALLEL_REQUESTS, null, null);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -22,7 +22,6 @@ import com.microsoft.appcenter.ingestion.models.json.DefaultLogSerializer;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.ingestion.models.json.LogSerializer;
 import com.microsoft.appcenter.ingestion.models.json.StartServiceLogFactory;
-import com.microsoft.appcenter.persistence.DatabasePersistence;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.IdHelper;
@@ -170,7 +169,7 @@ public class AppCenter {
     /**
      * Max storage size in bytes.
      */
-    private long mMaxStorageSizeInBytes = DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES;
+    private long mMaxStorageSizeInBytes;
 
     /**
      * AppCenterFuture of set maximum storage size.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -175,12 +175,12 @@ public class AppCenter {
     /**
      * Max storage size in bytes.
      */
-    private long mMaxStorageSizeInBytes = Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES;
+    private long mMaxStorageSizeInBytes = Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES;
 
     /**
      * AppCenterFuture of set maximum storage size.
      */
-    private DefaultAppCenterFuture<Boolean> mSetStorageSizeFuture;
+    private DefaultAppCenterFuture<Boolean> mSetMaxStorageSizeFuture;
 
     /**
      * Get unique instance.
@@ -494,26 +494,26 @@ public class AppCenter {
      * @param storageSizeInBytes size to set SQLite database to in bytes.
      * @return future of result of set maximum storage size.
      */
-    private synchronized AppCenterFuture<Boolean> setInstanceStorageSizeAsync(final long storageSizeInBytes) {
-        mSetStorageSizeFuture = new DefaultAppCenterFuture<>();
+    private synchronized AppCenterFuture<Boolean> setInstanceStorageSizeAsync(long storageSizeInBytes) {
+        mSetMaxStorageSizeFuture = new DefaultAppCenterFuture<>();
         if (mConfiguredFromApp) {
             AppCenterLog.warn(LOG_TAG, "setStorageSize may not be called after App Center has been configured.");
-            mSetStorageSizeFuture.complete(false);
-            return mSetStorageSizeFuture;
+            mSetMaxStorageSizeFuture.complete(false);
+            return mSetMaxStorageSizeFuture;
         }
         if (storageSizeInBytes <= 0) {
             AppCenterLog.error(LOG_TAG, "Storage size must be greater than 0.");
-            mSetStorageSizeFuture.complete(false);
-            return mSetStorageSizeFuture;
+            mSetMaxStorageSizeFuture.complete(false);
+            return mSetMaxStorageSizeFuture;
         }
         if (mSetStorageSizeWasCalled) {
             AppCenterLog.warn(LOG_TAG, "setStorageSize may only be called once per app launch.");
-            mSetStorageSizeFuture.complete(false);
-            return mSetStorageSizeFuture;
+            mSetMaxStorageSizeFuture.complete(false);
+            return mSetMaxStorageSizeFuture;
         }
         mMaxStorageSizeInBytes = storageSizeInBytes;
         mSetStorageSizeWasCalled = true;
-        return mSetStorageSizeFuture;
+        return mSetMaxStorageSizeFuture;
     }
 
     /**
@@ -572,8 +572,8 @@ public class AppCenter {
                     @Override
                     public void run() {
                         mChannel.setAppSecret(mAppSecret);
-                        if (mSetStorageSizeFuture != null) {
-                            mSetStorageSizeFuture.complete(mChannel.setMaxStorageSize(mMaxStorageSizeInBytes));
+                        if (mSetMaxStorageSizeFuture != null) {
+                            mSetMaxStorageSizeFuture.complete(mChannel.setMaxStorageSize(mMaxStorageSizeInBytes));
                         }
                     }
                 });
@@ -712,8 +712,8 @@ public class AppCenter {
         mChannel = new DefaultChannel(mApplication, mAppSecret, mLogSerializer, mHandler);
 
         /* Complete set maximum storage size future. */
-        if (mSetStorageSizeFuture != null) {
-            mSetStorageSizeFuture.complete(mChannel.setMaxStorageSize(mMaxStorageSizeInBytes));
+        if (mSetMaxStorageSizeFuture != null) {
+            mSetMaxStorageSizeFuture.complete(mChannel.setMaxStorageSize(mMaxStorageSizeInBytes));
         }
         mChannel.setEnabled(enabled);
         mChannel.addGroup(CORE_GROUP, DEFAULT_TRIGGER_COUNT, DEFAULT_TRIGGER_INTERVAL, DEFAULT_TRIGGER_MAX_PARALLEL_REQUESTS, null, null);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -510,8 +510,8 @@ public class AppCenter {
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
-        if (storageSizeInBytes < MINIMUM_STORAGE_SIZE) {
-            AppCenterLog.error(LOG_TAG, "Storage size must be greater than " + MINIMUM_STORAGE_SIZE + " bytes.");
+        if (storageSizeInBytes <= MINIMUM_STORAGE_SIZE) {
+            AppCenterLog.error(LOG_TAG, "Storage size must be at least " + MINIMUM_STORAGE_SIZE + " bytes.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -510,8 +510,8 @@ public class AppCenter {
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
-        if (storageSizeInBytes <= MINIMUM_STORAGE_SIZE) {
-            AppCenterLog.error(LOG_TAG, "Storage size must be at least " + MINIMUM_STORAGE_SIZE + " bytes.");
+        if (storageSizeInBytes < MINIMUM_STORAGE_SIZE) {
+            AppCenterLog.error(LOG_TAG, "Maximum storage size must be at least " + MINIMUM_STORAGE_SIZE + " bytes.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -395,13 +395,15 @@ public class AppCenter {
      * is smaller than the previous size (database is shrinking) and the capacity is greater than
      * the new size, then the operation will fail and a warning will be emitted. Can only be called
      * once per app lifetime and only before AppCenter.start(...).
+     * <p>
+     * If the size is not a multiple of 4096 bytes, the next multiple of 4096 is used as the new maximum size.
      *
      * @param storageSizeInBytes New size for the SQLite db in bytes.
      * @return Future with true result if succeeded, otherwise future with false result.
      */
     @SuppressWarnings("WeakerAccess") // TODO remove annotation when updating demo app for release.
-    public static AppCenterFuture<Boolean> setStorageSize(long storageSizeInBytes) {
-        return getInstance().setInstanceStorageSizeAsync(storageSizeInBytes);
+    public static AppCenterFuture<Boolean> setMaxStorageSize(long storageSizeInBytes) {
+        return getInstance().setInstanceMaxStorageSizeAsync(storageSizeInBytes);
     }
 
     /**
@@ -496,15 +498,15 @@ public class AppCenter {
     }
 
     /**
-     * {@link #setStorageSize(long)} implementation at instance level.
+     * {@link #setMaxStorageSize(long)} implementation at instance level.
      *
      * @param storageSizeInBytes size to set SQLite database to in bytes.
      * @return future of result of set maximum storage size.
      */
-    private synchronized AppCenterFuture<Boolean> setInstanceStorageSizeAsync(long storageSizeInBytes) {
+    private synchronized AppCenterFuture<Boolean> setInstanceMaxStorageSizeAsync(long storageSizeInBytes) {
         DefaultAppCenterFuture<Boolean> setMaxStorageSizeFuture = new DefaultAppCenterFuture<>();
         if (mConfiguredFromApp) {
-            AppCenterLog.error(LOG_TAG, "setStorageSize may not be called after App Center has been configured.");
+            AppCenterLog.error(LOG_TAG, "setMaxStorageSize may not be called after App Center has been configured.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }
@@ -514,7 +516,7 @@ public class AppCenter {
             return setMaxStorageSizeFuture;
         }
         if (mSetMaxStorageSizeFuture != null) {
-            AppCenterLog.error(LOG_TAG, "setStorageSize may only be called once per app launch.");
+            AppCenterLog.error(LOG_TAG, "setMaxStorageSize may only be called once per app launch.");
             setMaxStorageSizeFuture.complete(false);
             return setMaxStorageSizeFuture;
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -60,10 +60,11 @@ public class AppCenter {
     static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
 
     /**
-     * Minimum size allowed for set maximum size.
+     * Minimum size allowed for set maximum size (SQL limitation). setMaxStorageSize could accept values
+     * as low as 16385 but in practice the lowest size set is the next highest multiple of 4096.
      */
     @VisibleForTesting
-    static final long MINIMUM_STORAGE_SIZE = 16385;
+    static final long MINIMUM_STORAGE_SIZE = 20480;
 
     /**
      * Group for sending logs.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -85,11 +85,6 @@ public class AppCenter {
     static final String TRANSMISSION_TARGET_TOKEN_KEY = "target";
 
     /**
-     * Storage size used when setStorageSize is not called. Equal to 10Mib.
-     */
-    static final long DEFAULT_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
-
-    /**
      * Shared instance.
      */
     @SuppressLint("StaticFieldLeak")
@@ -505,6 +500,7 @@ public class AppCenter {
         }
 
         //TODO write storage size logic
+        mStorageSizeInBytes = storageSizeInBytes;
         DatabaseManager dm = new DatabaseManager()
         mSetStorageSizeWasCalled = true;
         return null;
@@ -689,7 +685,7 @@ public class AppCenter {
 
         /* Set storage size if not already configured. */
         if (!mSetStorageSizeWasCalled) {
-            setStorageSize(mApplication, DEFAULT_STORAGE_SIZE_IN_BYTES);
+            setStorageSize(mApplication, DatabaseManager.DEFAULT_STORAGE_SIZE_IN_BYTES);
         }
 
         /* If parameters are valid, init context related resources. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
@@ -19,6 +19,14 @@ public interface Channel {
     void setAppSecret(@NonNull String appSecret);
 
     /**
+     * Set maximum SQLite database size.
+     *
+     * @param maxStorageSizeInBytes Maximum SQLite database size.
+     * @return true if database size was set, otherwise false.
+     */
+    boolean setMaxStorageSize(long maxStorageSizeInBytes);
+
+    /**
      * Add a group for logs to be persisted and sent.
      *
      * @param groupName          the name of a group.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
@@ -21,7 +21,7 @@ public interface Channel {
     /**
      * Set maximum SQLite database size.
      *
-     * @param maxStorageSizeInBytes Maximum SQLite database size.
+     * @param maxStorageSizeInBytes maximum SQLite database size in bytes.
      * @return true if database size was set, otherwise false.
      */
     boolean setMaxStorageSize(long maxStorageSizeInBytes);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -6,7 +6,6 @@ import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.CancellationException;
 import com.microsoft.appcenter.http.HttpUtils;
 import com.microsoft.appcenter.http.ServiceCallback;
@@ -121,8 +120,8 @@ public class DefaultChannel implements Channel {
      * @param logSerializer    The log serializer.
      * @param appCenterHandler App Center looper thread handler.
      */
-    public DefaultChannel(@NonNull Context context, String appSecret, @NonNull LogSerializer logSerializer, @NonNull Handler appCenterHandler, long maxStorageSizeInBytes) {
-        this(context, appSecret, buildDefaultPersistence(context, logSerializer, maxStorageSizeInBytes), new AppCenterIngestion(context, logSerializer), appCenterHandler);
+    public DefaultChannel(@NonNull Context context, String appSecret, @NonNull LogSerializer logSerializer, @NonNull Handler appCenterHandler) {
+        this(context, appSecret, buildDefaultPersistence(context, logSerializer), new AppCenterIngestion(context, logSerializer), appCenterHandler);
     }
 
     /**
@@ -152,10 +151,15 @@ public class DefaultChannel implements Channel {
     /**
      * Init Persistence for default constructor.
      */
-    private static Persistence buildDefaultPersistence(@NonNull Context context, @NonNull LogSerializer logSerializer, long maxStorageSizeInBytes) {
-        Persistence persistence = new DatabasePersistence(context, maxStorageSizeInBytes);
+    private static Persistence buildDefaultPersistence(@NonNull Context context, @NonNull LogSerializer logSerializer) {
+        Persistence persistence = new DatabasePersistence(context);
         persistence.setLogSerializer(logSerializer);
         return persistence;
+    }
+
+    @Override
+    public boolean setMaxStorageSize(long maxStorageSizeInBytes) {
+        return mPersistence.setMaxStorageSize(maxStorageSizeInBytes);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -6,6 +6,7 @@ import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.CancellationException;
 import com.microsoft.appcenter.http.HttpUtils;
 import com.microsoft.appcenter.http.ServiceCallback;
@@ -120,8 +121,8 @@ public class DefaultChannel implements Channel {
      * @param logSerializer    The log serializer.
      * @param appCenterHandler App Center looper thread handler.
      */
-    public DefaultChannel(@NonNull Context context, String appSecret, @NonNull LogSerializer logSerializer, @NonNull Handler appCenterHandler) {
-        this(context, appSecret, buildDefaultPersistence(context, logSerializer), new AppCenterIngestion(context, logSerializer), appCenterHandler);
+    public DefaultChannel(@NonNull Context context, String appSecret, @NonNull LogSerializer logSerializer, @NonNull Handler appCenterHandler, long maxStorageSizeInBytes) {
+        this(context, appSecret, buildDefaultPersistence(context, logSerializer, maxStorageSizeInBytes), new AppCenterIngestion(context, logSerializer), appCenterHandler);
     }
 
     /**
@@ -151,8 +152,8 @@ public class DefaultChannel implements Channel {
     /**
      * Init Persistence for default constructor.
      */
-    private static Persistence buildDefaultPersistence(@NonNull Context context, @NonNull LogSerializer logSerializer) {
-        Persistence persistence = new DatabasePersistence(context);
+    private static Persistence buildDefaultPersistence(@NonNull Context context, @NonNull LogSerializer logSerializer, long maxStorageSizeInBytes) {
+        Persistence persistence = new DatabasePersistence(context, maxStorageSizeInBytes);
         persistence.setLogSerializer(logSerializer);
         return persistence;
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
@@ -132,7 +132,7 @@ public class DatabasePersistence extends Persistence {
      * @param context application context.
      */
     public DatabasePersistence(Context context) {
-        this(context, VERSION, SCHEMA, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES);
+        this(context, VERSION, SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
@@ -41,6 +41,11 @@ public class DatabasePersistence extends Persistence {
     private static final int VERSION = 2;
 
     /**
+     * Default maximum storage size for SQLite database.
+     */
+    public static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+
+    /**
      * Name of group column in the table.
      */
     @VisibleForTesting
@@ -127,12 +132,12 @@ public class DatabasePersistence extends Persistence {
     private final File mLargePayloadDirectory;
 
     /**
-     * Initializes variables with default storage size.
+     * Initializes variables with default values.
      *
      * @param context application context.
      */
     public DatabasePersistence(Context context) {
-        this(context, VERSION, SCHEMA, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        this(context, VERSION, SCHEMA, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
     }
 
     /**
@@ -141,7 +146,7 @@ public class DatabasePersistence extends Persistence {
      * @param context               application context.
      * @param version               The version of current schema.
      * @param schema                schema.
-     * @param maxStorageSizeInBytes The maximum number of records allowed in the table.
+     * @param maxStorageSizeInBytes the maximum SQLite database storage size in bytes.
      */
     @SuppressWarnings("SameParameterValue")
     DatabasePersistence(Context context, int version, ContentValues schema, long maxStorageSizeInBytes) {
@@ -208,7 +213,7 @@ public class DatabasePersistence extends Persistence {
             String targetToken;
             if (log instanceof CommonSchemaLog) {
                 if (isLargePayload) {
-                    throw new PersistenceException("Log is larger than " + PAYLOAD_MAX_SIZE + "b, cannot send to OneCollector.");
+                    throw new PersistenceException("Log is larger than " + PAYLOAD_MAX_SIZE + " bytes, cannot send to OneCollector.");
                 }
                 targetToken = log.getTransmissionTargetTokens().iterator().next();
                 targetToken = CryptoUtils.getInstance(mContext).encrypt(targetToken);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
@@ -127,16 +127,6 @@ public class DatabasePersistence extends Persistence {
     private final File mLargePayloadDirectory;
 
     /**
-     * Initializes variables.
-     *
-     * @param context application context.
-     * @param maxStorageSizeInBytes Max storage size.
-     */
-    public DatabasePersistence(Context context, long maxStorageSizeInBytes) {
-        this(context, VERSION, SCHEMA, maxStorageSizeInBytes);
-    }
-
-    /**
      * Initializes variables with default storage size.
      *
      * @param context application context.
@@ -182,6 +172,11 @@ public class DatabasePersistence extends Persistence {
 
         //noinspection ResultOfMethodCallIgnored we handle errors at read/write time for each file.
         mLargePayloadDirectory.mkdirs();
+    }
+
+    @Override
+    public boolean setMaxStorageSize(long maxStorageSizeInBytes) {
+        return mDatabaseStorage.setMaxStorageSize(maxStorageSizeInBytes);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
@@ -137,9 +137,10 @@ public class DatabasePersistence extends Persistence {
 
     /**
      * Initializes variables.
-     *  @param context               application context.
-     * @param version               The version of current schema.
-     * @param schema                schema.
+     *
+     * @param context application context.
+     * @param version The version of current schema.
+     * @param schema  schema.
      */
     @SuppressWarnings("SameParameterValue")
     DatabasePersistence(Context context, int version, ContentValues schema) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/DatabasePersistence.java
@@ -41,11 +41,6 @@ public class DatabasePersistence extends Persistence {
     private static final int VERSION = 2;
 
     /**
-     * Default maximum storage size for SQLite database.
-     */
-    public static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
-
-    /**
      * Name of group column in the table.
      */
     @VisibleForTesting
@@ -137,42 +132,39 @@ public class DatabasePersistence extends Persistence {
      * @param context application context.
      */
     public DatabasePersistence(Context context) {
-        this(context, VERSION, SCHEMA, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+        this(context, VERSION, SCHEMA);
     }
 
     /**
      * Initializes variables.
-     *
-     * @param context               application context.
+     *  @param context               application context.
      * @param version               The version of current schema.
      * @param schema                schema.
-     * @param maxStorageSizeInBytes the maximum SQLite database storage size in bytes.
      */
     @SuppressWarnings("SameParameterValue")
-    DatabasePersistence(Context context, int version, ContentValues schema, long maxStorageSizeInBytes) {
+    DatabasePersistence(Context context, int version, ContentValues schema) {
         mContext = context;
         mPendingDbIdentifiersGroups = new HashMap<>();
         mPendingDbIdentifiers = new HashSet<>();
-        mDatabaseStorage = DatabaseStorage.getDatabaseStorage(DATABASE, TABLE, version, schema, maxStorageSizeInBytes,
-                new DatabaseManager.Listener() {
+        mDatabaseStorage = DatabaseStorage.getDatabaseStorage(DATABASE, TABLE, version, schema, new DatabaseManager.Listener() {
 
-                    @Override
-                    public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            @Override
+            public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 
-                        /*
-                         * This is called only on upgrade and thus only if oldVersion is < 2.
-                         * Therefore we don't have to check anything to add the missing columns.
-                         */
-                        db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN `" + COLUMN_TARGET_TOKEN + "` TEXT");
-                        db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN `" + COLUMN_DATA_TYPE + "` TEXT");
-                        return true;
-                    }
+                /*
+                 * This is called only on upgrade and thus only if oldVersion is < 2.
+                 * Therefore we don't have to check anything to add the missing columns.
+                 */
+                db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN `" + COLUMN_TARGET_TOKEN + "` TEXT");
+                db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN `" + COLUMN_DATA_TYPE + "` TEXT");
+                return true;
+            }
 
-                    @Override
-                    public void onError(String operation, RuntimeException e) {
-                        AppCenterLog.error(LOG_TAG, "Cannot complete an operation (" + operation + ")", e);
-                    }
-                });
+            @Override
+            public void onError(String operation, RuntimeException e) {
+                AppCenterLog.error(LOG_TAG, "Cannot complete an operation (" + operation + ")", e);
+            }
+        });
         mLargePayloadDirectory = new File(Constants.FILES_PATH + PAYLOAD_LARGE_DIRECTORY);
 
         //noinspection ResultOfMethodCallIgnored we handle errors at read/write time for each file.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
@@ -16,11 +16,6 @@ import java.util.List;
 public abstract class Persistence implements Closeable {
 
     /**
-     * Default maximum storage size for SQLite database.
-     */
-    public static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
-
-    /**
      * Log serializer override.
      */
     private LogSerializer mLogSerializer;
@@ -111,7 +106,7 @@ public abstract class Persistence implements Closeable {
             super(detailMessage, throwable);
         }
 
-        public PersistenceException(String detailMessage) {
+        PersistenceException(String detailMessage) {
             super(detailMessage);
         }
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
@@ -16,9 +16,9 @@ import java.util.List;
 public abstract class Persistence implements Closeable {
 
     /**
-     * Storage capacity in number of logs.
+     * Default max storage size for SQLite database.
      */
-    static final int DEFAULT_CAPACITY = 300;
+    public static final long DEFAULT_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
 
     /**
      * Log serializer override.
@@ -101,6 +101,10 @@ public abstract class Persistence implements Closeable {
     public static class PersistenceException extends Exception {
         public PersistenceException(String detailMessage, Throwable throwable) {
             super(detailMessage, throwable);
+        }
+
+        public PersistenceException(String detailMessage) {
+            super(detailMessage);
         }
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
@@ -96,6 +96,14 @@ public abstract class Persistence implements Closeable {
     }
 
     /**
+     * Set maximum SQLite database size.
+     *
+     * @param maxStorageSizeInBytes Maximum SQLite database size.
+     * @return true if database size was set, otherwise false.
+     */
+    public abstract boolean setMaxStorageSize(long maxStorageSizeInBytes);
+
+    /**
      * Thrown when {@link Persistence} cannot write a log to the storage.
      */
     public static class PersistenceException extends Exception {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/persistence/Persistence.java
@@ -16,9 +16,9 @@ import java.util.List;
 public abstract class Persistence implements Closeable {
 
     /**
-     * Default max storage size for SQLite database.
+     * Default maximum storage size for SQLite database.
      */
-    public static final long DEFAULT_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+    public static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
 
     /**
      * Log serializer override.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -528,7 +528,7 @@ public class DatabaseManager implements Closeable {
 
         /* So to check the resize works, we need to check new max size against the next multiple of 4KB. */
         if (newMaxSize != expectedMultipleMaxSize) {
-            AppCenterLog.error(LOG_TAG, "Could not change database size, current size is " + newMaxSize + " bytes.");
+            AppCenterLog.error(LOG_TAG, "Could not change database size to " + maxStorageSizeInBytes + " bytes, current max size is " + newMaxSize + " bytes.");
             return false;
         }
         if (maxStorageSizeInBytes != newMaxSize) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -515,7 +515,7 @@ public class DatabaseManager implements Closeable {
      * @param maxStorageSizeInBytes Maximum SQLite database size.
      * @return true if database size was set, otherwise false.
      */
-    boolean setMaxStorageSize(long maxStorageSizeInBytes) {
+    boolean setMaxSize(long maxStorageSizeInBytes) {
         SQLiteDatabase db = getDatabase();
         long newMaxSize = db.setMaximumSize(maxStorageSizeInBytes);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -92,7 +92,7 @@ public class DatabaseManager implements Closeable {
      * @param listener         The error listener.
      */
     DatabaseManager(Context context, String database, String table, int version,
-                    ContentValues schema, final long maxDbSizeInBytes, Listener listener) {
+                    ContentValues schema, long maxDbSizeInBytes, Listener listener) {
         mContext = context;
         mDatabase = database;
         mTable = table;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -89,7 +89,6 @@ public class DatabaseManager implements Closeable {
      */
     private long mIMDBAutoInc;
 
-
     /**
      * Initializes the table in the database.
      *
@@ -521,10 +520,7 @@ public class DatabaseManager implements Closeable {
         long newMaxSize = db.setMaximumSize(maxStorageSizeInBytes);
 
         /* SQLite always use the next multiple of 4KB as maximum size. */
-        long expectedMultipleMaxSize = maxStorageSizeInBytes / ALLOWED_SIZE_MULTIPLE * ALLOWED_SIZE_MULTIPLE;
-        if (expectedMultipleMaxSize != maxStorageSizeInBytes) {
-            expectedMultipleMaxSize += ALLOWED_SIZE_MULTIPLE;
-        }
+        long expectedMultipleMaxSize = (long)Math.ceil((double)maxStorageSizeInBytes / (double)ALLOWED_SIZE_MULTIPLE) * ALLOWED_SIZE_MULTIPLE;
 
         /* So to check the resize works, we need to check new max size against the next multiple of 4KB. */
         if (newMaxSize != expectedMultipleMaxSize) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
@@ -730,6 +730,16 @@ public class StorageHelper {
         }
 
         /**
+         * Gets the maximum size of the database.
+         *
+         * @return The maximum size of database in bytes.
+         */
+        @SuppressWarnings("unused")
+        public long getMaxSize() {
+            return mDatabaseManager.getMaxSize();
+        }
+
+        /**
          * Gets an array of column names in the table.
          *
          * @return An array of column names.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
@@ -578,28 +578,7 @@ public class StorageHelper {
                                                          @IntRange(from = 1) int version,
                                                          @NonNull ContentValues schema,
                                                          @NonNull DatabaseManager.Listener listener) {
-            return getDatabaseStorage(database, table, version, schema, 0, listener);
-        }
-
-        /**
-         * Get a new instance of {@code DatabaseManager}.
-         *
-         * @param database       The database name.
-         * @param table          The table name.
-         * @param version        The version.
-         * @param schema         The schema of the database. If the database has more than one table,
-         *                       it should contain schemas for all tables.
-         * @param maxSizeInBytes The maximum allowed database size.
-         * @param listener       The database listener.
-         * @return database storage.
-         */
-        public static DatabaseStorage getDatabaseStorage(@NonNull String database,
-                                                         @NonNull String table,
-                                                         @IntRange(from = 1) int version,
-                                                         @NonNull ContentValues schema,
-                                                         @IntRange(from = 0) long maxSizeInBytes,
-                                                         @NonNull DatabaseManager.Listener listener) {
-            return new DatabaseStorage(new DatabaseManager(sContext, database, table, version, schema, maxSizeInBytes, listener));
+            return new DatabaseStorage(new DatabaseManager(sContext, database, table, version, schema, listener));
         }
 
         /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
@@ -603,6 +603,15 @@ public class StorageHelper {
         }
 
         /**
+         * Set maximum SQLite database size.
+         *
+         * @param maxStorageSizeInBytes Maximum SQLite database size.
+         */
+        public boolean setMaxStorageSize(long maxStorageSizeInBytes) {
+            return mDatabaseManager.setMaxStorageSize(maxStorageSizeInBytes);
+        }
+
+        /**
          * Store an entry in a table.
          *
          * @param values The entry to be stored.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
@@ -584,22 +584,22 @@ public class StorageHelper {
         /**
          * Get a new instance of {@code DatabaseManager}.
          *
-         * @param database   The database name.
-         * @param table      The table name.
-         * @param version    The version.
-         * @param schema     The schema of the database. If the database has more than one table,
-         *                   it should contain schemas for all tables.
-         * @param maxRecords The maximum number of records allowed in the table.
-         * @param listener   The database listener.
+         * @param database       The database name.
+         * @param table          The table name.
+         * @param version        The version.
+         * @param schema         The schema of the database. If the database has more than one table,
+         *                       it should contain schemas for all tables.
+         * @param maxSizeInBytes The maximum allowed database size.
+         * @param listener       The database listener.
          * @return database storage.
          */
         public static DatabaseStorage getDatabaseStorage(@NonNull String database,
                                                          @NonNull String table,
                                                          @IntRange(from = 1) int version,
                                                          @NonNull ContentValues schema,
-                                                         @IntRange(from = 0) int maxRecords,
+                                                         @IntRange(from = 0) long maxSizeInBytes,
                                                          @NonNull DatabaseManager.Listener listener) {
-            return new DatabaseStorage(new DatabaseManager(sContext, database, table, version, schema, maxRecords, listener));
+            return new DatabaseStorage(new DatabaseManager(sContext, database, table, version, schema, maxSizeInBytes, listener));
         }
 
         /**
@@ -610,17 +610,6 @@ public class StorageHelper {
          */
         public long put(@NonNull ContentValues values) {
             return mDatabaseManager.put(values);
-        }
-
-        /**
-         * Update an entry in a table.
-         *
-         * @param id     The existing database identifier.
-         * @param values The value to update.
-         * @return {@code true} if the values were updated successfully, {@code false} otherwise.
-         */
-        public boolean update(@IntRange(from = 0) long id, @NonNull ContentValues values) {
-            return mDatabaseManager.update(id, values);
         }
 
         /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/StorageHelper.java
@@ -587,7 +587,7 @@ public class StorageHelper {
          * @param maxStorageSizeInBytes Maximum SQLite database size.
          */
         public boolean setMaxStorageSize(long maxStorageSizeInBytes) {
-            return mDatabaseManager.setMaxStorageSize(maxStorageSizeInBytes);
+            return mDatabaseManager.setMaxSize(maxStorageSizeInBytes);
         }
 
         /**

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AbstractAppCenterTest.java
@@ -165,7 +165,7 @@ public class AbstractAppCenterTest {
 
         /* Mock empty database. */
         StorageHelper.DatabaseStorage databaseStorage = mock(StorageHelper.DatabaseStorage.class);
-        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class), anyInt(), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
+        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
         StorageHelper.DatabaseStorage.DatabaseScanner databaseScanner = mock(StorageHelper.DatabaseStorage.DatabaseScanner.class);
         when(databaseStorage.getScanner(anyString(), anyObject())).thenReturn(databaseScanner);
         when(databaseScanner.iterator()).thenReturn(mDataBaseScannerIterator);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterLibraryTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterLibraryTest.java
@@ -90,6 +90,9 @@ public class AppCenterLibraryTest extends AbstractAppCenterTest {
         verify(mChannel, never()).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
         verify(mChannel, never()).setAppSecret(anyString());
 
+        /* Libraries have to use the default max storage size. */
+        verify(mChannel).setMaxStorageSize(AppCenter.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+
         /* Verify state. */
         assertTrue(DummyService.isEnabled().get());
         assertFalse(AnotherDummyService.isEnabled().get());
@@ -124,7 +127,7 @@ public class AppCenterLibraryTest extends AbstractAppCenterTest {
         services.add(AnotherDummyService.getInstance().getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
 
-        /* Verify channel updated with app secret. */
+        /* Verify channel updated with app secret and storage size. */
         verify(mChannel).setAppSecret(DUMMY_APP_SECRET);
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterStorageTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterStorageTest.java
@@ -1,0 +1,71 @@
+package com.microsoft.appcenter;
+
+import com.microsoft.appcenter.utils.async.AppCenterFuture;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class AppCenterStorageTest extends AbstractAppCenterTest {
+
+    @Test
+    public void configureValidStorageSizeFromApp() {
+
+        /* Set up storage to succeed resize. */
+        when(mChannel.setMaxStorageSize(anyLong())).thenReturn(true);
+
+        /* Configure before start. */
+        AppCenterFuture<Boolean> future = AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
+
+        /* Verify the operation is still pending. */
+        assertFalse(future.isDone());
+
+        /* Since the call is registered, we cannot change our mind anymore. */
+        assertFalse(AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE + 1).get());
+
+        /* Start AppCenter. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+
+        /* Verify storage size applied. */
+        verify(mChannel).setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
+
+        /* And result returned to developer. */
+        assertTrue(future.get());
+    }
+
+    @Test
+    public void configureInvalidStorageSizeFromApp() {
+
+        /* Set up storage to succeed resize. */
+        when(mChannel.setMaxStorageSize(anyLong())).thenReturn(false);
+
+        /* Configure before start. */
+        AppCenterFuture<Boolean> future = AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE - 1);
+
+        /* Verify the operation is immediately failed. */
+        assertFalse(future.get());
+
+        /* Configure invalid size does not prevent us from trying again with valid size. */
+        configureValidStorageSizeFromApp();
+    }
+
+    @Test
+    public void cannotConfigureAfterStart() {
+
+        /* Set up storage to succeed resize. */
+        when(mChannel.setMaxStorageSize(anyLong())).thenReturn(true);
+
+        /* Start AppCenter. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+
+        /* Configure after start immediately fails. */
+        assertFalse(AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE).get());
+
+        /* Verify default storage size is used. */
+        verify(mChannel).setMaxStorageSize(AppCenter.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
+    }
+}

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterStorageTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterStorageTest.java
@@ -20,13 +20,13 @@ public class AppCenterStorageTest extends AbstractAppCenterTest {
         when(mChannel.setMaxStorageSize(anyLong())).thenReturn(true);
 
         /* Configure before start. */
-        AppCenterFuture<Boolean> future = AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
+        AppCenterFuture<Boolean> future = AppCenter.setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
 
         /* Verify the operation is still pending. */
         assertFalse(future.isDone());
 
         /* Since the call is registered, we cannot change our mind anymore. */
-        assertFalse(AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE + 1).get());
+        assertFalse(AppCenter.setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE + 1).get());
 
         /* Start AppCenter. */
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
@@ -45,7 +45,7 @@ public class AppCenterStorageTest extends AbstractAppCenterTest {
         when(mChannel.setMaxStorageSize(anyLong())).thenReturn(false);
 
         /* Configure before start. */
-        AppCenterFuture<Boolean> future = AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE - 1);
+        AppCenterFuture<Boolean> future = AppCenter.setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE - 1);
 
         /* Verify the operation is immediately failed. */
         assertFalse(future.get());
@@ -64,7 +64,7 @@ public class AppCenterStorageTest extends AbstractAppCenterTest {
         AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
 
         /* Configure after start immediately fails. */
-        assertFalse(AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE).get());
+        assertFalse(AppCenter.setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE).get());
 
         /* Verify default storage size is used. */
         verify(mChannel).setMaxStorageSize(AppCenter.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
@@ -77,7 +77,7 @@ public class AppCenterStorageTest extends AbstractAppCenterTest {
         when(mChannel.setMaxStorageSize(anyLong())).thenReturn(true);
 
         /* Configure before start. */
-        AppCenterFuture<Boolean> future = AppCenter.setStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
+        AppCenterFuture<Boolean> future = AppCenter.setMaxStorageSize(AppCenter.MINIMUM_STORAGE_SIZE);
 
         /* Verify the operation is still pending. */
         assertFalse(future.isDone());

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -90,6 +90,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         verify(service).onStarted(any(Context.class), any(Channel.class), eq(DUMMY_APP_SECRET), isNull(String.class), eq(true));
         verify(mApplication).registerActivityLifecycleCallbacks(service);
         verify(mChannel).enqueue(eq(mStartServiceLog), eq(CORE_GROUP));
+        verify(mChannel).setMaxStorageSize(AppCenter.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES);
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelOtherOperationsTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelOtherOperationsTest.java
@@ -1,20 +1,27 @@
 package com.microsoft.appcenter.channel;
 
+import android.content.ContentValues;
 import android.content.Context;
 
 import com.microsoft.appcenter.ingestion.AppCenterIngestion;
 import com.microsoft.appcenter.ingestion.Ingestion;
 import com.microsoft.appcenter.ingestion.models.Log;
+import com.microsoft.appcenter.persistence.DatabasePersistence;
 import com.microsoft.appcenter.persistence.Persistence;
 import com.microsoft.appcenter.utils.UUIDUtils;
+import com.microsoft.appcenter.utils.storage.DatabaseManager;
+import com.microsoft.appcenter.utils.storage.StorageHelper;
 
 import org.junit.Test;
 import org.mockito.Matchers;
 
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
@@ -23,6 +30,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 public class DefaultChannelOtherOperationsTest extends AbstractDefaultChannelTest {
@@ -185,5 +193,18 @@ public class DefaultChannelOtherOperationsTest extends AbstractDefaultChannelTes
         verify(listener).onGroupAdded(TEST_GROUP, groupListener);
         channel.removeGroup(TEST_GROUP);
         verify(listener).onGroupRemoved(TEST_GROUP);
+    }
+
+    @Test
+    public void checkSetStorageSizeForwarding() {
+
+        /* The real Android test for checking size is in StorageHelperAndroidTest. */
+        Persistence persistence = mock(Persistence.class);
+        when(persistence.setMaxStorageSize(anyLong())).thenReturn(true).thenReturn(false);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, mock(Ingestion.class), mAppCenterHandler);
+
+        /* Just checks calls are forwarded to the low level database layer. */
+        assertTrue(channel.setMaxStorageSize(20480));
+        assertFalse(channel.setMaxStorageSize(2));
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
@@ -52,7 +52,7 @@ public class DatabasePersistenceTest {
         mockStatic(AppCenterLog.class);
         LogSerializer mockSerializer = mock(DefaultLogSerializer.class);
         when(mockSerializer.serializeLog(any(Log.class))).thenReturn("{}");
-        DatabasePersistence mockPersistence = spy(new DatabasePersistence(mock(Context.class), 1, DatabasePersistence.SCHEMA, Persistence.DEFAULT_CAPACITY));
+        DatabasePersistence mockPersistence = spy(new DatabasePersistence(mock(Context.class), 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES));
         doReturn(mockSerializer).when(mockPersistence).getLogSerializer();
         try {
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
@@ -54,7 +54,7 @@ public class DatabasePersistenceTest {
         mockStatic(AppCenterLog.class);
         LogSerializer mockSerializer = mock(DefaultLogSerializer.class);
         when(mockSerializer.serializeLog(any(Log.class))).thenReturn("{}");
-        DatabasePersistence mockPersistence = spy(new DatabasePersistence(mock(Context.class), 1, DatabasePersistence.SCHEMA, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES));
+        DatabasePersistence mockPersistence = spy(new DatabasePersistence(mock(Context.class), 1, DatabasePersistence.SCHEMA));
         doReturn(mockSerializer).when(mockPersistence).getLogSerializer();
         try {
 
@@ -95,8 +95,7 @@ public class DatabasePersistenceTest {
         /* Mock instances. */
         mockStatic(StorageHelper.DatabaseStorage.class);
         StorageHelper.DatabaseStorage mockDatabaseStorage = mock(StorageHelper.DatabaseStorage.class);
-        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class),
-                anyInt(), any(DatabaseManager.Listener.class))).thenReturn(mockDatabaseStorage);
+        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class), any(DatabaseManager.Listener.class))).thenReturn(mockDatabaseStorage);
 
         for (int i = 0; i < groupCount; i++) {
             StorageHelper.DatabaseStorage.DatabaseScanner mockDatabaseScanner = mock(StorageHelper.DatabaseStorage.DatabaseScanner.class);
@@ -133,8 +132,7 @@ public class DatabasePersistenceTest {
         int logCount = 3;
         mockStatic(StorageHelper.DatabaseStorage.class);
         StorageHelper.DatabaseStorage databaseStorage = mock(StorageHelper.DatabaseStorage.class);
-        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class),
-                anyInt(), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
+        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
 
         /* Make 3 logs, the second one will be corrupted. */
         Collection<ContentValues> fieldValues = new ArrayList<>(logCount);
@@ -269,8 +267,7 @@ public class DatabasePersistenceTest {
         /* The real Android test for checking size is in StorageHelperAndroidTest. */
         mockStatic(StorageHelper.DatabaseStorage.class);
         StorageHelper.DatabaseStorage databaseStorage = mock(StorageHelper.DatabaseStorage.class);
-        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class),
-                anyInt(), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
+        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
         when(databaseStorage.setMaxStorageSize(anyLong())).thenReturn(true).thenReturn(false);
 
         /* Just checks calls are forwarded to the low level database layer. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/persistence/DatabasePersistenceTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import static com.microsoft.appcenter.persistence.DatabasePersistence.COLUMN_GROUP;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -259,5 +261,21 @@ public class DatabasePersistenceTest {
 
         /* Verify that the only log we deleted in the entire test was the one from previous test (id=1). */
         verify(databaseStorage).delete(anyLong());
+    }
+
+    @Test
+    public void checkSetStorageSizeForwarding() {
+
+        /* The real Android test for checking size is in StorageHelperAndroidTest. */
+        mockStatic(StorageHelper.DatabaseStorage.class);
+        StorageHelper.DatabaseStorage databaseStorage = mock(StorageHelper.DatabaseStorage.class);
+        when(StorageHelper.DatabaseStorage.getDatabaseStorage(anyString(), anyString(), anyInt(), any(ContentValues.class),
+                anyInt(), any(DatabaseManager.Listener.class))).thenReturn(databaseStorage);
+        when(databaseStorage.setMaxStorageSize(anyLong())).thenReturn(true).thenReturn(false);
+
+        /* Just checks calls are forwarded to the low level database layer. */
+        DatabasePersistence persistence = new DatabasePersistence(mock(Context.class));
+        assertTrue(persistence.setMaxStorageSize(20480));
+        assertFalse(persistence.setMaxStorageSize(2));
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 
-import static com.microsoft.appcenter.persistence.DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -42,7 +41,7 @@ public class DatabaseManagerTest {
     private static DatabaseManager getDatabaseManagerMock() {
 
         /* Mocking(spying) instance. */
-        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, null);
         DatabaseManager databaseManagerMock = spy(databaseManager);
         when(databaseManagerMock.getDatabase()).thenThrow(new RuntimeException());
         return databaseManagerMock;
@@ -75,7 +74,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing but closing working. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -93,7 +92,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing and closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -111,7 +110,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -235,7 +234,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenReturn(mock(SQLiteDatabase.class));
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */
@@ -255,7 +254,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenThrow(new RuntimeException());
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */
@@ -269,7 +268,7 @@ public class DatabaseManagerTest {
         Context contextMock = mock(Context.class);
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = spy(new DatabaseManager(contextMock, "database", "table", 1, null, DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+        DatabaseManager databaseManager = spy(new DatabaseManager(contextMock, "database", "table", 1, null, null));
         databaseManager.switchToInMemory("test", null);
 
         /* Put a first value, the test will eventually evict this one after inserting many more and hitting the limit. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
@@ -7,6 +7,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
 
+import com.microsoft.appcenter.persistence.Persistence;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.internal.stubbing.answers.Returns;
@@ -42,7 +44,7 @@ public class DatabaseManagerTest {
     private static DatabaseManager getDatabaseManagerMock() {
 
         /* Mocking(spying) instance. */
-        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, null);
+        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
         DatabaseManager databaseManagerMock = spy(databaseManager);
         when(databaseManagerMock.getDatabase()).thenThrow(new RuntimeException());
         return databaseManagerMock;
@@ -59,7 +61,8 @@ public class DatabaseManagerTest {
 
         /* Update. */
         databaseManagerMock = getDatabaseManagerMock();
-        databaseManagerMock.update(0, new ContentValues());
+        // TODO We removed this method so we need to fix the rest of the test
+        //databaseManagerMock.update(0, new ContentValues());
         verify(databaseManagerMock).switchToInMemory(eq("update"), any(RuntimeException.class));
 
         /* Get. */
@@ -80,7 +83,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing but closing working. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -98,7 +101,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing and closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -116,7 +119,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -207,18 +210,6 @@ public class DatabaseManagerTest {
         databaseManagerMock.get(DatabaseManager.PRIMARY_KEY, null);
     }
 
-    @Test
-    public void updateFailure() {
-        /* Update returns 0 or less. */
-        DatabaseManager databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, null));
-        SQLiteDatabase sQLiteDatabaseMock = mock(SQLiteDatabase.class);
-        when(databaseManagerMock.getDatabase()).thenReturn(sQLiteDatabaseMock);
-        when(sQLiteDatabaseMock.update(anyString(), any(ContentValues.class), anyString(), any(String[].class))).thenReturn(-1);
-
-        /* Verify. */
-        assertFalse(databaseManagerMock.update(0, new ContentValues()));
-    }
-
     @Test(expected = UnsupportedOperationException.class)
     public void scannerRemoveInMemoryDB() {
         DatabaseManager databaseManagerMock;
@@ -252,7 +243,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenReturn(mock(SQLiteDatabase.class));
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */
@@ -272,7 +263,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenThrow(new RuntimeException());
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
 
-import com.microsoft.appcenter.persistence.Persistence;
+import com.microsoft.appcenter.persistence.DatabasePersistence;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +43,7 @@ public class DatabaseManagerTest {
     private static DatabaseManager getDatabaseManagerMock() {
 
         /* Mocking(spying) instance. */
-        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         DatabaseManager databaseManagerMock = spy(databaseManager);
         when(databaseManagerMock.getDatabase()).thenThrow(new RuntimeException());
         return databaseManagerMock;
@@ -57,12 +57,6 @@ public class DatabaseManagerTest {
         databaseManagerMock = getDatabaseManagerMock();
         databaseManagerMock.put(new ContentValues());
         verify(databaseManagerMock).switchToInMemory(eq("put"), any(RuntimeException.class));
-
-        /* Update. */
-        databaseManagerMock = getDatabaseManagerMock();
-        // TODO We removed this method so we need to fix the rest of the test
-        //databaseManagerMock.update(0, new ContentValues());
-        verify(databaseManagerMock).switchToInMemory(eq("update"), any(RuntimeException.class));
 
         /* Get. */
         databaseManagerMock = getDatabaseManagerMock();
@@ -82,7 +76,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing but closing working. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -100,7 +94,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing and closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -118,7 +112,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -242,7 +236,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenReturn(mock(SQLiteDatabase.class));
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */
@@ -262,7 +256,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenThrow(new RuntimeException());
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, DatabasePersistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DatabaseManagerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -44,7 +43,7 @@ public class DatabaseManagerTest {
     private static DatabaseManager getDatabaseManagerMock() {
 
         /* Mocking(spying) instance. */
-        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         DatabaseManager databaseManagerMock = spy(databaseManager);
         when(databaseManagerMock.getDatabase()).thenThrow(new RuntimeException());
         return databaseManagerMock;
@@ -83,7 +82,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing but closing working. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -101,7 +100,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor next failing and closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -119,7 +118,7 @@ public class DatabaseManagerTest {
         }
         {
             /* Cursor closing failing. */
-            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null));
+            databaseManagerMock = spy(new DatabaseManager(null, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null));
             when(databaseManagerMock.getDatabase()).thenReturn(mock(SQLiteDatabase.class));
             mockStatic(SQLiteUtils.class);
             Cursor cursor = mock(Cursor.class);
@@ -243,7 +242,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenReturn(mock(SQLiteDatabase.class));
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */
@@ -263,7 +262,7 @@ public class DatabaseManagerTest {
         when(helperMock.getWritableDatabase()).thenThrow(new RuntimeException()).thenThrow(new RuntimeException());
 
         /* Instantiate real instance for DatabaseManager. */
-        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_STORAGE_SIZE_IN_BYTES, null);
+        DatabaseManager databaseManager = new DatabaseManager(contextMock, "database", "table", 1, null, Persistence.DEFAULT_MAX_STORAGE_SIZE_IN_BYTES, null);
         databaseManager.setSQLiteOpenHelper(helperMock);
 
         /* Get database. */


### PR DESCRIPTION
Adding setMaxStorageSize API to core module with the following behaviors:

- Set the storage size to a given amount, in bytes, rounded up to the nearest 4KB.
- Return value is "true" if the storage size was set to the next multiple of 4kB or false otherwise.
- If the number of logs currently stored is already larger than the new storage size, the size won't be set.
- The minimum storage size allowed is 20KB (20480 bytes) (SQL limitation).
- When new logs are inserted while the storage is full, the oldest logs will be discarded until the new log fits.
- If a log is larger than the entire storage size, all logs will be removed from storage, and the new log will be discarded.  This decision was made because calculating the size of individual logs already in storage is a very expensive operation.