### PR TITLE
Feature/pause resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### AppCenterAnalytics
 
+* **[Feature]** Added `pause`/`resume` APIs which pause/resume sending Analytics logs to App Center.
 * **[Feature]** Preparation work for a future change in transmission protocol and endpoint for Analytics data. There is no impact on your current workflow when using App Center.
 
 ## Version 1.8.0

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -621,14 +621,14 @@ public class Analytics extends AbstractAppCenterService {
      */
     private synchronized AppCenterFuture<Void> pauseInstanceAsync() {
         final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
-        post(new Runnable() {
+        postAsyncGetter(new Runnable() {
 
             @Override
             public void run() {
                 mChannel.pauseGroup(ANALYTICS_GROUP);
                 future.complete(null);
             }
-        });
+        }, future, null);
         return future;
     }
 
@@ -637,14 +637,14 @@ public class Analytics extends AbstractAppCenterService {
      */
     private synchronized AppCenterFuture<Void> resumeInstanceAsync() {
         final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
-        post(new Runnable() {
+        postAsyncGetter(new Runnable() {
 
             @Override
             public void run() {
                 mChannel.resumeGroup(ANALYTICS_GROUP);
                 future.complete(null);
             }
-        });
+        }, future, null);
         return future;
     }
 

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -167,6 +167,24 @@ public class Analytics extends AbstractAppCenterService {
     }
 
     /**
+     * Pauses log transmission.
+     *
+     * @return future with null result to monitor when the operation completes.
+     */
+    public static AppCenterFuture<Void> pause() {
+        return getInstance().pauseInstanceAsync();
+    }
+
+    /**
+     * Resumes log transmission if paused.
+     *
+     * @return future with null result to monitor when the operation completes.
+     */
+    public static AppCenterFuture<Void> resume() {
+        return getInstance().resumeInstanceAsync();
+    }
+
+    /**
      * Sets an analytics listener.
      * <p>
      * Note: it needs to be protected for Xamarin to change it back to public in bindings.
@@ -596,6 +614,40 @@ public class Analytics extends AbstractAppCenterService {
      */
     private synchronized void setInstanceListener(AnalyticsListener listener) {
         mAnalyticsListener = listener;
+    }
+
+    /**
+     * Implements {@link #pause()}}.
+     */
+    private synchronized AppCenterFuture<Void> pauseInstanceAsync() {
+        final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
+        Runnable runnable = new Runnable() {
+
+            @Override
+            public void run() {
+                mChannel.pauseGroup(ANALYTICS_GROUP);
+                future.complete(null);
+            }
+        };
+        post(runnable);
+        return future;
+    }
+
+    /**
+     * Implements {@link #resume()}}.
+     */
+    private synchronized AppCenterFuture<Void> resumeInstanceAsync() {
+        final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
+        Runnable runnable = new Runnable() {
+
+            @Override
+            public void run() {
+                mChannel.resumeGroup(ANALYTICS_GROUP);
+                future.complete(null);
+            }
+        };
+        post(runnable);
+        return future;
     }
 
     @VisibleForTesting

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -621,15 +621,14 @@ public class Analytics extends AbstractAppCenterService {
      */
     private synchronized AppCenterFuture<Void> pauseInstanceAsync() {
         final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
-        Runnable runnable = new Runnable() {
+        post(new Runnable() {
 
             @Override
             public void run() {
                 mChannel.pauseGroup(ANALYTICS_GROUP);
                 future.complete(null);
             }
-        };
-        post(runnable);
+        });
         return future;
     }
 
@@ -638,15 +637,14 @@ public class Analytics extends AbstractAppCenterService {
      */
     private synchronized AppCenterFuture<Void> resumeInstanceAsync() {
         final DefaultAppCenterFuture<Void> future = new DefaultAppCenterFuture<>();
-        Runnable runnable = new Runnable() {
+        post(new Runnable() {
 
             @Override
             public void run() {
                 mChannel.resumeGroup(ANALYTICS_GROUP);
                 future.complete(null);
             }
-        };
-        post(runnable);
+        });
         return future;
     }
 

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -352,7 +352,7 @@ public class AnalyticsTest extends AbstractAnalyticsTest {
         /* Check if Analytics group is paused. */
         verify(channel).pauseGroup(eq(analytics.getGroupName()));
 
-        /* Now try to use all methods. Should work. */
+        /* Send logs to verify the logs are enqueued after pause. */
         Analytics.trackEvent("test");
         Analytics.trackPage("test");
         verify(channel, times(2)).enqueue(any(Log.class), eq(analytics.getGroupName()));
@@ -363,7 +363,7 @@ public class AnalyticsTest extends AbstractAnalyticsTest {
         /* Check if Analytics group is resumed. */
         verify(channel).resumeGroup(eq(analytics.getGroupName()));
 
-        /* Now try to use all methods. Should work. */
+        /* Send logs to verify the logs are enqueued after resume. */
         Analytics.trackEvent("test");
         Analytics.trackPage("test");
         verify(channel, times(4)).enqueue(any(Log.class), eq(analytics.getGroupName()));

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/Channel.java
@@ -46,6 +46,20 @@ public interface Channel {
     void removeGroup(String groupName);
 
     /**
+     * Pauses the given group.
+     *
+     * @param groupName the name of a group.
+     */
+    void pauseGroup(String groupName);
+
+    /**
+     * Resumes transmission for the given group.
+     *
+     * @param groupName the name of a group.
+     */
+    void resumeGroup(String groupName);
+
+    /**
      * Add Log to queue to be persisted and sent.
      *
      * @param log       the Log to be enqueued.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -379,7 +379,8 @@ public class DefaultChannel implements Channel {
         }
     }
 
-    private void cancelTimer(GroupState groupState) {
+    @VisibleForTesting
+    void cancelTimer(GroupState groupState) {
         if (groupState.mScheduled) {
             groupState.mScheduled = false;
             mAppCenterHandler.removeCallbacks(groupState.mRunnable);
@@ -669,7 +670,8 @@ public class DefaultChannel implements Channel {
      *
      * @param groupName the group name.
      */
-    private synchronized void checkPendingLogs(@NonNull String groupName) {
+    @VisibleForTesting
+    synchronized void checkPendingLogs(@NonNull String groupName) {
         GroupState groupState = mGroupStates.get(groupName);
         if (groupState.mPaused) {
             AppCenterLog.debug(LOG_TAG, groupName + " is paused. Skip checking pending logs.");
@@ -683,6 +685,11 @@ public class DefaultChannel implements Channel {
             groupState.mScheduled = true;
             mAppCenterHandler.postDelayed(groupState.mRunnable, groupState.mBatchTimeInterval);
         }
+    }
+
+    @VisibleForTesting
+    GroupState getGroupState(String groupName) {
+        return mGroupStates.get(groupName);
     }
 
     @Override
@@ -703,7 +710,8 @@ public class DefaultChannel implements Channel {
     /**
      * State for a specific log group.
      */
-    private class GroupState {
+    @VisibleForTesting
+    class GroupState {
 
         /**
          * Group name

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -671,6 +671,10 @@ public class DefaultChannel implements Channel {
      */
     private synchronized void checkPendingLogs(@NonNull String groupName) {
         GroupState groupState = mGroupStates.get(groupName);
+        if (groupState.mPaused) {
+            AppCenterLog.debug(LOG_TAG, groupName + " is paused. Skip checking pending logs.");
+            return;
+        }
         long pendingLogCount = groupState.mPendingLogCount;
         AppCenterLog.debug(LOG_TAG, "checkPendingLogs(" + groupName + ") pendingLogCount=" + pendingLogCount);
         if (pendingLogCount >= groupState.mMaxLogsPerBatch) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -235,9 +235,9 @@ public class DefaultChannel implements Channel {
 
     @Override
     public synchronized void pauseGroup(String groupName) {
-        AppCenterLog.debug(LOG_TAG, "pauseGroup(" + groupName + ")");
         GroupState groupState = mGroupStates.get(groupName);
         if (groupState != null && !groupState.mPaused) {
+            AppCenterLog.debug(LOG_TAG, "pauseGroup(" + groupName + ")");
             groupState.mPaused = true;
             cancelTimer(groupState);
         }
@@ -245,9 +245,9 @@ public class DefaultChannel implements Channel {
 
     @Override
     public synchronized void resumeGroup(String groupName) {
-        AppCenterLog.debug(LOG_TAG, "resumeGroup(" + groupName + ")");
         GroupState groupState = mGroupStates.get(groupName);
         if (groupState != null && groupState.mPaused) {
+            AppCenterLog.debug(LOG_TAG, "resumeGroup(" + groupName + ")");
             groupState.mPaused = false;
             checkPendingLogs(groupState.mName);
         }
@@ -793,7 +793,6 @@ public class DefaultChannel implements Channel {
             mMaxParallelBatches = maxParallelBatches;
             mIngestion = ingestion;
             mListener = listener;
-            mPaused = false;
         }
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
@@ -720,6 +721,108 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.enqueue(mock(Log.class), TEST_GROUP);
 
         verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
+    }
+
+    @Test
+    public void pauseResumeGroup() throws Persistence.PersistenceException {
+        Persistence mockPersistence = mock(Persistence.class);
+        AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
+        Channel.GroupListener mockListener = mock(Channel.GroupListener.class);
+
+        when(mockPersistence.getLogs(any(String.class), anyInt(), any(ArrayList.class))).then(getGetLogsAnswer(50));
+        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
+
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
+        channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
+        assertFalse(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Pause group. */
+        channel.pauseGroup(TEST_GROUP);
+        assertTrue(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Enqueue a log. */
+        for (int i = 0; i < 50; i++) {
+            channel.enqueue(mock(Log.class), TEST_GROUP);
+        }
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
+
+        /* 50 logs are persisted but never being sent to Ingestion. */
+        assertEquals(50, channel.getCounter(TEST_GROUP));
+        verify(mockPersistence, times(50)).putLog(eq(TEST_GROUP), any(Log.class));
+        verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
+        verify(mockListener, never()).onBeforeSending(any(Log.class));
+        verify(mockListener, never()).onSuccess(any(Log.class));
+
+        /* The counter should still be 50 now as we did NOT send data. */
+        assertEquals(50, channel.getCounter(TEST_GROUP));
+
+        /* Resume group. */
+        channel.resumeGroup(TEST_GROUP);
+        assertFalse(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Verify channel starts sending logs. */
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
+        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
+        verify(mockListener, times(50)).onBeforeSending(any(Log.class));
+        verify(mockListener, times(50)).onSuccess(any(Log.class));
+
+        /* The counter should be 0 now as we sent data. */
+        assertEquals(0, channel.getCounter(TEST_GROUP));
+    }
+
+    @Test
+    public void pauseGroupTwice() {
+        DefaultChannel channel = spy(new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mock(Persistence.class), mock(AppCenterIngestion.class), mAppCenterHandler));
+        channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mock(Channel.GroupListener.class));
+        assertFalse(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Pause group twice. */
+        channel.pauseGroup(TEST_GROUP);
+        assertTrue(channel.getGroupState(TEST_GROUP).mPaused);
+        channel.pauseGroup(TEST_GROUP);
+        assertTrue(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Verify the group is paused only once. */
+        verify(channel).cancelTimer(any(DefaultChannel.GroupState.class));
+    }
+
+    @Test
+    public void resumeGroupWhileNotPaused() {
+        DefaultChannel channel = spy(new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mock(Persistence.class), mock(AppCenterIngestion.class), mAppCenterHandler));
+        channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mock(Channel.GroupListener.class));
+        verify(channel).checkPendingLogs(eq(TEST_GROUP));
+        assertFalse(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Resume group. */
+        channel.resumeGroup(TEST_GROUP);
+        assertFalse(channel.getGroupState(TEST_GROUP).mPaused);
+
+        /* Verify resumeGroup doesn't resume the group while un-paused.  */
+        verify(channel).checkPendingLogs(eq(TEST_GROUP));
+    }
+
+    @Test
+    public void pauseGroupWhileDisabled() {
+        DefaultChannel channel = spy(new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mock(Persistence.class), mock(AppCenterIngestion.class), mAppCenterHandler));
+
+        /* Pause group twice. */
+        channel.pauseGroup(TEST_GROUP);
+
+        /* Verify the group is NOT paused. */
+        verify(channel, never()).cancelTimer(any(DefaultChannel.GroupState.class));
+    }
+
+    @Test
+    public void resumeGroupWhileDisabled() {
+        DefaultChannel channel = spy(new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mock(Persistence.class), mock(AppCenterIngestion.class), mAppCenterHandler));
+
+        /* Resume group. */
+        channel.resumeGroup(TEST_GROUP);
+
+        /* Verify the group is NOT resumed.  */
+        verify(channel, never()).checkPendingLogs(eq(TEST_GROUP));
     }
 
     @Test


### PR DESCRIPTION
Adding `pause` and `resume` APIs at Analytics level.  Calling `pause` will stop the SDK from sending logs to App Center backend and saves them until `resume` is called.  Then we resume sending the logs