### PR TITLE
Fix creating a target right after AppCenter.start

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventActivity.java
@@ -48,6 +48,9 @@ public class EventActivity extends LogActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        /* Test start from library. */
+        AppCenter.startFromLibrary(this, Analytics.class);
+
         /* Transmission target views init. */
         mTransmissionTargetSpinner = findViewById(R.id.transmission_target);
         ArrayAdapter<String> targetAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, getResources().getStringArray(R.array.target_id_names));
@@ -100,9 +103,6 @@ public class EventActivity extends LogActivity {
                 startActivity(intent);
             }
         });
-
-        /* Test start from library. */
-        AppCenter.startFromLibrary(this, Analytics.class);
     }
 
     @Override

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.Analytics;
 import com.microsoft.appcenter.analytics.AnalyticsPrivateHelper;
+import com.microsoft.appcenter.analytics.AnalyticsTransmissionTarget;
 import com.microsoft.appcenter.analytics.channel.AnalyticsListener;
 import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.crashes.CrashesListener;
@@ -107,6 +108,15 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        // TODO revert block before PR
+        AppCenter.startFromLibrary(this, Analytics.class);
+        AnalyticsTransmissionTarget test = Analytics.getTransmissionTarget("0eac643c981e48e8afeb29d9df5593e1-cb0ac72d-a4c4-41a3-b032-9f5ae7b64460-7166");
+        test = test.getTransmissionTarget("4ee5ab442b354e6abebd166820bd8fef-88dbb064-f5f9-4dec-a428-d34062307511-8016");
+        test.getPropertyConfigurator().collectDeviceId();
+        AppCenter.setEnabled(false);
+        AppCenter.setEnabled(true);
+        test.trackEvent("test");
+
         sSharedPreferences = getSharedPreferences("Sasquatch", Context.MODE_PRIVATE);
         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectDiskReads().detectDiskWrites().build());
         StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().build());
@@ -153,7 +163,7 @@ public class MainActivity extends AppCompatActivity {
 
         /* Start App Center. */
         String startType = sSharedPreferences.getString(APPCENTER_START_TYPE, StartType.APP_SECRET.toString());
-        startAppCenter(getApplication(), startType);
+        //startAppCenter(getApplication(), startType);
 
         /* Attach NDK Crash Handler after SDK is initialized. */
         Crashes.getMinidumpDirectory().thenAccept(new AppCenterConsumer<String>() {
@@ -232,7 +242,7 @@ public class MainActivity extends AppCompatActivity {
 
                     /* SQLite always use the next multiple of 4KB as maximum size. */
                     final int ALLOWED_SIZE_MULTIPLE = 4096;
-                    long expectedMultipleMaxSize = (long)Math.ceil((double)maxStorageSize / (double)ALLOWED_SIZE_MULTIPLE) * ALLOWED_SIZE_MULTIPLE;
+                    long expectedMultipleMaxSize = (long) Math.ceil((double) maxStorageSize / (double) ALLOWED_SIZE_MULTIPLE) * ALLOWED_SIZE_MULTIPLE;
 
                     Toast.makeText(MainActivity.this, String.format(
                             MainActivity.this.getString(R.string.max_storage_size_change_success),

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -22,7 +22,6 @@ import android.widget.Toast;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.Analytics;
 import com.microsoft.appcenter.analytics.AnalyticsPrivateHelper;
-import com.microsoft.appcenter.analytics.AnalyticsTransmissionTarget;
 import com.microsoft.appcenter.analytics.channel.AnalyticsListener;
 import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.crashes.CrashesListener;
@@ -108,15 +107,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        // TODO revert block before PR
-        AppCenter.startFromLibrary(this, Analytics.class);
-        AnalyticsTransmissionTarget test = Analytics.getTransmissionTarget("0eac643c981e48e8afeb29d9df5593e1-cb0ac72d-a4c4-41a3-b032-9f5ae7b64460-7166");
-        test = test.getTransmissionTarget("4ee5ab442b354e6abebd166820bd8fef-88dbb064-f5f9-4dec-a428-d34062307511-8016");
-        test.getPropertyConfigurator().collectDeviceId();
-        AppCenter.setEnabled(false);
-        AppCenter.setEnabled(true);
-        test.trackEvent("test");
-
         sSharedPreferences = getSharedPreferences("Sasquatch", Context.MODE_PRIVATE);
         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectDiskReads().detectDiskWrites().build());
         StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().build());
@@ -163,7 +153,7 @@ public class MainActivity extends AppCompatActivity {
 
         /* Start App Center. */
         String startType = sSharedPreferences.getString(APPCENTER_START_TYPE, StartType.APP_SECRET.toString());
-        //startAppCenter(getApplication(), startType);
+        startAppCenter(getApplication(), startType);
 
         /* Attach NDK Crash Handler after SDK is initialized. */
         Crashes.getMinidumpDirectory().thenAccept(new AppCenterConsumer<String>() {
@@ -223,12 +213,15 @@ public class MainActivity extends AppCompatActivity {
         if (maxStorageSize <= 0) {
             return;
         }
+
         // TODO remove reflection once new APIs available in jCenter.
         // AppCenter.setMaxStorageSize(maxStorageSize)
         AppCenterFuture<Boolean> future;
         {
             try {
                 Method method = AppCenter.class.getMethod("setMaxStorageSize", long.class);
+
+                //noinspection unchecked
                 future = (AppCenterFuture<Boolean>) method.invoke(null, maxStorageSize);
             } catch (Exception ignored) {
                 return;

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -657,6 +657,11 @@ public class Analytics extends AbstractAppCenterService {
         postAsyncGetter(runnable, future, valueIfDisabledOrNotStarted);
     }
 
+    /**
+     * Post a command that will run on background even if SDK disabled (needs to be configured though).
+     *
+     * @param runnable command.
+     */
     void postCommandEvenIfDisabled(Runnable runnable) {
         post(runnable, runnable, runnable);
     }

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -320,8 +320,6 @@ public class Analytics extends AbstractAppCenterService {
             AppCenterLog.error(LOG_TAG, "Transmission target token may not be null or empty.");
             return null;
         } else if (!AppCenter.isConfigured()) {
-
-            /* Context and channel have the same lifecycle so we only have to check one. */
             AppCenterLog.error(LOG_TAG, "Cannot create transmission target, AppCenter is not configured or started.");
             return null;
         } else {

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -1,5 +1,6 @@
 package com.microsoft.appcenter.analytics;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.support.annotation.NonNull;
@@ -7,6 +8,7 @@ import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.channel.AnalyticsListener;
 import com.microsoft.appcenter.analytics.channel.AnalyticsValidator;
 import com.microsoft.appcenter.analytics.channel.SessionTracker;
@@ -59,7 +61,8 @@ public class Analytics extends AbstractAppCenterService {
     /**
      * Shared instance.
      */
-    private static Analytics sInstance = null;
+    @SuppressLint("StaticFieldLeak")
+    private static Analytics sInstance;
 
     /**
      * Log factories managed by this service.
@@ -316,10 +319,10 @@ public class Analytics extends AbstractAppCenterService {
         if (transmissionTargetToken == null || transmissionTargetToken.isEmpty()) {
             AppCenterLog.error(LOG_TAG, "Transmission target token may not be null or empty.");
             return null;
-        } else if (mContext == null) {
+        } else if (!AppCenter.isConfigured()) {
 
             /* Context and channel have the same lifecycle so we only have to check one. */
-            AppCenterLog.error(LOG_TAG, "App context is null, App Center has not been started.");
+            AppCenterLog.error(LOG_TAG, "Cannot create transmission target, AppCenter is not configured or started.");
             return null;
         } else {
             AnalyticsTransmissionTarget transmissionTarget = mTransmissionTargets.get(transmissionTargetToken);
@@ -327,9 +330,17 @@ public class Analytics extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Returning transmission target found with token " + transmissionTargetToken);
                 return transmissionTarget;
             }
-            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null, mContext, mChannel);
+            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null);
             AppCenterLog.debug(LOG_TAG, "Created transmission target with token " + transmissionTargetToken);
             mTransmissionTargets.put(transmissionTargetToken, transmissionTarget);
+            final AnalyticsTransmissionTarget finalTransmissionTarget = transmissionTarget;
+            postCommandEvenIfDisabled(new Runnable() {
+
+                @Override
+                public void run() {
+                    finalTransmissionTarget.initInBackground(mContext, mChannel);
+                }
+            });
             return transmissionTarget;
         }
     }
@@ -624,7 +635,9 @@ public class Analytics extends AbstractAppCenterService {
      */
     @WorkerThread
     private void setDefaultTransmissionTarget(String transmissionTargetToken) {
-        mDefaultTransmissionTarget = getInstanceTransmissionTarget(transmissionTargetToken);
+        if (transmissionTargetToken != null) {
+            mDefaultTransmissionTarget = getInstanceTransmissionTarget(transmissionTargetToken);
+        }
     }
 
     /**
@@ -642,6 +655,10 @@ public class Analytics extends AbstractAppCenterService {
          * it turns out the non get operations use the same flow as get.
          */
         postAsyncGetter(runnable, future, valueIfDisabledOrNotStarted);
+    }
+
+    void postCommandEvenIfDisabled(Runnable runnable) {
+        post(runnable, runnable, runnable);
     }
 
     /**

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -1,14 +1,15 @@
 package com.microsoft.appcenter.analytics;
 
 import android.annotation.SuppressLint;
-import android.support.annotation.NonNull;
 import android.provider.Settings.Secure;
+import android.support.annotation.NonNull;
 
 import com.microsoft.appcenter.channel.AbstractChannelListener;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.one.AppExtension;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
 import com.microsoft.appcenter.ingestion.models.one.DeviceExtension;
+import com.microsoft.appcenter.utils.AppCenterLog;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,9 +40,9 @@ public class PropertyConfigurator extends AbstractChannelListener {
     private String mAppLocale;
 
     /**
-     * The device id to populate common schema 'device.localId'.
+     * Flag to enable populating common schema 'device.localId'.
      */
-    private String mDeviceId;
+    private boolean mDeviceIdEnabled;
 
     /**
      * The transmission target which this configurator belongs to.
@@ -114,8 +115,12 @@ public class PropertyConfigurator extends AbstractChannelListener {
             }
 
             /* Fill out the device id if it has been collected. */
-            if (mDeviceId != null) {
-                device.setLocalId(ANDROID_DEVICE_ID_PREFIX + mDeviceId);
+            if (mDeviceIdEnabled) {
+
+                /* Get device identifier, Secure class already has an in memory cache. */
+                @SuppressLint("HardwareIds")
+                String androidId = Secure.getString(mTransmissionTarget.mContext.getContentResolver(), Secure.ANDROID_ID);
+                device.setLocalId(ANDROID_DEVICE_ID_PREFIX + androidId);
             }
         }
     }
@@ -208,9 +213,13 @@ public class PropertyConfigurator extends AbstractChannelListener {
         mEventProperties.remove(key);
     }
 
-    @SuppressLint("HardwareIds")
+    /**
+     * Enable collection of the Android device identifier for this target.
+     * This does not have any effect on child transmission targets.
+     */
     public void collectDeviceId() {
-        mDeviceId = Secure.getString(mTransmissionTarget.mContext.getContentResolver(), Secure.ANDROID_ID);
+        AppCenterLog.debug(AppCenterLog.LOG_TAG, "Context shall be null at that time " + mTransmissionTarget.mContext);  //TODO remove this log
+        mDeviceIdEnabled = true;
     }
 
     /*

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -9,7 +9,6 @@ import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.one.AppExtension;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
 import com.microsoft.appcenter.ingestion.models.one.DeviceExtension;
-import com.microsoft.appcenter.utils.AppCenterLog;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -218,7 +217,6 @@ public class PropertyConfigurator extends AbstractChannelListener {
      * This does not have any effect on child transmission targets.
      */
     public void collectDeviceId() {
-        AppCenterLog.debug(AppCenterLog.LOG_TAG, "Context shall be null at that time " + mTransmissionTarget.mContext);  //TODO remove this log
         mDeviceIdEnabled = true;
     }
 

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AbstractAnalyticsTest.java
@@ -45,6 +45,7 @@ abstract class AbstractAnalyticsTest {
         mockStatic(SystemClock.class);
         mockStatic(AppCenterLog.class);
         mockStatic(AppCenter.class);
+        when(AppCenter.isConfigured()).thenReturn(true);
         when(AppCenter.isEnabled()).thenReturn(mCoreEnabledFuture);
         when(mCoreEnabledFuture.get()).thenReturn(true);
         Answer<Void> runNow = new Answer<Void>() {

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -507,12 +507,17 @@ public class AnalyticsTest extends AbstractAnalyticsTest {
 
     @Test
     public void createTransmissionTargetBeforeStart() {
+
+        /* Given app center not configured. */
         mockStatic(AppCenterLog.class);
+        when(AppCenter.isConfigured()).thenReturn(false);
+
+        /* When creating a target, it returns null. */
         assertNull(Analytics.getTransmissionTarget("t1"));
 
-        /* Verify log. */
+        /* And prints an error. */
         verifyStatic();
-        AppCenterLog.error(anyString(), contains("App context is null, App Center has not been started."));
+        AppCenterLog.error(anyString(), contains("AppCenter is not configured"));
     }
 
     /**


### PR DESCRIPTION
Use the fact that any operation are queued into background looper so it is guaranteed that the `initInBackground` will be called in a sequence after the `Analytics.onStarted` that set context/channel to non null, in other terms if you execute anything in post, it will always have non null channel/context.