### PR TITLE
Fix sending previous one collector logs after app restart

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -205,8 +205,12 @@ public class DefaultChannel implements Channel {
         /* Count pending logs. */
         groupState.mPendingLogCount = mPersistence.countLogs(groupName);
 
-        /* If no app secret, don't resume sending App Center logs from storage. */
-        if (mAppSecret != null && mIngestion == ingestion) {
+        /*
+         * If no app secret, don't resume sending App Center logs from storage.
+         * If the ingestion is alternate implementation we assume One Collector
+         * and thus we have the keys in database.
+         */
+        if (mAppSecret != null || mIngestion != ingestion) {
 
             /* Schedule sending any pending log. */
             checkPendingLogs(groupState.mName);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelAlternateIngestionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelAlternateIngestionTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -104,29 +105,36 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
         Persistence mockPersistence = mock(Persistence.class);
         Ingestion defaultIngestion = mock(Ingestion.class);
         Ingestion alternateIngestion = mock(Ingestion.class);
+
+        /* Simulate we have 1 pending log in storage. */
+        when(mockPersistence.countLogs(anyString())).thenReturn(1);
         when(mockPersistence.getLogs(any(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer(1));
+
+        /* Create channel and groups. */
         DefaultChannel channel = new DefaultChannel(mock(Context.class), null, mockPersistence, defaultIngestion, mAppCenterHandler);
-        channel.addGroup(appCenterGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
+        channel.addGroup(appCenterGroup, 2, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
         channel.addGroup(oneCollectorGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, alternateIngestion, null);
 
-        /* Enqueuing 1 event. */
-        channel.enqueue(mock(Log.class), appCenterGroup);
-
-        /* Verify that we have called sendAsync on the ingestion. */
-        verify(alternateIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        /* App center previous log not sent yet. */
         verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
-        /* The counter should be 0 because we did not provide app secret. */
-        assertEquals(0, channel.getCounter(appCenterGroup));
+        /* One collector previous log sent. */
+        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
-        /* Verify we didn't persist the log. */
+        /* Enqueuing 1 new event for app center. */
+        channel.enqueue(mock(Log.class), appCenterGroup);
+
+        /* Not sent. */
+        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+
+        /* Verify we didn't persist the log since AppCenter not started with app secret. */
         verify(mockPersistence, never()).putLog(eq(appCenterGroup), any(Log.class));
 
         /* Enqueuing 1 event from one collector group. */
         channel.enqueue(mock(Log.class), oneCollectorGroup);
 
-        /* Verify that we have called sendAsync on the ingestion. */
-        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        /* Verify that we have called sendAsync on the alternate ingestion a second time. */
+        verify(alternateIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we can now send logs to app center after we have set app secret. */
@@ -152,12 +160,14 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
         /* Create channel with the two groups. */
         DefaultChannel channel = new DefaultChannel(mock(Context.class), null, mockPersistence, defaultIngestion, mAppCenterHandler);
         channel.addGroup(appCenterGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
-        channel.addGroup(oneCollectorGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, alternateIngestion, null);
 
         /* Verify that we can now send logs to app center after we have set app secret. */
         channel.setAppSecret("testAppSecret");
         verify(defaultIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(alternateIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+
+        /* If we add a one collector group it also resumes. */
+        channel.addGroup(oneCollectorGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, alternateIngestion, null);
+        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test


### PR DESCRIPTION
Previously it was working only with AppCenter logs to send pending logs after app restarted.
The if condition was wrong and the unit tests were also written the wrong way.