### PR TITLE
Common schema for Analytics.trackEvent with typed properties

### DIFF
--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactoryTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactoryTest.java
@@ -55,6 +55,7 @@ public class EventLogFactoryTest {
 
         /* Mock utilities. */
         mockStatic(PartAUtils.class);
+        mockStatic(PartCUtils.class);
 
         /* Create event log. */
         EventLog log = new EventLog();

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/CommonSchemaLogSerializerTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/CommonSchemaLogSerializerTest.java
@@ -50,7 +50,15 @@ public class CommonSchemaLogSerializerTest {
         log.setExt(new Extensions());
         checkSerialization(serializer, log);
 
-        /* Add extension and fields 1 by 1. Start with protocol. */
+        /* Add extension and fields 1 by 1. */
+
+        /* Metadata extension. */
+        log.getExt().setMetadata(new MetadataExtension());
+        checkSerialization(serializer, log);
+        log.getExt().getMetadata().getMetadata().put("f", new JSONObject());
+        checkSerialization(serializer, log);
+
+        /* Protocol extension. */
         log.getExt().setProtocol(new ProtocolExtension());
         checkSerialization(serializer, log);
         log.getExt().getProtocol().setTicketKeys(Arrays.asList("First", "Second"));

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/ExtensionsTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/ExtensionsTest.java
@@ -2,6 +2,8 @@ package com.microsoft.appcenter.ingestion.models.one;
 
 import com.microsoft.appcenter.test.TestUtils;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import static com.microsoft.appcenter.test.TestUtils.checkEquals;
@@ -15,11 +17,21 @@ public class ExtensionsTest {
     }
 
     @Test
-    public void equalsHashCode() {
+    public void equalsHashCode() throws JSONException {
 
         /* Empty objects. */
         Extensions a = new Extensions();
         Extensions b = new Extensions();
+        checkEquals(a, b);
+
+        /* Metadata. */
+        MetadataExtension metadata = new MetadataExtension();
+        metadata.getMetadata().put("f", new JSONObject());
+        a.setMetadata(metadata);
+        checkNotEquals(a, b);
+        b.setMetadata(new MetadataExtension());
+        checkNotEquals(a, b);
+        b.getMetadata().getMetadata().put("f", new JSONObject());
         checkEquals(a, b);
 
         /* Protocol. */

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/MetadataExtensionTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/MetadataExtensionTest.java
@@ -1,0 +1,32 @@
+package com.microsoft.appcenter.ingestion.models.one;
+
+import com.microsoft.appcenter.test.TestUtils;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import static com.microsoft.appcenter.test.TestUtils.checkEquals;
+import static com.microsoft.appcenter.test.TestUtils.checkNotEquals;
+
+public class MetadataExtensionTest {
+
+    @Test
+    public void compareDifferentType() {
+        TestUtils.compareSelfNullClass(new MetadataExtension());
+    }
+
+    @Test
+    public void equalsHashCode() throws JSONException {
+
+        /* Empty objects. */
+        MetadataExtension a = new MetadataExtension();
+        MetadataExtension b = new MetadataExtension();
+        checkEquals(a, b);
+
+        /* Properties. */
+        a.getMetadata().put("a", "b");
+        checkNotEquals(a, b);
+        b.getMetadata().put("a", "b");
+        checkEquals(a, b);
+    }
+}

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
@@ -282,4 +282,68 @@ public class PartCUtilsAndroidTest {
         expectedMetadata.put(METADATA_FIELDS, f1);
         assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
+
+    @Test
+    public void overrideMetadataToNull() throws JSONException {
+        MockCommonSchemaLog log = new MockCommonSchemaLog();
+        log.setExt(new Extensions());
+        List<TypedProperty> properties = new ArrayList<>();
+        LongTypedProperty a = new LongTypedProperty();
+        a.setName("a.b.c");
+        a.setValue(1);
+        properties.add(a);
+        StringTypedProperty b = new StringTypedProperty();
+        b.setName("a.b");
+        b.setValue("2");
+        properties.add(b);
+        PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
+        JSONObject aData = new JSONObject();
+        aData.put("b", "2");
+        JSONObject expectedData = new JSONObject();
+        expectedData.put("a", aData);
+        assertEquals(expectedData.toString(), log.getData().getProperties().toString());
+
+        /* Check metadata is null */
+        assertNull(log.getExt().getMetadata());
+    }
+
+    @Test
+    public void overrideMetadataCleanup() throws JSONException {
+        MockCommonSchemaLog log = new MockCommonSchemaLog();
+        List<TypedProperty> properties = new ArrayList<>();
+        LongTypedProperty a = new LongTypedProperty();
+        a.setName("a.b.c");
+        a.setValue(1);
+        properties.add(a);
+        StringTypedProperty b = new StringTypedProperty();
+        b.setName("a.b");
+        b.setValue("2");
+        properties.add(b);
+        DoubleTypedProperty c = new DoubleTypedProperty();
+        c.setName("a.c");
+        c.setValue(3.14);
+        properties.add(c);
+        PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
+        JSONObject aData = new JSONObject();
+        aData.put("b", "2");
+        aData.put("c", 3.14);
+        JSONObject expectedData = new JSONObject();
+        expectedData.put("a", aData);
+        assertEquals(expectedData.toString(), log.getData().getProperties().toString());
+
+        /* Check metadata contains only a.c. */
+        JSONObject aFields = new JSONObject();
+        aFields.put("c", DATA_TYPE_DOUBLE);
+        JSONObject aMetadata = new JSONObject();
+        aMetadata.put(METADATA_FIELDS, aFields);
+        JSONObject rootFields = new JSONObject();
+        rootFields.put("a", aMetadata);
+        JSONObject expectedMetadata = new JSONObject();
+        expectedMetadata.put(METADATA_FIELDS, rootFields);
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
+    }
 }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
@@ -197,4 +197,24 @@ public class PartCUtilsAndroidTest {
         assertNotNull(log.getExt().getMetadata());
         assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
+
+    @Test
+    public void unknownTypedProperty() {
+        MockCommonSchemaLog log = new MockCommonSchemaLog();
+        TypedProperty typedProperty = new TypedProperty() {
+
+            @Override
+            public String getType() {
+                return "unknown";
+            }
+        };
+        typedProperty.setName("a");
+        PartCUtils.addPartCFromLog(Collections.singletonList(typedProperty), log);
+
+        /* Data is empty because the invalid property filtered out. */
+        assertEquals(0, log.getData().getProperties().length());
+
+        /* And we don't send metadata when using only standard types. */
+        assertNull(log.getExt());
+    }
 }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
@@ -394,4 +394,41 @@ public class PartCUtilsAndroidTest {
         expectedMetadata.put(METADATA_FIELDS, rootFields);
         assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
+
+    @Test
+    public void noMetadataCleanupOnNestingString() throws JSONException {
+        MockCommonSchemaLog log = new MockCommonSchemaLog();
+        log.setExt(new Extensions());
+        List<TypedProperty> properties = new ArrayList<>();
+        LongTypedProperty a = new LongTypedProperty();
+        a.setName("a.b");
+        a.setValue(1);
+        properties.add(a);
+        StringTypedProperty b = new StringTypedProperty();
+        b.setName("b.c");
+        b.setValue("2");
+        properties.add(b);
+        PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
+        JSONObject aData = new JSONObject();
+        aData.put("b", 1);
+        JSONObject bData = new JSONObject();
+        bData.put("c", "2");
+        JSONObject expectedData = new JSONObject();
+        expectedData.put("a", aData);
+        expectedData.put("b", bData);
+        assertEquals(expectedData.toString(), log.getData().getProperties().toString());
+
+        /* Check metadata. a.b only. */
+        JSONObject aFields = new JSONObject();
+        aFields.put("b", DATA_TYPE_INT64);
+        JSONObject aMetadata = new JSONObject();
+        aMetadata.put(METADATA_FIELDS, aFields);
+        JSONObject rootFields = new JSONObject();
+        rootFields.put("a", aMetadata);
+        JSONObject expectedMetadata = new JSONObject();
+        expectedMetadata.put(METADATA_FIELDS, rootFields);
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
+    }
 }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
@@ -346,4 +346,52 @@ public class PartCUtilsAndroidTest {
         expectedMetadata.put(METADATA_FIELDS, rootFields);
         assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
+
+    @Test
+    public void noNestingAccident() throws JSONException {
+        MockCommonSchemaLog log = new MockCommonSchemaLog();
+        log.setExt(new Extensions());
+        List<TypedProperty> properties = new ArrayList<>();
+        LongTypedProperty a = new LongTypedProperty();
+        a.setName("a.b");
+        a.setValue(1);
+        properties.add(a);
+        DoubleTypedProperty b = new DoubleTypedProperty();
+        b.setName("b.c");
+        b.setValue(2.2);
+        properties.add(b);
+        PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
+        JSONObject aData = new JSONObject();
+        aData.put("b", 1);
+        JSONObject bData = new JSONObject();
+        bData.put("c", 2.2);
+        JSONObject expectedData = new JSONObject();
+        expectedData.put("a", aData);
+        expectedData.put("b", bData);
+        assertEquals(expectedData.toString(), log.getData().getProperties().toString());
+
+        /* Check metadata. a.b */
+        JSONObject aFields = new JSONObject();
+        aFields.put("b", DATA_TYPE_INT64);
+        JSONObject aMetadata = new JSONObject();
+        aMetadata.put(METADATA_FIELDS, aFields);
+
+        /* b.c */
+        JSONObject bFields = new JSONObject();
+        bFields.put("c", DATA_TYPE_DOUBLE);
+        JSONObject bMetadata = new JSONObject();
+        bMetadata.put(METADATA_FIELDS, bFields);
+
+        /* f at root. */
+        JSONObject rootFields = new JSONObject();
+        rootFields.put("a", aMetadata);
+        rootFields.put("b", bMetadata);
+
+        /* Check. */
+        JSONObject expectedMetadata = new JSONObject();
+        expectedMetadata.put(METADATA_FIELDS, rootFields);
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
+    }
 }

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsAndroidTest.java
@@ -17,6 +17,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static com.microsoft.appcenter.ingestion.models.one.PartCUtils.DATA_TYPE_DATETIME;
+import static com.microsoft.appcenter.ingestion.models.one.PartCUtils.DATA_TYPE_DOUBLE;
+import static com.microsoft.appcenter.ingestion.models.one.PartCUtils.DATA_TYPE_INT64;
+import static com.microsoft.appcenter.ingestion.models.one.PartCUtils.METADATA_FIELDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -41,6 +45,7 @@ public class PartCUtilsAndroidTest {
         MockCommonSchemaLog log = new MockCommonSchemaLog();
         PartCUtils.addPartCFromLog(null, log);
         assertNull(log.getData());
+        assertNull(log.getExt());
     }
 
     @Test
@@ -48,6 +53,7 @@ public class PartCUtilsAndroidTest {
         MockCommonSchemaLog log = new MockCommonSchemaLog();
         PartCUtils.addPartCFromLog(Collections.<TypedProperty>emptyList(), log);
         assertEquals(0, log.getData().getProperties().length());
+        assertNull(log.getExt());
     }
 
     @Test
@@ -58,6 +64,7 @@ public class PartCUtilsAndroidTest {
         PartCUtils.addPartCFromLog(properties, log);
         assertEquals(1, log.getData().getProperties().length());
         assertEquals("", log.getData().getProperties().getString(""));
+        assertNull(log.getExt());
     }
 
     @Test()
@@ -72,6 +79,7 @@ public class PartCUtilsAndroidTest {
         PartCUtils.addPartCFromLog(properties, log);
         assertEquals(1, log.getData().getProperties().length());
         assertEquals("b", log.getData().getProperties().getString("a"));
+        assertNull(log.getExt());
     }
 
     @Test
@@ -90,6 +98,7 @@ public class PartCUtilsAndroidTest {
         assertNotNull(c);
         assertEquals("2", c.optString("d", null));
         assertEquals("3", c.optString("e", null));
+        assertNull(log.getExt());
     }
 
     @Test
@@ -103,6 +112,7 @@ public class PartCUtilsAndroidTest {
         JSONObject b = log.getData().getProperties().optJSONObject("a").optJSONObject("b");
         assertNotNull(b);
         assertEquals("3", b.optString("c", null));
+        assertNull(log.getExt());
     }
 
     @Test
@@ -127,8 +137,19 @@ public class PartCUtilsAndroidTest {
         property.setValue(new Date(100));
         properties.add(property);
         PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
         assertEquals(1, log.getData().getProperties().length());
         assertEquals(new Date(100), JSONDateUtils.toDate(log.getData().getProperties().getString("a")));
+
+        /* Check metadata. */
+        JSONObject expectedMetadata = new JSONObject();
+        JSONObject a = new JSONObject();
+        a.put("a", DATA_TYPE_DATETIME);
+        expectedMetadata.put(METADATA_FIELDS, a);
+        assertNotNull(log.getExt());
+        assertNotNull(log.getExt().getMetadata());
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
 
     @Test
@@ -140,8 +161,19 @@ public class PartCUtilsAndroidTest {
         property.setValue(1.1);
         properties.add(property);
         PartCUtils.addPartCFromLog(properties, log);
+
+        /* Check data. */
         assertEquals(1, log.getData().getProperties().length());
         assertEquals(1.1, log.getData().getProperties().getDouble("a"), 0);
+
+        /* Check metadata. */
+        JSONObject expectedMetadata = new JSONObject();
+        JSONObject a = new JSONObject();
+        a.put("a", DATA_TYPE_DOUBLE);
+        expectedMetadata.put(METADATA_FIELDS, a);
+        assertNotNull(log.getExt());
+        assertNotNull(log.getExt().getMetadata());
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
 
     @Test
@@ -155,5 +187,14 @@ public class PartCUtilsAndroidTest {
         PartCUtils.addPartCFromLog(properties, log);
         assertEquals(1, log.getData().getProperties().length());
         assertEquals(10000000000L, log.getData().getProperties().getLong("a"));
+
+        /* Check metadata. */
+        JSONObject expectedMetadata = new JSONObject();
+        JSONObject a = new JSONObject();
+        a.put("a", DATA_TYPE_INT64);
+        expectedMetadata.put(METADATA_FIELDS, a);
+        assertNotNull(log.getExt());
+        assertNotNull(log.getExt().getMetadata());
+        assertEquals(expectedMetadata.toString(), log.getExt().getMetadata().getMetadata().toString());
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/Data.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/Data.java
@@ -15,12 +15,12 @@ public class Data implements Model {
     /**
      * Part B data type property.
      */
-    public static final String BASE_DATA_TYPE = "baseDataType";
+    static final String BASE_DATA_TYPE = "baseDataType";
 
     /**
      * Part B data property.
      */
-    public static final String BASE_DATA = "baseData";
+    static final String BASE_DATA = "baseData";
 
     /**
      * Part C properties.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/Extensions.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/Extensions.java
@@ -12,6 +12,11 @@ import org.json.JSONStringer;
 public class Extensions implements Model {
 
     /**
+     * Metadata extension.
+     */
+    private static final String METADATA = "metadata";
+
+    /**
      * Protocol property.
      */
     private static final String PROTOCOL = "protocol";
@@ -52,6 +57,11 @@ public class Extensions implements Model {
     private static final String LOC = "loc";
 
     /**
+     * Metadata extension.
+     */
+    private MetadataExtension metadata;
+
+    /**
      * Protocol extension.
      */
     private ProtocolExtension protocol;
@@ -90,6 +100,24 @@ public class Extensions implements Model {
      * Loc extension.
      */
     private LocExtension loc;
+
+    /**
+     * Get metadata extension.
+     *
+     * @return metadata extension.
+     */
+    public MetadataExtension getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Set metadata extension.
+     *
+     * @param metadata metadata extension.
+     */
+    public void setMetadata(MetadataExtension metadata) {
+        this.metadata = metadata;
+    }
 
     /**
      * Get protocol extension.
@@ -222,6 +250,7 @@ public class Extensions implements Model {
      *
      * @return loc extension.
      */
+    @SuppressWarnings("WeakerAccess")
     public LocExtension getLoc() {
         return loc;
     }
@@ -231,12 +260,20 @@ public class Extensions implements Model {
      *
      * @param loc loc extension.
      */
+    @SuppressWarnings("WeakerAccess")
     public void setLoc(LocExtension loc) {
         this.loc = loc;
     }
 
     @Override
     public void read(JSONObject object) throws JSONException {
+
+        /* Metadata. */
+        if (object.has(METADATA)) {
+            MetadataExtension metadata = new MetadataExtension();
+            metadata.read(object.getJSONObject(METADATA));
+            setMetadata(metadata);
+        }
 
         /* Protocol. */
         if (object.has(PROTOCOL)) {
@@ -298,6 +335,13 @@ public class Extensions implements Model {
     @Override
     public void write(JSONStringer writer) throws JSONException {
 
+        /* Metadata. */
+        if (getMetadata() != null) {
+            writer.key(METADATA).object();
+            getMetadata().write(writer);
+            writer.endObject();
+        }
+
         /* Protocol. */
         if (getProtocol() != null) {
             writer.key(PROTOCOL).object();
@@ -355,7 +399,6 @@ public class Extensions implements Model {
         }
     }
 
-    @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -363,6 +406,8 @@ public class Extensions implements Model {
 
         Extensions that = (Extensions) o;
 
+        if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null)
+            return false;
         if (protocol != null ? !protocol.equals(that.protocol) : that.protocol != null)
             return false;
         if (user != null ? !user.equals(that.user) : that.user != null) return false;
@@ -376,7 +421,8 @@ public class Extensions implements Model {
 
     @Override
     public int hashCode() {
-        int result = protocol != null ? protocol.hashCode() : 0;
+        int result = metadata != null ? metadata.hashCode() : 0;
+        result = 31 * result + (protocol != null ? protocol.hashCode() : 0);
         result = 31 * result + (user != null ? user.hashCode() : 0);
         result = 31 * result + (device != null ? device.hashCode() : 0);
         result = 31 * result + (os != null ? os.hashCode() : 0);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/MetadataExtension.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/MetadataExtension.java
@@ -1,0 +1,57 @@
+package com.microsoft.appcenter.ingestion.models.one;
+
+import com.microsoft.appcenter.ingestion.models.Model;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONStringer;
+
+import java.util.Iterator;
+
+/**
+ * Part A extension for metadata of Part B and Part C fields.
+ */
+public class MetadataExtension implements Model {
+
+    /**
+     * Metadata.
+     */
+    private JSONObject mMetadata = new JSONObject();
+
+    /**
+     * Get metadata.
+     *
+     * @return metadata.
+     */
+    public JSONObject getMetadata() {
+        return mMetadata;
+    }
+
+    @Override
+    public void read(JSONObject object) throws JSONException {
+        mMetadata = object;
+    }
+
+    @Override
+    public void write(JSONStringer writer) throws JSONException {
+        for (Iterator<String> iterator = mMetadata.keys(); iterator.hasNext(); ) {
+            String key = iterator.next();
+            writer.key(key).value(mMetadata.get(key));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MetadataExtension metadataExtension = (MetadataExtension) o;
+
+        return mMetadata.toString().equals(metadataExtension.mMetadata.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return mMetadata.toString().hashCode();
+    }
+}

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartAUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartAUtils.java
@@ -64,7 +64,9 @@ public class PartAUtils {
         dest.addTransmissionTarget(transmissionTarget);
 
         /* Add extension. */
-        dest.setExt(new Extensions());
+        if (dest.getExt() == null) {
+            dest.setExt(new Extensions());
+        }
 
         /* Add protocol extension. */
         dest.getExt().setProtocol(new ProtocolExtension());

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -132,8 +132,6 @@ public class PartCUtils {
                             fields.put(subKey, subMetadataObject);
                         }
                         destMetadata = subMetadataObject;
-                    } else if (fields != null) {
-                        destMetadata.remove(METADATA_FIELDS);
                     }
                 }
 
@@ -153,7 +151,10 @@ public class PartCUtils {
                     }
                     fields.put(lastKey, metadataType);
                 } else if (fields != null) {
-                    destMetadata.remove(METADATA_FIELDS);
+                    fields.remove(lastKey);
+                    if (fields.length() == 0) {
+                        destMetadata.remove(METADATA_FIELDS);
+                    }
                 }
             }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -176,6 +176,9 @@ public class PartCUtils {
 
             /* Add metadata extension only if not empty. */
             if (metadata.getMetadata().length() > 0) {
+                if (dest.getExt() == null) {
+                    dest.setExt(new Extensions());
+                }
                 dest.getExt().setMetadata(metadata);
             }
         } catch (JSONException ignore) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -121,22 +121,17 @@ public class PartCUtils {
 
                     /* Add sub metadata intermediate object if using a non default type. */
                     if (metadataType != null) {
-                        JSONObject subMetadataObject = destMetadata.optJSONObject(METADATA_FIELDS);
-                        if (subMetadataObject != null) {
-                            JSONObject fObject = subMetadataObject.optJSONObject(subKey);
-                            if (fObject != null) {
-                                subMetadataObject = fObject;
-                            }
+                        JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
+                        if (fields == null) {
+                            fields = new JSONObject();
+                            destMetadata.put(METADATA_FIELDS, fields);
                         }
+                        JSONObject subMetadataObject = fields.optJSONObject(subKey);
                         if (subMetadataObject == null) {
                             subMetadataObject = new JSONObject();
-                            destMetadata.put(METADATA_FIELDS, subMetadataObject);
+                            fields.put(subKey, subMetadataObject);
                         }
-
-                        /* Put intermediate fields object for that intermediate key. */
-                        JSONObject fields = new JSONObject();
-                        subMetadataObject.put(subKey, fields);
-                        destMetadata = fields;
+                        destMetadata = subMetadataObject;
                     }
                 }
 
@@ -148,18 +143,13 @@ public class PartCUtils {
                 destProperties.put(lastKey, value);
 
                 /* Add metadata if not a default type. */
-                JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                 if (metadataType != null) {
+                    JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                     if (fields == null) {
                         fields = new JSONObject();
                         destMetadata.put(METADATA_FIELDS, fields);
                     }
                     fields.put(lastKey, metadataType);
-                } else if (fields != null) {
-                    fields.remove(lastKey);
-                    if (fields.length() == 0) {
-                        metadata.getMetadata().remove(METADATA_FIELDS);
-                    }
                 }
             }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -133,6 +133,19 @@ public class PartCUtils {
                         }
                         destMetadata = subMetadataObject;
                     }
+
+                    /*
+                     * If overriding from metadata type in a sub object to default type in a parent object,
+                     * Select sub object without creating it to be able to override metadata after the loop.
+                     * Example: put "a.b.c": 2 then put "a.b": "3" will trigger that code
+                     * and we need to cleanup metadata.
+                     */
+                    else if (fields != null) {
+                        JSONObject subMetadataObject = fields.optJSONObject(subKey);
+                        if (subMetadataObject != null) {
+                            destMetadata = subMetadataObject;
+                        }
+                    }
                 }
 
                 /* Handle the last key, the leaf. */
@@ -150,7 +163,10 @@ public class PartCUtils {
                         destMetadata.put(METADATA_FIELDS, fields);
                     }
                     fields.put(lastKey, metadataType);
-                } else if (fields != null) {
+                }
+
+                /* If we override a key that needs metadata with a key that doesn't, cleanup. */
+                else if (fields != null) {
                     fields.remove(lastKey);
                     if (fields.length() == 0) {
                         destMetadata.remove(METADATA_FIELDS);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -14,9 +14,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import static com.microsoft.appcenter.utils.AppCenterLog.LOG_TAG;
@@ -72,7 +70,7 @@ public class PartCUtils {
                 }
 
                 /* Get value from property. */
-                Object value = null;
+                Object value;
                 Integer metadataType = null;
                 if (property instanceof StringTypedProperty) {
                     StringTypedProperty stringTypedProperty = (StringTypedProperty) property;
@@ -91,6 +89,9 @@ public class PartCUtils {
                 } else if (property instanceof BooleanTypedProperty) {
                     BooleanTypedProperty booleanTypedProperty = (BooleanTypedProperty) property;
                     value = booleanTypedProperty.getValue();
+                } else {
+                    AppCenterLog.warn(LOG_TAG, "Unsupported property type: " + property.getType());
+                    continue;
                 }
 
                 /* Validate value not null. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/one/PartCUtils.java
@@ -120,8 +120,8 @@ public class PartCUtils {
                     destProperties = subDataObject;
 
                     /* Add sub metadata intermediate object if using a non default type. */
+                    JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                     if (metadataType != null) {
-                        JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                         if (fields == null) {
                             fields = new JSONObject();
                             destMetadata.put(METADATA_FIELDS, fields);
@@ -132,6 +132,8 @@ public class PartCUtils {
                             fields.put(subKey, subMetadataObject);
                         }
                         destMetadata = subMetadataObject;
+                    } else if (fields != null) {
+                        destMetadata.remove(METADATA_FIELDS);
                     }
                 }
 
@@ -143,13 +145,15 @@ public class PartCUtils {
                 destProperties.put(lastKey, value);
 
                 /* Add metadata if not a default type. */
+                JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                 if (metadataType != null) {
-                    JSONObject fields = destMetadata.optJSONObject(METADATA_FIELDS);
                     if (fields == null) {
                         fields = new JSONObject();
                         destMetadata.put(METADATA_FIELDS, fields);
                     }
                     fields.put(lastKey, metadataType);
+                } else if (fields != null) {
+                    destMetadata.remove(METADATA_FIELDS);
                 }
             }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/PartAUtilsTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/PartAUtilsTest.java
@@ -1,5 +1,7 @@
 package com.microsoft.appcenter.ingestion.models.one;
 
+import android.support.annotation.NonNull;
+
 import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.Log;
 
@@ -17,11 +19,6 @@ import static org.mockito.Mockito.when;
 
 public class PartAUtilsTest {
 
-    @Test
-    public void coverInit() {
-        new PartAUtils();
-    }
-
     private static void testInvalidName(String name) {
         CommonSchemaLog log = new MockCommonSchemaLog();
         try {
@@ -36,6 +33,11 @@ public class PartAUtilsTest {
         CommonSchemaLog log = new MockCommonSchemaLog();
         PartAUtils.setName(log, name);
         assertEquals(name, log.getName());
+    }
+
+    @Test
+    public void coverInit() {
+        new PartAUtils();
     }
 
     @Test
@@ -68,26 +70,22 @@ public class PartAUtilsTest {
         checkPartAConversion(-480, "-08:00");
     }
 
+    @Test
+    public void checkPartAConversionDoesNotInstantiateExtensionObjectAgain() {
+        Log log = mock(Log.class);
+        when(log.getDevice()).thenReturn(getDevice(0));
+        MockCommonSchemaLog commonSchemaLog = new MockCommonSchemaLog();
+        Extensions extensions = new Extensions();
+        commonSchemaLog.setExt(extensions);
+        PartAUtils.addPartAFromLog(log, commonSchemaLog, "T1UUID1-T2UUID2");
+        assertEquals(extensions, commonSchemaLog.getExt());
+    }
+
     /**
      * Convert to Part A and check.
      */
     private void checkPartAConversion(int appCenterTimeZoneOffset, String commonSchemaTimeZoneOffset) {
-
-        /* Create App Center models, starting with the device object. */
-        Device device = new Device();
-        device.setModel("model");
-        device.setOemName("oemName");
-        device.setLocale("en_US");
-        device.setOsName("osName");
-        device.setOsVersion("8.1.0");
-        device.setOsBuild("ABC.123");
-        device.setOsApiLevel(23);
-        device.setAppVersion("1.0.0");
-        device.setAppNamespace("com.appcenter.test");
-        device.setCarrierName("carrierName");
-        device.setSdkName("appcenter.android");
-        device.setSdkVersion("1.5.0");
-        device.setTimeZoneOffset(appCenterTimeZoneOffset);
+        Device device = getDevice(appCenterTimeZoneOffset);
 
         /* App Center timestamp and transmission targets. */
         Date timestamp = new Date();
@@ -124,5 +122,25 @@ public class PartAUtilsTest {
         assertEquals(commonSchemaTimeZoneOffset, commonSchemaLog.getExt().getLoc().getTz());
         assertEquals(Collections.singleton(transmissionTarget), commonSchemaLog.getTransmissionTargetTokens());
         assertNotNull(commonSchemaLog.getExt().getDevice());
+    }
+
+    @NonNull
+    private Device getDevice(int appCenterTimeZoneOffset) {
+        /* Create App Center models, starting with the device object. */
+        Device device = new Device();
+        device.setModel("model");
+        device.setOemName("oemName");
+        device.setLocale("en_US");
+        device.setOsName("osName");
+        device.setOsVersion("8.1.0");
+        device.setOsBuild("ABC.123");
+        device.setOsApiLevel(23);
+        device.setAppVersion("1.0.0");
+        device.setAppNamespace("com.appcenter.test");
+        device.setCarrierName("carrierName");
+        device.setSdkName("appcenter.android");
+        device.setSdkVersion("1.5.0");
+        device.setTimeZoneOffset(appCenterTimeZoneOffset);
+        return device;
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/one/PartCUtilsTest.java
@@ -40,25 +40,4 @@ public class PartCUtilsTest {
         PartCUtils.addPartCFromLog(properties, commonSchemaLog);
         assertEquals(0, commonSchemaLog.getData().getProperties().length());
     }
-
-    @Test
-    public void coverUnsupportedTypedProperty() throws Exception {
-
-        /* Fake JSON exception to cover unsupported typed property. */
-        JSONObject value = mock(JSONObject.class);
-        whenNew(JSONObject.class).withNoArguments().thenReturn(value);
-        when(value.put(anyString(), any())).thenThrow(new JSONException("mock"));
-        CommonSchemaLog commonSchemaLog = new MockCommonSchemaLog();
-        List<TypedProperty> properties = new ArrayList<>();
-        TypedProperty unsupportedTypedProperty = new TypedProperty() {
-            @Override
-            public String getType() {
-                return "unsupported";
-            }
-        };
-        unsupportedTypedProperty.setName("a");
-        properties.add(unsupportedTypedProperty);
-        PartCUtils.addPartCFromLog(properties, commonSchemaLog);
-        assertEquals(0, commonSchemaLog.getData().getProperties().length());
-    }
 }


### PR DESCRIPTION
Add metadata extension to common schema logs when a Part C property is not using the default JSON type.