### PR TITLE
Fix part A properties to not be applied retro-actively

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -438,7 +438,7 @@ public class Analytics extends AbstractAppCenterService {
     }
 
     /**
-     * Unconditionally create a new transmission target at root level.
+     * Unconditionally create a new transmission target at root level, even if one exists with the given token.
      *
      * @param transmissionTargetToken the token.
      * @return the created target.

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -80,7 +80,8 @@ public class Analytics extends AbstractAppCenterService {
     /**
      * The default transmission target.
      */
-    private AnalyticsTransmissionTarget mDefaultTransmissionTarget;
+    @VisibleForTesting
+    AnalyticsTransmissionTarget mDefaultTransmissionTarget;
 
     /**
      * Current activity to replay onResume when enabled in foreground.
@@ -430,19 +431,29 @@ public class Analytics extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Returning transmission target found with token " + transmissionTargetToken);
                 return transmissionTarget;
             }
-            transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null);
-            AppCenterLog.debug(LOG_TAG, "Created transmission target with token " + transmissionTargetToken);
+            transmissionTarget = createAnalyticsTransmissionTarget(transmissionTargetToken);
             mTransmissionTargets.put(transmissionTargetToken, transmissionTarget);
-            final AnalyticsTransmissionTarget finalTransmissionTarget = transmissionTarget;
-            postCommandEvenIfDisabled(new Runnable() {
-
-                @Override
-                public void run() {
-                    finalTransmissionTarget.initInBackground(mContext, mChannel);
-                }
-            });
             return transmissionTarget;
         }
+    }
+
+    /**
+     * Unconditionally create a new transmission target at root level.
+     *
+     * @param transmissionTargetToken the token.
+     * @return the created target.
+     */
+    private AnalyticsTransmissionTarget createAnalyticsTransmissionTarget(String transmissionTargetToken) {
+        final AnalyticsTransmissionTarget transmissionTarget = new AnalyticsTransmissionTarget(transmissionTargetToken, null);
+        AppCenterLog.debug(LOG_TAG, "Created transmission target with token " + transmissionTargetToken);
+        postCommandEvenIfDisabled(new Runnable() {
+
+            @Override
+            public void run() {
+                transmissionTarget.initInBackground(mContext, mChannel);
+            }
+        });
+        return transmissionTarget;
     }
 
     @Override
@@ -671,6 +682,7 @@ public class Analytics extends AbstractAppCenterService {
                 if (aTransmissionTarget != null) {
                     if (aTransmissionTarget.isEnabled()) {
                         eventLog.addTransmissionTarget(aTransmissionTarget.getTransmissionTargetToken());
+                        eventLog.setTag(aTransmissionTarget);
                     } else {
                         AppCenterLog.error(LOG_TAG, "This transmission target is disabled.");
                         return;
@@ -760,7 +772,7 @@ public class Analytics extends AbstractAppCenterService {
     @WorkerThread
     private void setDefaultTransmissionTarget(String transmissionTargetToken) {
         if (transmissionTargetToken != null) {
-            mDefaultTransmissionTarget = getInstanceTransmissionTarget(transmissionTargetToken);
+            mDefaultTransmissionTarget = createAnalyticsTransmissionTarget(transmissionTargetToken);
         }
     }
 

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/PropertyConfigurator.java
@@ -132,15 +132,14 @@ public class PropertyConfigurator extends AbstractChannelListener {
      * @return true if log should be overridden, false otherwise.
      */
     private boolean shouldOverridePartAProperties(@NonNull Log log) {
-        String targetToken = mTransmissionTarget.getTransmissionTargetToken();
-        return log instanceof CommonSchemaLog && mTransmissionTarget.isEnabled()
-                && log.getTransmissionTargetTokens().contains(targetToken);
+        return log instanceof CommonSchemaLog && log.getTag() == mTransmissionTarget &&
+                mTransmissionTarget.isEnabled();
     }
 
     /**
      * Get app name. Used for checking parents for property inheritance.
      *
-     * @return App name
+     * @return App name.
      */
     private String getAppName() {
         return mAppName;
@@ -149,16 +148,22 @@ public class PropertyConfigurator extends AbstractChannelListener {
     /**
      * Override common schema Part A property App.Name.
      *
-     * @param appName App name
+     * @param appName App name.
      */
-    public void setAppName(String appName) {
-        mAppName = appName;
+    public void setAppName(final String appName) {
+        Analytics.getInstance().postCommandEvenIfDisabled(new Runnable() {
+
+            @Override
+            public void run() {
+                mAppName = appName;
+            }
+        });
     }
 
     /**
      * Get app version. Used for checking parents for property inheritance.
      *
-     * @return App version
+     * @return App version.
      */
     private String getAppVersion() {
         return mAppVersion;
@@ -169,8 +174,14 @@ public class PropertyConfigurator extends AbstractChannelListener {
      *
      * @param appVersion App version
      */
-    public void setAppVersion(String appVersion) {
-        mAppVersion = appVersion;
+    public void setAppVersion(final String appVersion) {
+        Analytics.getInstance().postCommandEvenIfDisabled(new Runnable() {
+
+            @Override
+            public void run() {
+                mAppVersion = appVersion;
+            }
+        });
     }
 
     /**
@@ -187,8 +198,14 @@ public class PropertyConfigurator extends AbstractChannelListener {
      *
      * @param appLocale App Locale
      */
-    public void setAppLocale(String appLocale) {
-        mAppLocale = appLocale;
+    public void setAppLocale(final String appLocale) {
+        Analytics.getInstance().postCommandEvenIfDisabled(new Runnable() {
+
+            @Override
+            public void run() {
+                mAppLocale = appLocale;
+            }
+        });
     }
 
     /**
@@ -260,7 +277,13 @@ public class PropertyConfigurator extends AbstractChannelListener {
      * This does not have any effect on child transmission targets.
      */
     public void collectDeviceId() {
-        mDeviceIdEnabled = true;
+        Analytics.getInstance().postCommandEvenIfDisabled(new Runnable() {
+
+            @Override
+            public void run() {
+                mDeviceIdEnabled = true;
+            }
+        });
     }
 
     /*

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactory.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactory.java
@@ -36,6 +36,9 @@ public class EventLogFactory extends AbstractLogFactory {
             /* Properties go to Part C. */
             PartCUtils.addPartCFromLog(eventLog.getTypedProperties(), commonSchemaEventLog);
             commonSchemaLogs.add(commonSchemaEventLog);
+
+            /* Copy tag. */
+            commonSchemaEventLog.setTag(log.getTag());
         }
         return commonSchemaLogs;
     }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTransmissionTargetTest.java
@@ -111,7 +111,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         mChannel = mock(Channel.class);
         analytics.onStarting(mAppCenterHandler);
         analytics.onStarted(mock(Context.class), mChannel, null, defaultToken, startFromApp);
-        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("token");
+        final AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("token");
         assertNotNull(target);
 
         /* Getting a reference to the same target a second time actually returns the same. */
@@ -128,12 +128,15 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
                         EventLog eventLog = (EventLog) item;
                         boolean nameAndPropertiesMatch = eventLog.getName().equals("name") && eventLog.getTypedProperties() == null;
                         boolean tokenMatch;
+                        boolean tagMatch;
                         if (defaultToken != null) {
                             tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains(defaultToken);
+                            tagMatch = Analytics.getInstance().mDefaultTransmissionTarget.equals(eventLog.getTag());
                         } else {
                             tokenMatch = eventLog.getTransmissionTargetTokens().isEmpty();
+                            tagMatch = eventLog.getTag() == null;
                         }
-                        return nameAndPropertiesMatch && tokenMatch;
+                        return nameAndPropertiesMatch && tokenMatch && tagMatch;
                     }
                     return false;
                 }
@@ -153,7 +156,8 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
                     EventLog eventLog = (EventLog) item;
                     boolean nameAndPropertiesMatch = eventLog.getName().equals("name") && eventLog.getTypedProperties() == null;
                     boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("token");
-                    return nameAndPropertiesMatch && tokenMatch;
+                    boolean tagMatch = target.equals(eventLog.getTag());
+                    return nameAndPropertiesMatch && tokenMatch && tagMatch;
                 }
                 return false;
             }
@@ -177,7 +181,8 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
                     stringTypedProperty.setValue("valid");
                     typedProperties.add(stringTypedProperty);
                     boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("token2");
-                    return nameMatches && tokenMatch && typedProperties.equals(eventLog.getTypedProperties());
+                    boolean tagMatch = Analytics.getTransmissionTarget("token2").equals(eventLog.getTag());
+                    return nameMatches && tokenMatch && tagMatch && typedProperties.equals(eventLog.getTypedProperties());
                 }
                 return false;
             }
@@ -185,7 +190,7 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
         reset(mChannel);
 
         /* Create a child transmission target and track event. */
-        AnalyticsTransmissionTarget childTarget = target.getTransmissionTarget("token3");
+        final AnalyticsTransmissionTarget childTarget = target.getTransmissionTarget("token3");
         childTarget.trackEvent("name");
         verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
 
@@ -195,7 +200,8 @@ public class AnalyticsTransmissionTargetTest extends AbstractAnalyticsTest {
                     EventLog eventLog = (EventLog) item;
                     boolean nameAndPropertiesMatch = eventLog.getName().equals("name") && eventLog.getTypedProperties() == null;
                     boolean tokenMatch = eventLog.getTransmissionTargetTokens().size() == 1 && eventLog.getTransmissionTargetTokens().contains("token3");
-                    return nameAndPropertiesMatch && tokenMatch;
+                    boolean tagMatch = childTarget.equals(eventLog.getTag());
+                    return nameAndPropertiesMatch && tokenMatch && tagMatch;
                 }
                 return false;
             }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -29,7 +29,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -615,7 +614,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         /* Start analytics and simulate background thread handler (we hold the thread command and run it in the test). */
         Analytics analytics = Analytics.getInstance();
         AppCenterHandler handler = mock(AppCenterHandler.class);
-        final Collection<Runnable> backgroundCommands = new LinkedList<>();
+        final LinkedList<Runnable> backgroundCommands = new LinkedList<>();
         doAnswer(new Answer() {
 
             @Override
@@ -629,6 +628,9 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Create a target. */
         AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+
+        /* Init target background code now. */
+        backgroundCommands.removeFirst().run();
 
         /* Simulate a track event call with no property. */
         CommonSchemaLog logBeforeSetProperty = new CommonSchemaEventLog();

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/PropertyConfiguratorTest.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.provider.Settings.Secure;
 
+import com.microsoft.appcenter.AppCenterHandler;
 import com.microsoft.appcenter.analytics.ingestion.models.EventLog;
 import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
 import com.microsoft.appcenter.channel.Channel;
@@ -23,22 +24,29 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -116,7 +124,10 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         pc.setAppVersion("appVersion");
         pc.setAppName("appName");
         pc.setAppLocale("appLocale");
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
         log.addTransmissionTarget("test");
+        log.setTag(Analytics.getTransmissionTarget("test"));
         pc.onPreparingLog(log, "groupName");
 
         /* Assert properties set on common schema. */
@@ -138,7 +149,10 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         /* Get property configurator and collect device ID. */
         PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
         pc.collectDeviceId();
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
         log.addTransmissionTarget("test");
+        log.setTag(Analytics.getTransmissionTarget("test"));
         pc.onPreparingLog(log, "groupName");
 
         /* Assert device ID is collected. */
@@ -161,7 +175,10 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         /* Get property configurator and collect device ID. */
         PropertyConfigurator pc = Analytics.getTransmissionTarget("test").getPropertyConfigurator();
         pc.collectDeviceId();
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
         log.addTransmissionTarget("test");
+        log.setTag(Analytics.getTransmissionTarget("test"));
 
         /* Enable and simulate log preparing. */
         Analytics.setEnabled(true).get();
@@ -183,7 +200,10 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         target.getPropertyConfigurator().setAppVersion("appVersion");
         target.getPropertyConfigurator().setAppName("appName");
         target.getPropertyConfigurator().setAppLocale("appLocale");
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
         log.addTransmissionTarget("test");
+        log.setTag(target);
         target.getPropertyConfigurator().onPreparingLog(log, "groupName");
 
         /* Assert properties are null. */
@@ -211,16 +231,13 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         grandparent.getPropertyConfigurator().setAppName("appName");
         grandparent.getPropertyConfigurator().setAppLocale("appLocale");
 
-        /* Mock Secure and set device ID. */
-        mockStatic(Secure.class);
-        when(Secure.getString(any(ContentResolver.class), anyString())).thenReturn("mockDeviceId");
-
         /* Set up hierarchy. */
         AnalyticsTransmissionTarget parent = grandparent.getTransmissionTarget("parent");
         AnalyticsTransmissionTarget child = parent.getTransmissionTarget("child");
 
         /* Simulate channel callbacks. */
         log.addTransmissionTarget("child");
+        log.setTag(child);
         grandparent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         parent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         child.getPropertyConfigurator().onPreparingLog(log, "groupName");
@@ -252,6 +269,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Simulate channel callbacks. */
         log.addTransmissionTarget("grandParent");
+        log.setTag(grandparent);
         grandparent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         parent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         child.getPropertyConfigurator().onPreparingLog(log, "groupName");
@@ -275,6 +293,7 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
 
         /* Simulate channel callbacks. */
         log.addTransmissionTarget("child");
+        log.setTag(child);
         grandparent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         parent.getPropertyConfigurator().onPreparingLog(log, "groupName");
         child.getPropertyConfigurator().onPreparingLog(log, "groupName");
@@ -546,5 +565,114 @@ public class PropertyConfiguratorTest extends AbstractAnalyticsTest {
         typedProperties.add(typedProperty("f", new Date(6666)));
         typedProperties.add(typedProperty("g", "7777"));
         assertUnorderedListEquals(typedProperties, log.getTypedProperties());
+    }
+
+    @Test
+    public void defaultTargetIsNotReturnedFromGetTransmissionTarget() {
+
+        /* Start the application with a token. */
+        Analytics analytics = Analytics.getInstance();
+        analytics.onStarting(mAppCenterHandler);
+        String defaultToken = "test";
+        analytics.onStarted(mock(Context.class), mChannel, null, defaultToken, true);
+
+        /* Create the test target with the same default token. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget(defaultToken);
+
+        /* Verify it's not the same instance. */
+        assertNotSame(target, analytics.mDefaultTransmissionTarget);
+
+        /* Set a Part A property on the target. */
+        target.getPropertyConfigurator().setAppName("someName");
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
+        CommonSchemaLog log = new CommonSchemaEventLog();
+        log.setExt(new Extensions());
+        log.getExt().setApp(new AppExtension());
+        log.addTransmissionTarget("test");
+        log.setTag(target);
+
+        /* When the callback is called on the default target. */
+        analytics.mDefaultTransmissionTarget.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Then the log is not modified. */
+        assertNull(log.getExt().getApp().getName());
+
+        /* When the callback is called on the returned target. */
+        target.getPropertyConfigurator().onPreparingLog(log, "groupName");
+
+        /* Check the property is added to the log. */
+        assertEquals("someName", log.getExt().getApp().getName());
+    }
+
+    @Test
+    public void overridingPartAIsNotRetroactive() {
+
+        /* Mock deviceId. */
+        mockStatic(Secure.class);
+        when(Secure.getString(any(ContentResolver.class), anyString())).thenReturn("mockDeviceId");
+
+        /* Start analytics and simulate background thread handler (we hold the thread command and run it in the test). */
+        Analytics analytics = Analytics.getInstance();
+        AppCenterHandler handler = mock(AppCenterHandler.class);
+        final Collection<Runnable> backgroundCommands = new LinkedList<>();
+        doAnswer(new Answer() {
+
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                backgroundCommands.add((Runnable) invocation.getArguments()[0]);
+                return null;
+            }
+        }).when(handler).post(notNull(Runnable.class), any(Runnable.class));
+        analytics.onStarting(handler);
+        analytics.onStarted(mock(Context.class), mChannel, null, null, true);
+
+        /* Create a target. */
+        AnalyticsTransmissionTarget target = Analytics.getTransmissionTarget("test");
+
+        /* Simulate a track event call with no property. */
+        CommonSchemaLog logBeforeSetProperty = new CommonSchemaEventLog();
+        logBeforeSetProperty.setExt(new Extensions());
+        logBeforeSetProperty.getExt().setApp(new AppExtension());
+        logBeforeSetProperty.getExt().setDevice(new DeviceExtension());
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
+        logBeforeSetProperty.addTransmissionTarget("test");
+        logBeforeSetProperty.setTag(target);
+
+        /* Set all common properties that should not be set retroactively before first log persisted. */
+        target.getPropertyConfigurator().setAppVersion("appVersion");
+        target.getPropertyConfigurator().setAppLocale("appLocale");
+        target.getPropertyConfigurator().setAppName("appName");
+        target.getPropertyConfigurator().collectDeviceId();
+
+        /* Run background commands in order: first prepare first log, then all the set property calls. */
+        target.getPropertyConfigurator().onPreparingLog(logBeforeSetProperty, "groupName");
+        for (Runnable command : backgroundCommands) {
+            command.run();
+        }
+
+        /* Simulate the second track event call. */
+        CommonSchemaLog logAfterSetProperty = new CommonSchemaEventLog();
+        logAfterSetProperty.setExt(new Extensions());
+        logAfterSetProperty.getExt().setApp(new AppExtension());
+        logAfterSetProperty.getExt().setDevice(new DeviceExtension());
+
+        /* Simulate what the pipeline does to convert from App Center to Common Schema. */
+        logAfterSetProperty.addTransmissionTarget("test");
+        logAfterSetProperty.setTag(target);
+        target.getPropertyConfigurator().onPreparingLog(logAfterSetProperty, "groupName");
+
+        /* Check first log has no property. */
+        assertNull(logBeforeSetProperty.getExt().getApp().getVer());
+        assertNull(logBeforeSetProperty.getExt().getApp().getLocale());
+        assertNull(logBeforeSetProperty.getExt().getApp().getName());
+        assertNull(logBeforeSetProperty.getExt().getDevice().getLocalId());
+
+        /* Check second log has all of them. */
+        assertEquals("appVersion", logAfterSetProperty.getExt().getApp().getVer());
+        assertEquals("appLocale", logAfterSetProperty.getExt().getApp().getLocale());
+        assertEquals("appName", logAfterSetProperty.getExt().getApp().getName());
+        assertEquals("a:mockDeviceId", logAfterSetProperty.getExt().getDevice().getLocalId());
     }
 }

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactoryTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/ingestion/models/json/EventLogFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Matchers.same;
@@ -77,14 +78,27 @@ public class EventLogFactoryTest {
         /* With 2 targets. */
         log.addTransmissionTarget("t1");
         log.addTransmissionTarget("t2");
+
+        /* And with a tag. */
+        Object tag = new Object();
+        log.setTag(tag);
+
+        /* When we convert logs. */
         Collection<CommonSchemaLog> convertedLogs = new EventLogFactory().toCommonSchemaLogs(log);
+
+        /* Check number of logs: 1 per target. */
         assertNotNull(convertedLogs);
         assertEquals(2, convertedLogs.size());
 
-        /* Check name was added. */
+        /* For each target. */
         for (CommonSchemaLog commonSchemaLog : convertedLogs) {
+
+            /* Check name was added. */
             verifyStatic();
             PartAUtils.setName(same(commonSchemaLog), eq("test"));
+
+            /* Check tag was added. */
+            assertSame(tag, commonSchemaLog.getTag());
         }
 
         /* Check Part A was added with target tokens. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
@@ -72,6 +72,11 @@ public abstract class AbstractLog implements Log {
      */
     private Device device;
 
+    /**
+     * Transient object tag.
+     */
+    private Object tag;
+
     @Override
     public Date getTimestamp() {
         return this.timestamp;
@@ -136,6 +141,16 @@ public abstract class AbstractLog implements Log {
         this.device = device;
     }
 
+    @Override
+    public Object getTag() {
+        return tag;
+    }
+
+    @Override
+    public void setTag(Object tag) {
+        this.tag = tag;
+    }
+
     /**
      * Adds a transmission target that this log should be sent to.
      *
@@ -188,7 +203,6 @@ public abstract class AbstractLog implements Log {
         }
     }
 
-    @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -202,7 +216,8 @@ public abstract class AbstractLog implements Log {
         if (sid != null ? !sid.equals(that.sid) : that.sid != null) return false;
         if (distributionGroupId != null ? !distributionGroupId.equals(that.distributionGroupId) : that.distributionGroupId != null)
             return false;
-        return device != null ? device.equals(that.device) : that.device == null;
+        if (device != null ? !device.equals(that.device) : that.device != null) return false;
+        return tag != null ? tag.equals(that.tag) : that.tag == null;
     }
 
     @Override
@@ -212,6 +227,7 @@ public abstract class AbstractLog implements Log {
         result = 31 * result + (sid != null ? sid.hashCode() : 0);
         result = 31 * result + (distributionGroupId != null ? distributionGroupId.hashCode() : 0);
         result = 31 * result + (device != null ? device.hashCode() : 0);
+        result = 31 * result + (tag != null ? tag.hashCode() : 0);
         return result;
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
@@ -85,4 +85,18 @@ public interface Log extends Model {
      */
     @SuppressWarnings("unused")
     Set<String> getTransmissionTargetTokens();
+
+    /**
+     * Get internal tag for this log.
+     *
+     * @return internal tag or null.
+     */
+    Object getTag();
+
+    /**
+     * Set internal tag for this log.
+     *
+     * @param tag tag object or null to reset tag.
+     */
+    void setTag(Object tag);
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
@@ -90,6 +90,12 @@ public class AbstractLogTest {
         checkNotEquals(a, b);
         b.setDevice(d1);
         checkEquals(a, b);
+
+        /* Tag. */
+        a.setTag(new Object());
+        checkNotEquals(a, b);
+        b.setTag(a.getTag());
+        checkEquals(a, b);
     }
 
     @Test


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated? (Yes but in https://msasg.visualstudio.com/Shared%20Data/_git/1dsdocs/pullrequest/809581?_a=overview)
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

* Fix part A properties to not be applied retro-actively.
* Fix distinction between default target and explicit target using the same token.
