### PR TITLE
Preventing stack overflow crash while reading a huge throwable file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 1.10.0 (Under active development)
+
+### AppCenterCrashes
+
+* **[Fix]** Preventing stack overflow crash while reading a huge throwable file.
+
+___
+
 ## Version 1.9.0
 
 ### AppCenter
@@ -13,6 +21,8 @@
 * **[Feature]** Add `pause`/`resume` APIs which pause/resume sending Analytics logs to App Center.
 * **[Feature]** Add support for typed properties. Note that these APIs still convert properties back to strings on the App Center backend. More work is needed to store and display typed properties in the App Center portal. Using the new APIs now will enable future scenarios, but for now the behavior will be the same as it is for current event properties.
 * **[Feature]** Preparation work for a future change in transmission protocol and endpoint for Analytics data. There is no impact on your current workflow when using App Center.
+
+___
 
 ## Version 1.8.0
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
@@ -19,7 +19,6 @@ import com.microsoft.appcenter.sasquatch.R;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Random;
 
 import static com.microsoft.appcenter.sasquatch.activities.CrashSubActivity.INTENT_EXTRA_CRASH_TYPE;
@@ -70,7 +69,7 @@ public class CrashActivity extends AppCompatActivity {
                 public void run() {
                     Exception e = new Exception();
                     for (int i = 0; i < 1000; i++) {
-                        e = new Exception(String.format(Locale.ROOT, "%d", i), e);
+                        e = new Exception(String.valueOf(i), e);
                     }
                     throw new RuntimeException(e);
                 }

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
@@ -64,7 +64,7 @@ public class CrashActivity extends AppCompatActivity {
                     run();
                 }
             }),
-            new Crash(R.string.title_deep_cause_exception_crash, R.string.description_deep_cause_exception_crash, new Runnable() {
+            new Crash(R.string.title_deeply_nested_exception_crash, R.string.description_deeply_nested_exception_crash, new Runnable() {
 
                 @Override
                 public void run() {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/CrashActivity.java
@@ -19,6 +19,7 @@ import com.microsoft.appcenter.sasquatch.R;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 import static com.microsoft.appcenter.sasquatch.activities.CrashSubActivity.INTENT_EXTRA_CRASH_TYPE;
@@ -61,6 +62,17 @@ public class CrashActivity extends AppCompatActivity {
                 @SuppressWarnings("InfiniteRecursion")
                 public void run() {
                     run();
+                }
+            }),
+            new Crash(R.string.title_deep_cause_exception_crash, R.string.description_deep_cause_exception_crash, new Runnable() {
+
+                @Override
+                public void run() {
+                    Exception e = new Exception();
+                    for (int i = 0; i < 1000; i++) {
+                        e = new Exception(String.format(Locale.ROOT, "%d", i), e);
+                    }
+                    throw new RuntimeException(e);
                 }
             }),
             new Crash(R.string.title_memory_crash, R.string.description_memory_crash, new Runnable() {

--- a/apps/sasquatch/src/main/res/values/crashes.xml
+++ b/apps/sasquatch/src/main/res/values/crashes.xml
@@ -6,8 +6,8 @@
     <string name="description_crash_divide_by_0" tools:ignore="MissingTranslation">Divide by 0</string>
     <string name="title_test_ui_crash" tools:ignore="MissingTranslation">Test some UI crash</string>
     <string name="description_test_ui_crash" tools:ignore="MissingTranslation">A UI coding mistake, has inner exception</string>
-    <string name="title_deep_cause_exception_crash" tools:ignore="MissingTranslation">A exception with plenty of causes</string>
-    <string name="description_deep_cause_exception_crash" tools:ignore="MissingTranslation">The exception that caused the exception that caused the exception that caused the exception…</string>
+    <string name="title_deeply_nested_exception_crash" tools:ignore="MissingTranslation">A exception with plenty of causes</string>
+    <string name="description_deeply_nested_exception_crash" tools:ignore="MissingTranslation">The exception that caused the exception that caused the exception that caused the exception…</string>
     <string name="title_stack_overflow_crash" tools:ignore="MissingTranslation">Stack overflow crash</string>
     <string name="description_stack_overflow_crash" tools:ignore="MissingTranslation">Caused by infinite recursion</string>
     <string name="title_memory_crash" tools:ignore="MissingTranslation">Out of memory crash</string>

--- a/apps/sasquatch/src/main/res/values/crashes.xml
+++ b/apps/sasquatch/src/main/res/values/crashes.xml
@@ -6,6 +6,8 @@
     <string name="description_crash_divide_by_0" tools:ignore="MissingTranslation">Divide by 0</string>
     <string name="title_test_ui_crash" tools:ignore="MissingTranslation">Test some UI crash</string>
     <string name="description_test_ui_crash" tools:ignore="MissingTranslation">A UI coding mistake, has inner exception</string>
+    <string name="title_deep_cause_exception_crash" tools:ignore="MissingTranslation">A exception with plenty of causes</string>
+    <string name="description_deep_cause_exception_crash" tools:ignore="MissingTranslation">The exception that caused the exception that caused the exception that caused the exception…</string>
     <string name="title_stack_overflow_crash" tools:ignore="MissingTranslation">Stack overflow crash</string>
     <string name="description_stack_overflow_crash" tools:ignore="MissingTranslation">Caused by infinite recursion</string>
     <string name="title_memory_crash" tools:ignore="MissingTranslation">Out of memory crash</string>

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -513,14 +513,17 @@ public class CrashesAndroidTest {
 
     @SuppressWarnings("SameParameterValue")
     private static RuntimeException generateHugeException(int stacktraceIncrease, int causes) {
-        if (stacktraceIncrease <= 0) {
-            Exception e = new Exception();
-            for (int i = 0; i < causes; i++) {
-                e = new Exception(String.format(Locale.ROOT, "%d", i), e);
+
+        if (stacktraceIncrease > 0) {
+            try {
+                return generateHugeException(stacktraceIncrease - 1, causes);
+            } catch (StackOverflowError ignore) {
             }
-            return new RuntimeException(e);
-        } else {
-            return generateHugeException(stacktraceIncrease - 1, causes);
         }
+        Exception e = new Exception();
+        for (int i = 0; i < causes; i++) {
+            e = new Exception(String.format(Locale.ROOT, "%d", i), e);
+        }
+        return new RuntimeException(e);
     }
 }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -131,7 +131,41 @@ public class CrashesAndroidTest {
     }
 
     @Test
-    public void getLastSessionCrashReport() throws Exception {
+    public void getLastSessionCrashReportSimpleException() throws Exception {
+
+        /* Null before start. */
+        Crashes.unsetInstance();
+        assertNull(Crashes.getLastSessionCrashReport().get());
+        assertFalse(Crashes.hasCrashedInLastSession().get());
+
+        /* Crash on 1st process. */
+        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
+        Thread.setDefaultUncaughtExceptionHandler(uncaughtExceptionHandler);
+        startFresh(null);
+        assertNull(Crashes.getLastSessionCrashReport().get());
+        assertFalse(Crashes.hasCrashedInLastSession().get());
+        final RuntimeException exception = new IllegalArgumentException();
+        final Thread thread = new Thread() {
+
+            @Override
+            public void run() {
+                throw exception;
+            }
+        };
+        thread.start();
+        thread.join();
+
+        /* Get last session crash on 2nd process. */
+        startFresh(null);
+        ErrorReport errorReport = Crashes.getLastSessionCrashReport().get();
+        assertNotNull(errorReport);
+        Throwable lastThrowable = errorReport.getThrowable();
+        assertTrue(lastThrowable instanceof IllegalArgumentException);
+        assertTrue(Crashes.hasCrashedInLastSession().get());
+    }
+
+    @Test
+    public void getLastSessionCrashReportStackOverflowException() throws Exception {
 
         /* Null before start. */
         Crashes.unsetInstance();
@@ -164,6 +198,56 @@ public class CrashesAndroidTest {
         assertTrue(lastThrowable instanceof StackOverflowError);
         assertEquals(ErrorLogHelper.FRAME_LIMIT, lastThrowable.getStackTrace().length);
         assertTrue(Crashes.hasCrashedInLastSession().get());
+    }
+
+    @Test
+    public void getLastSessionCrashReportExceptionWithHugeFramesAndHugeCauses() throws Exception {
+
+        /* Null before start. */
+        Crashes.unsetInstance();
+        assertNull(Crashes.getLastSessionCrashReport().get());
+        assertFalse(Crashes.hasCrashedInLastSession().get());
+
+        /* Crash on 1st process. */
+        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
+        Thread.setDefaultUncaughtExceptionHandler(uncaughtExceptionHandler);
+        startFresh(null);
+        assertNull(Crashes.getLastSessionCrashReport().get());
+        assertFalse(Crashes.hasCrashedInLastSession().get());
+        final RuntimeException exception = generateHugeException(300, 300);
+        assertTrue(exception.getStackTrace().length > ErrorLogHelper.FRAME_LIMIT);
+        final Thread thread = new Thread() {
+
+            @Override
+            public void run() {
+                throw exception;
+            }
+        };
+        thread.start();
+        thread.join();
+
+        /* Get last session crash on 2nd process. */
+        startFresh(null);
+        ErrorReport errorReport = Crashes.getLastSessionCrashReport().get();
+        assertNotNull(errorReport);
+
+        /* The client side throwable failed to save as huge so will be null. */
+        assertNull(errorReport.getThrowable());
+        assertTrue(Crashes.hasCrashedInLastSession().get());
+
+        /* Check managed error was sent as truncated. */
+        ArgumentCaptor<ManagedErrorLog> errorLog = ArgumentCaptor.forClass(ManagedErrorLog.class);
+        verify(mChannel).enqueue(errorLog.capture(), eq(Crashes.ERROR_GROUP));
+        assertNotNull(errorLog.getValue());
+        assertNotNull(errorLog.getValue().getException());
+        assertNotNull(errorLog.getValue().getException().getFrames());
+        assertEquals(ErrorLogHelper.FRAME_LIMIT, errorLog.getValue().getException().getFrames().size());
+        int causesCount = 0;
+        com.microsoft.appcenter.crashes.ingestion.models.Exception e = errorLog.getValue().getException();
+        while (e.getInnerExceptions() != null && (e = e.getInnerExceptions().get(0)) != null) {
+            causesCount++;
+        }
+        assertEquals(ErrorLogHelper.CAUSE_LIMIT, causesCount + 1);
     }
 
     @Test
@@ -242,6 +326,7 @@ public class CrashesAndroidTest {
     public void testNoDuplicateCallbacksOrSending() throws Exception {
 
         /* Crash on 1st process. */
+        Crashes.unsetInstance();
         assertFalse(Crashes.hasCrashedInLastSession().get());
         android.util.Log.i(TAG, "Process 1");
         Thread.UncaughtExceptionHandler uncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
@@ -259,8 +344,7 @@ public class CrashesAndroidTest {
         });
         when(crashesListener.shouldAwaitUserConfirmation()).thenReturn(true);
         startFresh(crashesListener);
-        final RuntimeException exception = generateHugeException(300, 100);
-        assertTrue(exception.getStackTrace().length > ErrorLogHelper.FRAME_LIMIT);
+        final RuntimeException exception = new RuntimeException();
         final Thread thread = new Thread() {
 
             @Override
@@ -270,7 +354,6 @@ public class CrashesAndroidTest {
         };
         thread.start();
         thread.join();
-        assertEquals(ErrorLogHelper.FRAME_LIMIT, exception.getStackTrace().length);
         verify(uncaughtExceptionHandler).uncaughtException(thread, exception);
         assertEquals(2, ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter).length);
         verifyZeroInteractions(crashesListener);
@@ -287,7 +370,6 @@ public class CrashesAndroidTest {
                 assertNotNull(errorReport);
                 Throwable lastThrowable = errorReport.getThrowable();
                 assertTrue(lastThrowable instanceof RuntimeException);
-                assertEquals(ErrorLogHelper.FRAME_LIMIT, lastThrowable.getStackTrace().length);
             }
         });
         assertTrue(Crashes.hasCrashedInLastSession().get());
@@ -370,19 +452,6 @@ public class CrashesAndroidTest {
         verify(crashesListener).onBeforeSending(any(ErrorReport.class));
         verify(crashesListener).onSendingSucceeded(any(ErrorReport.class));
         verifyNoMoreInteractions(crashesListener);
-
-        /* Verify log was truncated to 256 frames. */
-        assertTrue(log.get() instanceof ManagedErrorLog);
-        ManagedErrorLog errorLog = (ManagedErrorLog) log.get();
-        assertNotNull(errorLog.getException());
-        assertNotNull(errorLog.getException().getFrames());
-        assertEquals(ErrorLogHelper.FRAME_LIMIT, errorLog.getException().getFrames().size());
-        int causesCount = 0;
-        com.microsoft.appcenter.crashes.ingestion.models.Exception e = errorLog.getException();
-        while (e.getInnerExceptions() != null && (e = e.getInnerExceptions().get(0)) != null) {
-            causesCount++;
-        }
-        assertEquals(ErrorLogHelper.CAUSE_LIMIT, causesCount + 1);
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -229,9 +229,7 @@ public class CrashesAndroidTest {
         File invalidFile1 = new File(ErrorLogHelper.getErrorStorageDirectory(), UUIDUtils.randomUUID() + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION);
         File invalidFile2 = new File(ErrorLogHelper.getErrorStorageDirectory(), UUIDUtils.randomUUID() + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION);
         assertTrue(invalidFile1.createNewFile());
-        FileWriter fw = new FileWriter(invalidFile2);
-        fw.write("{{{");
-        fw.close();
+        new FileWriter(invalidFile2).append("fake_data").close();
         assertEquals(2, ErrorLogHelper.getStoredErrorLogFiles().length);
 
         /* Invalid files should be cleared. */

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -597,7 +597,6 @@ public class CrashesAndroidTest {
 
     @SuppressWarnings("SameParameterValue")
     private static RuntimeException generateHugeException(int stacktraceIncrease, int causes) {
-
         if (stacktraceIncrease > 0) {
             try {
                 return generateHugeException(stacktraceIncrease - 1, causes);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -744,19 +744,17 @@ public class Crashes extends AbstractAppCenterService {
         } else {
             File file = ErrorLogHelper.getStoredThrowableFile(id);
             if (file != null) {
-                try {
-                    Throwable throwable = null;
-                    if (file.length() > 0) {
+                Throwable throwable = null;
+                if (file.length() > 0) {
+                    try {
                         throwable = StorageHelper.InternalStorage.readObject(file);
+                    } catch (IOException | ClassNotFoundException | StackOverflowError e) {
+                        AppCenterLog.error(LOG_TAG, "Cannot read throwable file " + file.getName(), e);
                     }
-                    ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(log, throwable);
-                    mErrorReportCache.put(id, new ErrorLogReport(log, report));
-                    return report;
-                } catch (ClassNotFoundException | StackOverflowError e) {
-                    AppCenterLog.error(LOG_TAG, "Cannot read throwable file " + file.getName(), e);
-                } catch (IOException e) {
-                    AppCenterLog.error(LOG_TAG, "Cannot access serialized throwable file " + file.getName(), e);
                 }
+                ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(log, throwable);
+                mErrorReportCache.put(id, new ErrorLogReport(log, report));
+                return report;
             }
         }
         return null;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -617,6 +617,13 @@ public class Crashes extends AbstractAppCenterService {
 
             /* Check last session crash. */
             File logFile = ErrorLogHelper.getLastErrorLogFile();
+            while (logFile != null && logFile.length() == 0) {
+                AppCenterLog.warn(Crashes.LOG_TAG, "Deleting empty error file: " + logFile);
+
+                //noinspection ResultOfMethodCallIgnored
+                logFile.delete();
+                logFile = ErrorLogHelper.getLastErrorLogFile();
+            }
             if (logFile != null) {
                 AppCenterLog.debug(LOG_TAG, "Processing crash report for the last session.");
                 String logFileContents = StorageHelper.InternalStorage.read(logFile);
@@ -637,13 +644,6 @@ public class Crashes extends AbstractAppCenterService {
 
     private void processPendingErrors() {
         for (File logFile : ErrorLogHelper.getStoredErrorLogFiles()) {
-            if (logFile.length() == 0) {
-                AppCenterLog.warn(Crashes.LOG_TAG, "Deleting empty error file: " + logFile);
-
-                //noinspection ResultOfMethodCallIgnored
-                logFile.delete();
-                continue;
-            }
             AppCenterLog.debug(LOG_TAG, "Process pending error file: " + logFile);
             String logfileContents = StorageHelper.InternalStorage.read(logFile);
             if (logfileContents != null) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -752,10 +752,10 @@ public class Crashes extends AbstractAppCenterService {
                     ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(log, throwable);
                     mErrorReportCache.put(id, new ErrorLogReport(log, report));
                     return report;
-                } catch (ClassNotFoundException ignored) {
-                    AppCenterLog.error(LOG_TAG, "Cannot read throwable file " + file.getName(), ignored);
-                } catch (IOException ignored) {
-                    AppCenterLog.error(LOG_TAG, "Cannot access serialized throwable file " + file.getName(), ignored);
+                } catch (ClassNotFoundException | StackOverflowError e) {
+                    AppCenterLog.error(LOG_TAG, "Cannot read throwable file " + file.getName(), e);
+                } catch (IOException e) {
+                    AppCenterLog.error(LOG_TAG, "Cannot access serialized throwable file " + file.getName(), e);
                 }
             }
         }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -944,9 +944,18 @@ public class Crashes extends AbstractAppCenterService {
         AppCenterLog.debug(Crashes.LOG_TAG, "Saved JSON content for ingestion into " + errorLogFile);
         File throwableFile = new File(errorStorageDirectory, filename + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
         if (throwable != null) {
-            StorageHelper.InternalStorage.writeObject(throwableFile, throwable);
-            AppCenterLog.debug(Crashes.LOG_TAG, "Saved Throwable as is for client side inspection in " + throwableFile + " throwable:", throwable);
-        } else {
+            try {
+                StorageHelper.InternalStorage.writeObject(throwableFile, throwable);
+                AppCenterLog.debug(Crashes.LOG_TAG, "Saved Throwable as is for client side inspection in " + throwableFile + " throwable:", throwable);
+            } catch (StackOverflowError e) {
+                AppCenterLog.error(Crashes.LOG_TAG, "Failed to store throwable", e);
+                throwable = null;
+
+                //noinspection ResultOfMethodCallIgnored
+                throwableFile.delete();
+            }
+        }
+        if (throwable == null) {
 
             /*
              * If there is no Java Throwable to save as is (typical in wrapper SDKs),

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -637,6 +637,13 @@ public class Crashes extends AbstractAppCenterService {
 
     private void processPendingErrors() {
         for (File logFile : ErrorLogHelper.getStoredErrorLogFiles()) {
+            if (logFile.length() == 0) {
+                AppCenterLog.warn(Crashes.LOG_TAG, "Deleting empty error file: " + logFile);
+
+                //noinspection ResultOfMethodCallIgnored
+                logFile.delete();
+                continue;
+            }
             AppCenterLog.debug(LOG_TAG, "Process pending error file: " + logFile);
             String logfileContents = StorageHelper.InternalStorage.read(logFile);
             if (logfileContents != null) {
@@ -656,7 +663,10 @@ public class Crashes extends AbstractAppCenterService {
                         removeAllStoredErrorLogFiles(id);
                     }
                 } catch (JSONException e) {
-                    AppCenterLog.error(LOG_TAG, "Error parsing error log", e);
+                    AppCenterLog.error(LOG_TAG, "Error parsing error log. Deleting invalid file: " + logFile, e);
+
+                    //noinspection ResultOfMethodCallIgnored
+                    logFile.delete();
                 }
             }
         }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -66,7 +66,7 @@ public class ErrorLogHelper {
      * For huge stack traces such as giant StackOverflowError, we keep only beginning and end of frames according to this limit.
      */
     @VisibleForTesting
-    static final int FRAME_LIMIT = 256;
+    public static final int FRAME_LIMIT = 256;
 
     /**
      * We keep the first half of the limit of frames from the beginning and the second half from end.
@@ -77,7 +77,7 @@ public class ErrorLogHelper {
      * For huge exception cause chains, we keep only beginning and end of causes according to this limit.
      */
     @VisibleForTesting
-    static final int CAUSE_LIMIT = 16;
+    public static final int CAUSE_LIMIT = 16;
 
     /**
      * We keep the first half of the limit of causes from the beginning and the second half from end.
@@ -320,6 +320,7 @@ public class ErrorLogHelper {
             causeChain.add(cause);
         }
         if (causeChain.size() > CAUSE_LIMIT) {
+            AppCenterLog.warn(Crashes.LOG_TAG, "Crash causes truncated from " + causeChain.size() + " to " + CAUSE_LIMIT + " causes.");
             causeChain.subList(CAUSE_LIMIT_HALF, causeChain.size() - CAUSE_LIMIT_HALF).clear();
         }
         for (Throwable cause: causeChain) {

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -885,6 +885,7 @@ public class CrashesTest {
         File throwableFile = mock(File.class);
         when(throwableFile.length()).thenReturn(1L);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(Throwable.class))).thenReturn(mock(ErrorReport.class));
 
         /* Mock exceptions. */
         Throwable classNotFoundException = mock(ClassNotFoundException.class);
@@ -898,19 +899,21 @@ public class CrashesTest {
 
         /* Test ClassNotFoundException. */
         ErrorReport report = crashes.buildErrorReport(mErrorLog);
-        assertNull(report);
+        assertNotNull(report);
         verifyStatic();
         AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(classNotFoundException));
 
         /* Test IOException. */
+        mErrorLog.setId(UUIDUtils.randomUUID());
         report = crashes.buildErrorReport(mErrorLog);
-        assertNull(report);
+        assertNotNull(report);
         verifyStatic();
         AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(ioException));
 
         /* Test StackOverflowError. */
+        mErrorLog.setId(UUIDUtils.randomUUID());
         report = crashes.buildErrorReport(mErrorLog);
-        assertNull(report);
+        assertNotNull(report);
         verifyStatic();
         AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(stackOverflowError));
     }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -886,21 +886,33 @@ public class CrashesTest {
         when(throwableFile.length()).thenReturn(1L);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
 
-        Exception classNotFoundException = mock(ClassNotFoundException.class);
-        Exception ioException = mock(IOException.class);
-        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenThrow(classNotFoundException).thenThrow(ioException);
-
+        /* Mock exceptions. */
+        Throwable classNotFoundException = mock(ClassNotFoundException.class);
+        Throwable ioException = mock(IOException.class);
+        Throwable stackOverflowError = mock(StackOverflowError.class);
+        when(StorageHelper.InternalStorage.readObject(any(File.class)))
+                .thenThrow(classNotFoundException)
+                .thenThrow(ioException)
+                .thenThrow(stackOverflowError);
         Crashes crashes = Crashes.getInstance();
 
+        /* Test ClassNotFoundException. */
         ErrorReport report = crashes.buildErrorReport(mErrorLog);
         assertNull(report);
-        report = crashes.buildErrorReport(mErrorLog);
-        assertNull(report);
-
         verifyStatic();
         AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(classNotFoundException));
+
+        /* Test IOException. */
+        report = crashes.buildErrorReport(mErrorLog);
+        assertNull(report);
         verifyStatic();
         AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(ioException));
+
+        /* Test StackOverflowError. */
+        report = crashes.buildErrorReport(mErrorLog);
+        assertNull(report);
+        verifyStatic();
+        AppCenterLog.error(eq(Crashes.LOG_TAG), anyString(), eq(stackOverflowError));
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -702,7 +702,9 @@ public class CrashesTest {
         ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, EXCEPTION);
 
         mockStatic(ErrorLogHelper.class);
-        when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(mock(File.class));
+        File errorLogFile = mock(File.class);
+        when(errorLogFile.length()).thenReturn(1L);
+        when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(errorLogFile);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         File throwableFile = mock(File.class);
@@ -1002,6 +1004,7 @@ public class CrashesTest {
 
         mockStatic(ErrorLogHelper.class);
         File lastErrorLogFile = errorStorageDirectory.newFile("last-error-log.json");
+        new FileWriter(lastErrorLogFile).append("fake_data").close();
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(lastErrorLogFile);
         File throwableFile = errorStorageDirectory.newFile();
         new FileWriter(throwableFile).append("fake_data").close();
@@ -1009,7 +1012,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getErrorReportFromErrorLog(errorLog, throwable)).thenReturn(errorReport);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{lastErrorLogFile});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("");
+        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("fake_data");
         when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(throwable);
 
         Crashes crashes = Crashes.getInstance();
@@ -1074,10 +1077,11 @@ public class CrashesTest {
 
         mockStatic(ErrorLogHelper.class);
         File lastErrorLogFile = errorStorageDirectory.newFile("last-error-log.json");
+        new FileWriter(lastErrorLogFile).append("fake_data").close();
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(lastErrorLogFile);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{lastErrorLogFile});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("");
+        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("fake_data");
 
         Crashes crashes = Crashes.getInstance();
         crashes.setLogSerializer(logSerializer);
@@ -1111,6 +1115,7 @@ public class CrashesTest {
     public void crashInLastSessionCorrupted() throws IOException {
         mockStatic(ErrorLogHelper.class);
         File file = errorStorageDirectory.newFile("last-error-log.json");
+        new FileWriter(file).append("fake_data").close();
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{file});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(file);
@@ -1360,7 +1365,9 @@ public class CrashesTest {
         when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenReturn(mock(Device.class));
         ErrorReport report = new ErrorReport();
         mockStatic(ErrorLogHelper.class);
-        when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(mock(File.class));
+        File errorLogFile = mock(File.class);
+        when(errorLogFile.length()).thenReturn(1L);
+        when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(errorLogFile);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{minidumpFile});
         File pendingDir = mock(File.class);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClient.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClient.java
@@ -99,6 +99,11 @@ public class DefaultHttpClient implements HttpClient {
     private static final int MIN_GZIP_LENGTH = 1400;
 
     /**
+     * Maximum payload length to use prettify for logging.
+     */
+    private static final int MAX_PRETTIFY_LOG_LENGTH = 4 * 1024;
+
+    /**
      * Pattern used to replace token in url encoded parameters.
      */
     private static final Pattern TOKEN_REGEX_URL_ENCODED = Pattern.compile("token=[^&]+");
@@ -215,14 +220,18 @@ public class DefaultHttpClient implements HttpClient {
             /* Send payload. */
             if (binaryPayload != null) {
 
-                /* Compress payload if large enough to be worth it. */
+                /* Log payload. */
                 if (AppCenterLog.getLogLevel() <= Log.VERBOSE) {
-                    payload = TOKEN_REGEX_URL_ENCODED.matcher(payload).replaceAll("token=***");
-                    if (CONTENT_TYPE_VALUE.equals(headers.get(CONTENT_TYPE_KEY))) {
-                        payload = new JSONObject(payload).toString(2);
+                    if (payload.length() < MAX_PRETTIFY_LOG_LENGTH) {
+                        payload = TOKEN_REGEX_URL_ENCODED.matcher(payload).replaceAll("token=***");
+                        if (CONTENT_TYPE_VALUE.equals(headers.get(CONTENT_TYPE_KEY))) {
+                            payload = new JSONObject(payload).toString(2);
+                        }
                     }
                     AppCenterLog.verbose(LOG_TAG, payload);
                 }
+
+                /* Compress payload if large enough to be worth it. */
                 if (shouldCompress) {
                     ByteArrayOutputStream gzipBuffer = new ByteArrayOutputStream(binaryPayload.length);
                     GZIPOutputStream gzipStream = new GZIPOutputStream(gzipBuffer);


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Preventing stack overflow crash while reading a huge throwable file.

## Related PRs or issues

#855
