### PR TITLE
Fix test reliability of truncating causes

### DIFF
--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -344,4 +344,18 @@ public class ErrorLogHelperTest {
         assertEquals(1, actualProperties.size());
         assertEquals(truncatedMapItem, actualProperties.get(truncatedMapItem));
     }
+
+    @Test
+    public void truncateCauses() {
+        RuntimeException e = new RuntimeException();
+        for (int i = 0; i < 32; i++) {
+            e = new RuntimeException(Integer.valueOf(i).toString(), e);
+        }
+        int depth = 1;
+        Exception model = ErrorLogHelper.getModelExceptionFromThrowable(e);
+        while (model.getInnerExceptions() != null && (model = model.getInnerExceptions().get(0)) != null) {
+            depth++;
+        }
+        assertEquals(ErrorLogHelper.CAUSE_LIMIT, depth);
+    }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Last attempts were not enough: https://msmobilecenter.visualstudio.com/SDK/_build/results?buildId=375780&view=logs

To verify cause truncation we just need to test utility anyway.

Needed for #866 