### PR TITLE
Implement userId in AppCenter crashes

### DIFF
--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.Constants;
 import com.microsoft.appcenter.Flags;
 import com.microsoft.appcenter.SessionContext;
@@ -533,6 +534,7 @@ public class Crashes extends AbstractAppCenterService {
             public void run() {
                 HandledErrorLog errorLog = new HandledErrorLog();
                 errorLog.setId(UUID.randomUUID());
+                errorLog.setUserId(AppCenter.getInstance().getUserId());
                 errorLog.setException(exceptionModelBuilder.buildExceptionModel());
                 errorLog.setProperties(properties);
                 mChannel.enqueue(errorLog, ERROR_GROUP, Flags.DEFAULTS);
@@ -597,10 +599,11 @@ public class Crashes extends AbstractAppCenterService {
                 errorLog.setProcessName("");
 
                 /*
-                 * TODO device properties are read after restart contrary to Java crashes.
-                 * We should have a device property history like we did for session to fix that issue.
-                 * The main issue with the current code is that app version can change between crash and reporting.
+                 * TODO user id and device properties are read after restart contrary to Java crashes.
+                 * We should have a user/device property history like we did for session to fix that issue.
+                 * The main issue with the current code is that app version or userId can change between crash and reporting.
                  */
+                errorLog.setUserId(AppCenter.getInstance().getUserId());
                 try {
                     errorLog.setDevice(DeviceInfoHelper.getDeviceInfo(mContext));
                     errorLog.getDevice().setWrapperSdkName(Constants.WRAPPER_SDK_NAME_NDK);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.Constants;
 import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.crashes.ingestion.models.Exception;
@@ -129,6 +130,9 @@ public class ErrorLogHelper {
 
         /* Set current time. Will be correlated to session after restart. */
         errorLog.setTimestamp(new Date());
+
+        /* Set user identifier. */
+        errorLog.setUserId(AppCenter.getInstance().getUserId());
 
         /* Snapshot device properties. */
         try {
@@ -323,7 +327,7 @@ public class ErrorLogHelper {
             AppCenterLog.warn(Crashes.LOG_TAG, "Crash causes truncated from " + causeChain.size() + " to " + CAUSE_LIMIT + " causes.");
             causeChain.subList(CAUSE_LIMIT_HALF, causeChain.size() - CAUSE_LIMIT_HALF).clear();
         }
-        for (Throwable cause: causeChain) {
+        for (Throwable cause : causeChain) {
             Exception exception = new Exception();
             exception.setType(cause.getClass().getName());
             exception.setMessage(cause.getMessage());

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/json/LogSerializerAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/ingestion/models/json/LogSerializerAndroidTest.java
@@ -8,7 +8,6 @@ import com.microsoft.appcenter.ingestion.models.StartServiceLog;
 import com.microsoft.appcenter.utils.UUIDUtils;
 
 import org.json.JSONException;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -21,6 +20,7 @@ import java.util.UUID;
 
 import static com.microsoft.appcenter.ingestion.models.json.MockLog.MOCK_LOG_TYPE;
 import static com.microsoft.appcenter.test.TestUtils.TAG;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -35,7 +35,7 @@ public class LogSerializerAndroidTest {
         String payload = serializer.serializeContainer(expectedContainer);
         android.util.Log.v(TAG, payload);
         LogContainer actualContainer = serializer.deserializeContainer(payload, null);
-        Assert.assertEquals(expectedContainer, actualContainer);
+        assertEquals(expectedContainer, actualContainer);
     }
 
     @Test
@@ -46,8 +46,8 @@ public class LogSerializerAndroidTest {
         String payload = serializer.serializeContainer(expectedContainer);
         android.util.Log.v(TAG, payload);
         LogContainer actualContainer = serializer.deserializeContainer(payload, null);
-        Assert.assertEquals(expectedContainer, actualContainer);
-        Assert.assertEquals(expectedContainer.hashCode(), actualContainer.hashCode());
+        assertEquals(expectedContainer, actualContainer);
+        assertEquals(expectedContainer.hashCode(), actualContainer.hashCode());
     }
 
     @Test(expected = JSONException.class)
@@ -76,7 +76,22 @@ public class LogSerializerAndroidTest {
         serializer.addLogFactory(StartServiceLog.TYPE, new StartServiceLogFactory());
         String payload = serializer.serializeLog(log);
         Log actualContainer = serializer.deserializeLog(payload, null);
-        Assert.assertEquals(log, actualContainer);
+        assertEquals(log, actualContainer);
+    }
+
+    @Test
+    public void logWithUserId() throws JSONException {
+        MockLog expectedLog = AndroidTestUtils.generateMockLog();
+        expectedLog.setTimestamp(new Date());
+        expectedLog.setUserId("charlie");
+
+        /* Verify serialize and deserialize. */
+        LogSerializer serializer = new DefaultLogSerializer();
+        serializer.addLogFactory(MOCK_LOG_TYPE, new MockLogFactory());
+        String payload = serializer.serializeLog(expectedLog);
+        Log actualLog = serializer.deserializeLog(payload, null);
+        assertEquals(expectedLog, actualLog);
+        assertEquals("charlie", actualLog.getUserId());
     }
 
     @Test
@@ -87,6 +102,8 @@ public class LogSerializerAndroidTest {
         properties.put("t2", new Date(0));
         properties.put("t3", 0);
         properties.put("t4", false);
+
+        //noinspection ConstantConditions
         properties.put("t5", null);
         log.setProperties(properties);
         UUID sid = UUIDUtils.randomUUID();
@@ -98,7 +115,7 @@ public class LogSerializerAndroidTest {
         serializer.addLogFactory(CustomPropertiesLog.TYPE, new CustomPropertiesLogFactory());
         String payload = serializer.serializeLog(log);
         Log actualContainer = serializer.deserializeLog(payload, null);
-        Assert.assertEquals(log, actualContainer);
+        assertEquals(log, actualContainer);
     }
 
     @Test(expected = JSONException.class)

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/Constants.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/Constants.java
@@ -28,6 +28,11 @@ public class Constants {
     static final int DEFAULT_TRIGGER_MAX_PARALLEL_REQUESTS = 3;
 
     /**
+     * Maximum allowed length for user identifier for App Center server.
+     */
+    static final int USER_ID_MAX_LENGTH = 256;
+
+    /**
      * Path where crash logs and temporary files are stored.
      */
     public static String FILES_PATH = null;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/AbstractLog.java
@@ -26,20 +26,22 @@ public abstract class AbstractLog implements Log {
     /**
      * timestamp property.
      */
-    @VisibleForTesting
-    static final String TIMESTAMP = "timestamp";
+    private static final String TIMESTAMP = "timestamp";
 
     /**
      * Session identifier property.
      */
-    @VisibleForTesting
-    static final String SID = "sid";
+    private static final String SID = "sid";
 
     /**
      * Distribution group ID property.
      */
-    @VisibleForTesting
-    static final String DISTRIBUTION_GROUP_ID = "distributionGroupId";
+    private static final String DISTRIBUTION_GROUP_ID = "distributionGroupId";
+
+    /**
+     * UserID property.
+     */
+    private static final String USER_ID = "userId";
 
     /**
      * device property.
@@ -68,6 +70,11 @@ public abstract class AbstractLog implements Log {
     private String distributionGroupId;
 
     /**
+     * The optional user identifier.
+     */
+    private String userId;
+
+    /**
      * Device characteristics associated to this log.
      */
     private Device device;
@@ -87,56 +94,42 @@ public abstract class AbstractLog implements Log {
         this.timestamp = timestamp;
     }
 
-    /**
-     * Get the sid value.
-     *
-     * @return the sid value
-     */
+    @Override
     public UUID getSid() {
         return this.sid;
     }
 
-    /**
-     * Set the sid value.
-     *
-     * @param sid the sid value to set
-     */
+    @Override
     public void setSid(UUID sid) {
         this.sid = sid;
     }
 
-    /**
-     * Get the distributionGroupId value.
-     *
-     * @return the distributionGroupId value.
-     */
+    @Override
     public String getDistributionGroupId() {
         return this.distributionGroupId;
     }
 
-    /**
-     * Set the distributionGroupId value.
-     *
-     * @param distributionGroupId the distributionGroupId value to set.
-     */
+    @Override
     public void setDistributionGroupId(String distributionGroupId) {
         this.distributionGroupId = distributionGroupId;
     }
 
-    /**
-     * Get the device value.
-     *
-     * @return the device value
-     */
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    @Override
     public Device getDevice() {
         return this.device;
     }
 
-    /**
-     * Set the device value.
-     *
-     * @param device the device value to set
-     */
+    @Override
     public void setDevice(Device device) {
         this.device = device;
     }
@@ -151,21 +144,11 @@ public abstract class AbstractLog implements Log {
         this.tag = tag;
     }
 
-    /**
-     * Adds a transmission target that this log should be sent to.
-     *
-     * @param transmissionTargetToken the identifier of the transmission target.
-     */
     @Override
     public synchronized void addTransmissionTarget(String transmissionTargetToken) {
         transmissionTargetTokens.add(transmissionTargetToken);
     }
 
-    /**
-     * Gets all transmissionTargetTokens that this log should be sent to.
-     *
-     * @return Collection of transmissionTargetTokens that this log should be sent to.
-     */
     @Override
     public synchronized Set<String> getTransmissionTargetTokens() {
         return Collections.unmodifiableSet(transmissionTargetTokens);
@@ -177,6 +160,7 @@ public abstract class AbstractLog implements Log {
         writer.key(TIMESTAMP).value(JSONDateUtils.toString(getTimestamp()));
         JSONUtils.write(writer, SID, getSid());
         JSONUtils.write(writer, DISTRIBUTION_GROUP_ID, getDistributionGroupId());
+        JSONUtils.write(writer, USER_ID, getUserId());
         if (getDevice() != null) {
             writer.key(DEVICE).object();
             getDevice().write(writer);
@@ -193,9 +177,8 @@ public abstract class AbstractLog implements Log {
         if (object.has(SID)) {
             setSid(UUID.fromString(object.getString(SID)));
         }
-        if (object.has(DISTRIBUTION_GROUP_ID)) {
-            setDistributionGroupId(object.getString(DISTRIBUTION_GROUP_ID));
-        }
+        setDistributionGroupId(object.optString(DISTRIBUTION_GROUP_ID, null));
+        setUserId(object.optString(USER_ID, null));
         if (object.has(DEVICE)) {
             Device device = new Device();
             device.read(object.getJSONObject(DEVICE));
@@ -216,6 +199,7 @@ public abstract class AbstractLog implements Log {
         if (sid != null ? !sid.equals(that.sid) : that.sid != null) return false;
         if (distributionGroupId != null ? !distributionGroupId.equals(that.distributionGroupId) : that.distributionGroupId != null)
             return false;
+        if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
         if (device != null ? !device.equals(that.device) : that.device != null) return false;
         return tag != null ? tag.equals(that.tag) : that.tag == null;
     }
@@ -226,6 +210,7 @@ public abstract class AbstractLog implements Log {
         result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
         result = 31 * result + (sid != null ? sid.hashCode() : 0);
         result = 31 * result + (distributionGroupId != null ? distributionGroupId.hashCode() : 0);
+        result = 31 * result + (userId != null ? userId.hashCode() : 0);
         result = 31 * result + (device != null ? device.hashCode() : 0);
         result = 31 * result + (tag != null ? tag.hashCode() : 0);
         return result;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/Log.java
@@ -56,6 +56,20 @@ public interface Log extends Model {
     void setDistributionGroupId(String distributionGroupId);
 
     /**
+     * Get the userId value.
+     *
+     * @return the userId value.
+     */
+    String getUserId();
+
+    /**
+     * Set the userId value.
+     *
+     * @param userId the userId value to set.
+     */
+    void setUserId(String userId);
+
+    /**
      * Get the device value.
      *
      * @return the device value

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterUserIdTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterUserIdTest.java
@@ -1,0 +1,73 @@
+package com.microsoft.appcenter;
+
+import org.junit.Test;
+
+import static com.microsoft.appcenter.AppCenter.PAIR_DELIMITER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AppCenterUserIdTest extends AbstractAppCenterTest {
+
+    private static String longUserId() {
+        StringBuilder userId = new StringBuilder();
+        for (int i = 0; i <= Constants.USER_ID_MAX_LENGTH; i++) {
+            userId.append("x");
+        }
+        return userId.toString();
+    }
+
+    @Test
+    public void setUserIdBeforeStart() {
+        AppCenter.setUserId("test");
+        assertNull(AppCenter.getInstance().getUserId());
+    }
+
+    @Test
+    public void setUserIdAfterStart() {
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+        AppCenter.setUserId("test");
+        assertEquals("test", AppCenter.getInstance().getUserId());
+
+        /* Unset. */
+        AppCenter.setUserId(null);
+        assertNull(AppCenter.getInstance().getUserId());
+
+        /* Another value. */
+        AppCenter.setUserId("test2");
+        assertEquals("test2", AppCenter.getInstance().getUserId());
+    }
+
+    @Test
+    public void setLongUserIdWithNoSecret() {
+        AppCenter.configure(mApplication);
+        String userId = longUserId();
+        AppCenter.setUserId(userId);
+        assertEquals(userId, AppCenter.getInstance().getUserId());
+    }
+
+    @Test
+    public void setLongUserIdWithAppSecret() {
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+        String userId = longUserId();
+        AppCenter.setUserId(userId);
+        assertNull(AppCenter.getInstance().getUserId());
+    }
+
+    @Test
+    public void setLongUserIdWithTargetTokenSecret() {
+        AppCenter.start(mApplication, DUMMY_TARGET_TOKEN_STRING, DummyService.class);
+        String userId = longUserId();
+        AppCenter.setUserId(userId);
+        assertEquals(userId, AppCenter.getInstance().getUserId());
+    }
+
+    @Test
+    public void setLongUserIdWithBothSecrets() {
+        String secret = DUMMY_TARGET_TOKEN_STRING + PAIR_DELIMITER +
+                DUMMY_APP_SECRET;
+        AppCenter.start(mApplication, secret, DummyService.class);
+        String userId = longUserId();
+        AppCenter.setUserId(userId);
+        assertNull(AppCenter.getInstance().getUserId());
+    }
+}

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/AbstractLogTest.java
@@ -13,8 +13,6 @@ import java.util.UUID;
 import static com.microsoft.appcenter.test.TestUtils.checkEquals;
 import static com.microsoft.appcenter.test.TestUtils.checkNotEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -79,6 +77,16 @@ public class AbstractLogTest {
         b.setDistributionGroupId(distributionGroupId1);
         checkEquals(a, b);
 
+        /* User ID. */
+        String userId1 = "alice";
+        String userId2 = "bob";
+        a.setUserId(userId1);
+        checkNotEquals(a, b);
+        b.setUserId(userId2);
+        checkNotEquals(a, b);
+        b.setUserId(userId1);
+        checkEquals(a, b);
+
         /* Device. */
         Device d1 = new Device();
         d1.setLocale("a");
@@ -120,33 +128,6 @@ public class AbstractLogTest {
         when(mockJsonObject.getString(CommonProperties.TYPE)).thenReturn("type");
         AbstractLog mockLog = new MockLog();
         mockLog.read(mockJsonObject);
-    }
-
-    @Test
-    public void readWithoutOptionalPropertiesTest() throws JSONException {
-        AbstractLog mockLog = new MockLogWithType();
-        UUID uuid = UUID.randomUUID();
-        String distributionGroupId = UUID.randomUUID().toString();
-
-        JSONObject mockJsonObject = mock(JSONObject.class);
-        when(mockJsonObject.getString(CommonProperties.TYPE)).thenReturn(mockLog.getType());
-        when(mockJsonObject.getString(AbstractLog.TIMESTAMP)).thenReturn("2017-07-08T01:17:43.245Z");
-        when(mockJsonObject.has(AbstractLog.SID)).thenReturn(false).thenReturn(true);
-        when(mockJsonObject.has(AbstractLog.DISTRIBUTION_GROUP_ID)).thenReturn(false).thenReturn(true);
-        when(mockJsonObject.has(AbstractLog.DEVICE)).thenReturn(false).thenReturn(true);
-        when(mockJsonObject.getString(AbstractLog.SID)).thenReturn(uuid.toString());
-        when(mockJsonObject.getString(AbstractLog.DISTRIBUTION_GROUP_ID)).thenReturn(distributionGroupId);
-        when(mockJsonObject.getJSONObject(AbstractLog.DEVICE)).thenReturn(mock(JSONObject.class));
-
-        mockLog.read(mockJsonObject);
-        assertNull(mockLog.getSid());
-        assertNull(mockLog.getDistributionGroupId());
-        assertNull(mockLog.getDevice());
-
-        mockLog.read(mockJsonObject);
-        assertEquals(uuid, mockLog.getSid());
-        assertEquals(distributionGroupId, mockLog.getDistributionGroupId());
-        assertNotNull(mockLog.getDevice());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

First part of the userId feature for crash logs.
