### PR TITLE
Fix a bug where crash data file could leak when the database is full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 1.11.0 (Under active development)
+
+### AppCenterCrashes
+
+* **[Fix]** Fix a bug where crash data file could leak when the database is full.
+
+___
+
 ## Version 1.10.0
 
 ### AppCenterAnalytics

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -643,19 +643,23 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                 when(mockPersistence).putLog(any(Log.class), anyString(), anyInt());
         AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
-        channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
+        channel.addGroup(TEST_GROUP, 10, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
+        channel.addGroup(TEST_GROUP + "2", 10, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
 
         /* Verify no request is sent if Persistence fails. */
-        for (int i = 0; i < 50; i++) {
+        for (int i = 0; i < 10; i++) {
             channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
+            channel.enqueue(mock(Log.class), TEST_GROUP + "2", Flags.DEFAULTS);
         }
-        verify(mockPersistence, times(50)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
+        verify(mockPersistence, times(10)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
+        verify(mockPersistence, times(10)).putLog(any(Log.class), eq(TEST_GROUP + "2"), eq(PERSISTENCE_NORMAL));
         verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
-        verify(mockListener, times(50)).onBeforeSending(any(Log.class));
-        verify(mockListener, times(50)).onFailure(any(Log.class), any(Persistence.PersistenceException.class));
+        verify(mockListener, times(10)).onBeforeSending(any(Log.class));
+        verify(mockListener, times(10)).onFailure(any(Log.class), any(Persistence.PersistenceException.class));
     }
 
     @Test


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~

## Description

Change storage size to 32KB (don't restart)
Crash with "generate huge exceptions and a lot of causes"
Restart app and click send.
Check logs: json file deleted because putLog failed, but throwable file is still there.
