### PR TITLE
Min database size changed with index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### AppCenter
 
-* **[Fix]** Fix minimum storage size verification to match actual value.
+* **[Fix]** Fix minimum storage size verification to match minimum possible value.
 
 ### AppCenterCrashes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 1.11.0 (Under active development)
+
+### AppCenter
+
+* **[Fix]** Fix minimum storage size verification to match actual value.
+
+___
+
 ## Version 1.10.0
 
 ### AppCenterAnalytics

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -61,11 +61,10 @@ public class AppCenter {
     static final long DEFAULT_MAX_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
 
     /**
-     * Minimum size allowed for set maximum size (SQL limitation). setMaxStorageSize could accept values
-     * as low as 16385 but in practice the lowest size set is the next highest multiple of 4096.
+     * Minimum size allowed for set maximum size (SQL limitation).
      */
     @VisibleForTesting
-    static final long MINIMUM_STORAGE_SIZE = 20480;
+    static final long MINIMUM_STORAGE_SIZE = 24 * 1024;
 
     /**
      * Group for sending logs.


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Set size to minimum accepted value on fresh install (20480).
Restart app => failed dialog.
SDK message: Could not change maximum database size to 20480 bytes, current maximum size is 24576 bytes.

We need to bump minimum size due to the new index.