### PR TITLE
Fix push foreground listener after re-enabling push service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 1.11.0 (Under active development)
+
+### AppCenterPush
+
+* **[Fix]** Fix push foreground listener after re-enabling push service.
+
+___
+
 ## Version 1.10.0
 
 ### AppCenterAnalytics

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -326,13 +326,7 @@ public class Push extends AbstractAppCenterService {
 
     @Override
     public void onActivityPaused(Activity activity) {
-        postOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mActivity = null;
-            }
-        });
+        mActivity = null;
     }
 
     private void checkPushInActivityIntent(Activity activity) {
@@ -348,11 +342,11 @@ public class Push extends AbstractAppCenterService {
             AppCenterLog.error(LOG_TAG, "Push.checkLaunchedFromNotification: intent may not be null");
             return;
         }
+        mActivity = activity;
         postOnUiThread(new Runnable() {
 
             @Override
             public void run() {
-                mActivity = activity;
                 checkPushInIntent(intent);
             }
         });

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -347,7 +347,7 @@ public class Push extends AbstractAppCenterService {
 
             @Override
             public void run() {
-                checkPushInIntent(intent);
+                checkPushInIntent(activity, intent);
             }
         });
     }
@@ -357,7 +357,7 @@ public class Push extends AbstractAppCenterService {
      *
      * @param intent intent to inspect.
      */
-    private synchronized void checkPushInIntent(Intent intent) {
+    private synchronized void checkPushInIntent(Activity activity, Intent intent) {
         if (mInstanceListener != null) {
             String googleMessageId = PushIntentUtils.getMessageId(intent);
             if (googleMessageId != null && !googleMessageId.equals(mLastGoogleMessageId)
@@ -369,7 +369,7 @@ public class Push extends AbstractAppCenterService {
                 AppCenterLog.info(LOG_TAG, "Clicked push message from background id=" + googleMessageId);
                 mLastGoogleMessageId = googleMessageId;
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
-                mInstanceListener.onPushNotificationReceived(mActivity, notification);
+                mInstanceListener.onPushNotificationReceived(activity, notification);
             }
         }
     }

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
@@ -300,6 +300,10 @@ public class PushTest {
     @Test
     public void receivedInForeground() {
 
+        /* Was disabled before start. */
+        when(SharedPreferencesManager.getBoolean(PUSH_ENABLED_KEY, true)).thenReturn(false);
+
+        /* Start. */
         PushListener pushListener = mock(PushListener.class);
         Push.setListener(pushListener);
         Push push = Push.getInstance();
@@ -307,7 +311,10 @@ public class PushTest {
         start(push, channel);
         Activity activity = mock(Activity.class);
         when(activity.getIntent()).thenReturn(mock(Intent.class));
+
+        /* Enable after activity resume. */
         push.onActivityResumed(activity);
+        Push.setEnabled(true);
 
         /* Mock some message. */
         Intent pushIntent = createPushIntent("some title", "some message", null);


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

1. Start Sasquatch
2. Go to settings
3. Disable push
4. Restart app
5. Go to settings
6. Enable push
7. Stay on settings screen, do not turn screen off and on
8. Push => no dialog

Reason is that `mActivity` is null in that case for Push class, we need to store/update `mActivity` reference even when Push is disabled so that it's ready at enabled time.