### PR TITLE
Improve error message when 1DS userId has only an invalid prefix and nothing after the prefix

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/UserIdContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/UserIdContext.java
@@ -58,15 +58,18 @@ public class UserIdContext {
         if (userId == null) {
             return true;
         }
-        int prefixIndex = userId.indexOf(COMMON_SCHEMA_PREFIX_SEPARATOR);
-        if (prefixIndex == userId.length() - 1) {
+        if (userId.isEmpty()) {
             AppCenterLog.error(LOG_TAG, "userId must not be empty.");
             return false;
         }
+        int prefixIndex = userId.indexOf(COMMON_SCHEMA_PREFIX_SEPARATOR);
         if (prefixIndex >= 0) {
             String prefix = userId.substring(0, prefixIndex);
             if (!prefix.equals(CUSTOM_PREFIX)) {
                 AppCenterLog.error(LOG_TAG, String.format("userId prefix must be '%s%s', '%s%s' is not supported.", CUSTOM_PREFIX, COMMON_SCHEMA_PREFIX_SEPARATOR, prefix, COMMON_SCHEMA_PREFIX_SEPARATOR));
+                return false;
+            } else if (prefixIndex == userId.length() - 1) {
+                AppCenterLog.error(LOG_TAG, "userId must not be empty.");
                 return false;
             }
         }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/UserIdContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/UserIdContextTest.java
@@ -14,6 +14,7 @@ public class UserIdContextTest {
         assertFalse(UserIdContext.checkUserIdValidForOneCollector(""));
         assertFalse(UserIdContext.checkUserIdValidForOneCollector(":alice"));
         assertFalse(UserIdContext.checkUserIdValidForOneCollector("c:"));
+        assertFalse(UserIdContext.checkUserIdValidForOneCollector("x:"));
         assertFalse(UserIdContext.checkUserIdValidForOneCollector("x:alice"));
     }
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

When 1DS userId is like `x:` that has an invalid prefix `x` with nothing after the `:`, the error log message is "userId must not be empty."

Now it is "userId prefix must be 'c', 'x' is not supported.".

## Related PRs or issues

Exactly same as https://github.com/Microsoft/AppCenter-SDK-Apple/pull/1239
