### PR TITLE
Fix disabling network state logs when debug logs disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **[Fix]** Do not delete old logs when trying to add a log larger than the maximum storage capacity.
 * **[Fix]** Fix error detection of `setMaxStorageSize` API if database uses custom page size.
 * **[Fix]** Fix minimum storage size verification to match minimum possible value.
+* **[Fix]** Fix disabling logging of network state changes according to `AppCenter.getLogLevel`.
 
 ### AppCenterCrashes
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -13,7 +13,6 @@ import android.net.NetworkRequest;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.microsoft.appcenter.AppCenter;
 
@@ -22,7 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static android.content.Context.CONNECTIVITY_SERVICE;
-import static com.microsoft.appcenter.utils.AppCenterLog.LOG_TAG;
+import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
 /**
  * Network state helper.
@@ -134,7 +133,7 @@ public class NetworkStateHelper implements Closeable {
              * Can be security exception if permission missing or sometimes another runtime exception
              * on some customized firmwares.
              */
-            AppCenterLog.error(LOG_TAG, "Cannot access network state information", e);
+            AppCenterLog.error(AppCenterLog.LOG_TAG, "Cannot access network state information", e);
         }
     }
 
@@ -157,9 +156,9 @@ public class NetworkStateHelper implements Closeable {
      * Handle network available update on API level >= 21.
      */
     private synchronized void onNetworkAvailable(Network network) {
-        Log.d(AppCenter.LOG_TAG, "Network available netId: " + network);
+        AppCenterLog.debug(LOG_TAG, "Network available netId: " + network);
         mAvailableNetworks.add(network);
-        Log.d(AppCenter.LOG_TAG, "Available networks netIds: " + mAvailableNetworks);
+        AppCenterLog.debug(LOG_TAG, "Available networks netIds: " + mAvailableNetworks);
 
         /*
          * Trigger event only once if we gain a new network while one was already
@@ -183,9 +182,9 @@ public class NetworkStateHelper implements Closeable {
          * and fast. This notification scheme is similar to the old connectivity receiver
          * implementation.
          */
-        Log.d(AppCenter.LOG_TAG, "Network lost netId: " + network);
+        AppCenterLog.debug(LOG_TAG, "Network lost netId: " + network);
         mAvailableNetworks.remove(network);
-        Log.d(AppCenter.LOG_TAG, "Available networks netIds: " + mAvailableNetworks);
+        AppCenterLog.debug(LOG_TAG, "Available networks netIds: " + mAvailableNetworks);
         notifyNetworkStateUpdated(false);
         if (!mAvailableNetworks.isEmpty()) {
             notifyNetworkStateUpdated(true);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -133,7 +133,7 @@ public class NetworkStateHelper implements Closeable {
              * Can be security exception if permission missing or sometimes another runtime exception
              * on some customized firmwares.
              */
-            AppCenterLog.error(AppCenterLog.LOG_TAG, "Cannot access network state information", e);
+            AppCenterLog.error(LOG_TAG, "Cannot access network state information", e);
         }
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Log was used directly in NetworkStateHelper instead of AppCenterLog.
