### PR TITLE
Fix test app

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -219,6 +219,9 @@ public class MainActivity extends AppCompatActivity {
 
     @SuppressWarnings("unchecked")
     private void setMaxStorageSize() {
+        if (AppCenter.isConfigured()) {
+            return;
+        }
         final long maxStorageSize = sSharedPreferences.getLong(MAX_STORAGE_SIZE_KEY, 0);
         if (maxStorageSize <= 0) {
             return;

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ManagedErrorActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ManagedErrorActivity.java
@@ -45,7 +45,8 @@ public class ManagedErrorActivity extends AppCompatActivity {
             AssertionError.class,
             LinkageError.class,
             ThreadDeath.class,
-            VirtualMachineError.class);
+            InternalError.class,
+            OutOfMemoryError.class);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -69,7 +70,13 @@ public class ManagedErrorActivity extends AppCompatActivity {
                 try {
                     @SuppressWarnings("unchecked")
                     Class<? extends Throwable> clazz = (Class<? extends Throwable>) parent.getItemAtPosition(position);
-                    CrashesPrivateHelper.trackException(clazz.getConstructor(String.class).newInstance("Test Exception"),
+                    Throwable e;
+                    try {
+                        e = clazz.getConstructor(String.class).newInstance("Test Exception");
+                    } catch (NoSuchMethodException ignored) {
+                        e = clazz.getConstructor().newInstance();
+                    }
+                    CrashesPrivateHelper.trackException(e,
                             new HashMap<String, String>() {{
                                 put("prop1", "value1");
                                 put("prop2", "value2");


### PR DESCRIPTION


* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

### Crash on sending managed errors: AssertionError, ThreadDeath and VirtualMachineError

![error1213](https://user-images.githubusercontent.com/1836384/49937906-51528e00-fee9-11e8-8e92-e75dae55ce1b.gif)

### Storage Max Size is changed to the same as Storage file size after clicked back button to exit and re-launch test app

#### Repro Steps

1. In the Settings Android SDK demo App Sasquatch, set Storage Max Size to 369 KB
2. Kill and restart the app, the Storage Max Size set 369 KB successfully.
3. Click back button until app exit.
4. Launch the app again, view the Storage Max Size.

#### Expected Behaviour
The Storage Max Size should still be 369 KB
#### Actual Behaviour
It says failed to change Storage Max Size. And Storage Max Size is set to the same as Storage file size as 24KB.
![201e7a34-c881-47b0-9750-908f51f14052](https://user-images.githubusercontent.com/1836384/49937942-63ccc780-fee9-11e8-8280-58bb93b0a4fc.gif)

