### PR TITLE
[Fix] Not forcing Chrome when opening a browser in distribution flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for Android Change Log
 
+## Version 1.11.1
+
+### AppCenterDistribute
+
+* **[Fix]** Fix issue with forcing Chrome to open links when other browsers are the default.
+
 ## Version 1.11.0
 
 ### AppCenter

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
@@ -15,7 +15,6 @@ import org.mockito.InOrder;
 import java.net.URISyntaxException;
 import java.util.Collections;
 
-import static com.microsoft.appcenter.distribute.BrowserUtils.GOOGLE_CHROME_URL_SCHEME;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -34,14 +33,14 @@ public class BrowserUtilsTest {
 
     private static final String TEST_URL = "https://www.contoso.com?a=b";
 
-    private static final ArgumentMatcher<Intent> CHROME_MATCHER = new ArgumentMatcher<Intent>() {
-
-        @Override
-        public boolean matches(Object o) {
-            Intent intent = (Intent) o;
-            return Intent.ACTION_VIEW.equals(intent.getAction()) && Uri.parse(GOOGLE_CHROME_URL_SCHEME + TEST_URL).equals(intent.getData());
-        }
-    };
+//    private static final ArgumentMatcher<Intent> CHROME_MATCHER = new ArgumentMatcher<Intent>() {
+//
+//        @Override
+//        public boolean matches(Object o) {
+//            Intent intent = (Intent) o;
+//            return Intent.ACTION_VIEW.equals(intent.getAction()) && Uri.parse(GOOGLE_CHROME_URL_SCHEME + TEST_URL).equals(intent.getData());
+//        }
+//    };
 
     @Test
     public void init() {
@@ -62,38 +61,30 @@ public class BrowserUtilsTest {
         assertEquals(url, "http://mock?a=b&x=y");
     }
 
-    @Test
-    public void chrome() {
-        Activity activity = mock(Activity.class);
-        BrowserUtils.openBrowser(TEST_URL, activity);
-        verify(activity).startActivity(argThat(CHROME_MATCHER));
-        verifyNoMoreInteractions(activity);
-    }
 
-    @Test
-    public void noBrowserFound() {
-
-        /* Mock no browser. */
-        Activity activity = mock(Activity.class);
-        PackageManager packageManager = mock(PackageManager.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(any(Intent.class));
-        when(activity.getPackageManager()).thenReturn(packageManager);
-        when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.<ResolveInfo>emptyList());
-
-        /* Open Chrome then abort. */
-        BrowserUtils.openBrowser(TEST_URL, activity);
-        verify(activity).startActivity(argThat(CHROME_MATCHER));
-
-        /* Verify no more call to startActivity. */
-        verify(activity).startActivity(any(Intent.class));
-    }
+//    @Test
+//    public void noBrowserFound() {
+//
+//        /* Mock no browser. */
+//        Activity activity = mock(Activity.class);
+//        PackageManager packageManager = mock(PackageManager.class);
+//        doThrow(new ActivityNotFoundException()).when(activity).startActivity(any(Intent.class));
+//        when(activity.getPackageManager()).thenReturn(packageManager);
+//        when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.<ResolveInfo>emptyList());
+//
+//        /* Open Chrome then abort. */
+//        BrowserUtils.openBrowser(TEST_URL, activity);
+//        verify(activity).startActivity(new Intent());
+//
+//        /* Verify no more call to startActivity. */
+//        verify(activity).startActivity(any(Intent.class));
+//    }
 
     @Test
     public void onlySystemBrowserNoDefaultAsNull() {
 
         /* Mock no browser. */
         Activity activity = mock(Activity.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(argThat(CHROME_MATCHER));
         PackageManager packageManager = mock(PackageManager.class);
         when(activity.getPackageManager()).thenReturn(packageManager);
         when(packageManager.resolveActivity(any(Intent.class), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(null);
@@ -106,10 +97,9 @@ public class BrowserUtilsTest {
             when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.singletonList(resolveInfo));
         }
 
-        /* Open Chrome then abort. */
+        /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override
@@ -126,7 +116,6 @@ public class BrowserUtilsTest {
 
         /* Mock no browser. */
         Activity activity = mock(Activity.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(argThat(CHROME_MATCHER));
         PackageManager packageManager = mock(PackageManager.class);
         when(activity.getPackageManager()).thenReturn(packageManager);
         {
@@ -146,10 +135,9 @@ public class BrowserUtilsTest {
             when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.singletonList(resolveInfo));
         }
 
-        /* Open Chrome then abort. */
+        /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override
@@ -166,7 +154,6 @@ public class BrowserUtilsTest {
 
         /* Mock no browser. */
         Activity activity = mock(Activity.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(argThat(BrowserUtilsTest.CHROME_MATCHER));
         PackageManager packageManager = mock(PackageManager.class);
         when(activity.getPackageManager()).thenReturn(packageManager);
         {
@@ -186,10 +173,10 @@ public class BrowserUtilsTest {
             when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.singletonList(resolveInfo));
         }
 
-        /* Open Chrome then abort. */
+        /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        order.verify(activity).startActivity(argThat(CHROME_MATCHER));
+        //order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override
@@ -206,7 +193,6 @@ public class BrowserUtilsTest {
 
         /* Mock no browser. */
         Activity activity = mock(Activity.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(argThat(CHROME_MATCHER));
         PackageManager packageManager = mock(PackageManager.class);
         when(activity.getPackageManager()).thenReturn(packageManager);
         {
@@ -231,10 +217,9 @@ public class BrowserUtilsTest {
             when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(asList(resolveInfo, resolveInfo2));
         }
 
-        /* Open Chrome then abort. */
+        /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override
@@ -251,7 +236,6 @@ public class BrowserUtilsTest {
 
         /* Mock no browser. */
         Activity activity = mock(Activity.class);
-        doThrow(new ActivityNotFoundException()).when(activity).startActivity(argThat(CHROME_MATCHER));
         PackageManager packageManager = mock(PackageManager.class);
         when(activity.getPackageManager()).thenReturn(packageManager);
         {
@@ -276,10 +260,9 @@ public class BrowserUtilsTest {
             when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(asList(resolveInfo, resolveInfo2));
         }
 
-        /* Open Chrome then abort. */
+        /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("WrongConstant")
@@ -64,17 +64,9 @@ public class BrowserUtilsTest {
 
         /* Open Browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
-        verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
-
-            @Override
-            public boolean matches(Object o) {
-                Intent intent = (Intent) o;
-                return Intent.ACTION_VIEW.equals(intent.getAction()) && Uri.parse(TEST_URL).equals(intent.getData()) && intent.getComponent().getClassName().equals("browser");
-            }
-        }));
 
         /* Verify no more call to startActivity. */
-        verify(activity).startActivity(any(Intent.class));
+        verify(activity, never()).startActivity(any(Intent.class));
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
@@ -33,15 +33,6 @@ public class BrowserUtilsTest {
 
     private static final String TEST_URL = "https://www.contoso.com?a=b";
 
-//    private static final ArgumentMatcher<Intent> CHROME_MATCHER = new ArgumentMatcher<Intent>() {
-//
-//        @Override
-//        public boolean matches(Object o) {
-//            Intent intent = (Intent) o;
-//            return Intent.ACTION_VIEW.equals(intent.getAction()) && Uri.parse(GOOGLE_CHROME_URL_SCHEME + TEST_URL).equals(intent.getData());
-//        }
-//    };
-
     @Test
     public void init() {
         new BrowserUtils();
@@ -62,23 +53,23 @@ public class BrowserUtilsTest {
     }
 
 
-//    @Test
-//    public void noBrowserFound() {
-//
-//        /* Mock no browser. */
-//        Activity activity = mock(Activity.class);
-//        PackageManager packageManager = mock(PackageManager.class);
-//        doThrow(new ActivityNotFoundException()).when(activity).startActivity(any(Intent.class));
-//        when(activity.getPackageManager()).thenReturn(packageManager);
-//        when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.<ResolveInfo>emptyList());
-//
-//        /* Open Chrome then abort. */
-//        BrowserUtils.openBrowser(TEST_URL, activity);
-//        verify(activity).startActivity(new Intent());
-//
-//        /* Verify no more call to startActivity. */
-//        verify(activity).startActivity(any(Intent.class));
-//    }
+    @Test
+    public void noBrowserFound() {
+
+        /* Mock no browser. */
+        Activity activity = mock(Activity.class);
+        PackageManager packageManager = mock(PackageManager.class);
+        doThrow(new ActivityNotFoundException()).when(activity).startActivity(any(Intent.class));
+        when(activity.getPackageManager()).thenReturn(packageManager);
+        when(packageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.<ResolveInfo>emptyList());
+
+        /* Open Browser then abort. */
+        BrowserUtils.openBrowser(TEST_URL, activity);
+        // verify(activity).startActivity(argThat(CHROME_MATCHER));
+
+        /* Verify no more call to startActivity. */
+        verify(activity).startActivity(any(Intent.class));
+    }
 
     @Test
     public void onlySystemBrowserNoDefaultAsNull() {

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/BrowserUtilsTest.java
@@ -52,7 +52,6 @@ public class BrowserUtilsTest {
         assertEquals(url, "http://mock?a=b&x=y");
     }
 
-
     @Test
     public void noBrowserFound() {
 
@@ -65,7 +64,14 @@ public class BrowserUtilsTest {
 
         /* Open Browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
-        // verify(activity).startActivity(argThat(CHROME_MATCHER));
+        verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
+
+            @Override
+            public boolean matches(Object o) {
+                Intent intent = (Intent) o;
+                return Intent.ACTION_VIEW.equals(intent.getAction()) && Uri.parse(TEST_URL).equals(intent.getData()) && intent.getComponent().getClassName().equals("browser");
+            }
+        }));
 
         /* Verify no more call to startActivity. */
         verify(activity).startActivity(any(Intent.class));
@@ -167,7 +173,6 @@ public class BrowserUtilsTest {
         /* Open browser then abort. */
         BrowserUtils.openBrowser(TEST_URL, activity);
         InOrder order = inOrder(activity);
-        //order.verify(activity).startActivity(argThat(CHROME_MATCHER));
         order.verify(activity).startActivity(argThat(new ArgumentMatcher<Intent>() {
 
             @Override

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -57,6 +57,7 @@ class BrowserUtils {
                 ActivityInfo activityInfo = defaultBrowser.activityInfo;
                 defaultBrowserPackageName = activityInfo.packageName;
                 defaultBrowserClassName = activityInfo.name;
+
                 AppCenterLog.debug(LOG_TAG, "Default browser seems to be " + defaultBrowserPackageName + "/" + defaultBrowserClassName);
             }
             String selectedPackageName = null;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -1,7 +1,6 @@
 package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -22,13 +22,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
  * Browser utils.
  */
 class BrowserUtils {
-
-    /**
-     * Scheme used to open URLs in Google Chrome instead of any browser.
-     */
-    @VisibleForTesting
-    static final String GOOGLE_CHROME_URL_SCHEME = "googlechrome://navigate?url=";
-
+    
     @VisibleForTesting
     BrowserUtils() {
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -57,7 +57,6 @@ class BrowserUtils {
                 ActivityInfo activityInfo = defaultBrowser.activityInfo;
                 defaultBrowserPackageName = activityInfo.packageName;
                 defaultBrowserClassName = activityInfo.name;
-
                 AppCenterLog.debug(LOG_TAG, "Default browser seems to be " + defaultBrowserPackageName + "/" + defaultBrowserClassName);
             }
             String selectedPackageName = null;
@@ -89,7 +88,6 @@ class BrowserUtils {
             intent.setClassName(selectedPackageName, selectedClassName);
             activity.startActivity(intent);
         }
-
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -43,65 +43,57 @@ class BrowserUtils {
      * @param activity activity from which to open browser.
      */
     static void openBrowser(@NonNull String url, @NonNull Activity activity) {
+        /* Open a browser but we don't want a chooser U.I. to pop. */
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        List<ResolveInfo> browsers = activity.getPackageManager().queryIntentActivities(intent, 0);
+        if (browsers.isEmpty()) {
+            AppCenterLog.error(LOG_TAG, "No browser found on device, abort login.");
+        } else {
 
-        /* Try to force using Chrome first, we want fall back url support for intent. */
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(GOOGLE_CHROME_URL_SCHEME + url));
-        try {
-            activity.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
-
-            /* Fall back using a browser but we don't want a chooser U.I. to pop. */
-            AppCenterLog.debug(LOG_TAG, "Google Chrome not found, pick another one.");
-            intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            List<ResolveInfo> browsers = activity.getPackageManager().queryIntentActivities(intent, 0);
-            if (browsers.isEmpty()) {
-                AppCenterLog.error(LOG_TAG, "No browser found on device, abort login.");
-            } else {
-
-                /*
-                 * Check the default browser is not the picker,
-                 * last thing we want is app to start and suddenly asks user to pick
-                 * between 2 browsers without explaining why.
-                 */
-                String defaultBrowserPackageName = null;
-                String defaultBrowserClassName = null;
-                ResolveInfo defaultBrowser = activity.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
-                if (defaultBrowser != null) {
-                    ActivityInfo activityInfo = defaultBrowser.activityInfo;
-                    defaultBrowserPackageName = activityInfo.packageName;
-                    defaultBrowserClassName = activityInfo.name;
-                    AppCenterLog.debug(LOG_TAG, "Default browser seems to be " + defaultBrowserPackageName + "/" + defaultBrowserClassName);
-                }
-                String selectedPackageName = null;
-                String selectedClassName = null;
-                for (ResolveInfo browser : browsers) {
-                    ActivityInfo activityInfo = browser.activityInfo;
-                    if (activityInfo.packageName.equals(defaultBrowserPackageName) && activityInfo.name.equals(defaultBrowserClassName)) {
-                        selectedPackageName = defaultBrowserPackageName;
-                        selectedClassName = defaultBrowserClassName;
-                        AppCenterLog.debug(LOG_TAG, "And its not the picker.");
-                        break;
-                    }
-                }
-                if (defaultBrowser != null && selectedPackageName == null) {
-                    AppCenterLog.debug(LOG_TAG, "Default browser is actually a picker...");
-                }
-
-                /* If no default browser found, pick first one we can find. */
-                if (selectedPackageName == null) {
-                    AppCenterLog.debug(LOG_TAG, "Picking first browser in list.");
-                    ResolveInfo browser = browsers.iterator().next();
-                    ActivityInfo activityInfo = browser.activityInfo;
-                    selectedPackageName = activityInfo.packageName;
-                    selectedClassName = activityInfo.name;
-                }
-
-                /* Launch generic browser. */
-                AppCenterLog.debug(LOG_TAG, "Launch browser=" + selectedPackageName + "/" + selectedClassName);
-                intent.setClassName(selectedPackageName, selectedClassName);
-                activity.startActivity(intent);
+            /*
+             * Check the default browser is not the picker,
+             * last thing we want is app to start and suddenly asks user to pick
+             * between 2 browsers without explaining why.
+             */
+            String defaultBrowserPackageName = null;
+            String defaultBrowserClassName = null;
+            ResolveInfo defaultBrowser = activity.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
+            if (defaultBrowser != null) {
+                ActivityInfo activityInfo = defaultBrowser.activityInfo;
+                defaultBrowserPackageName = activityInfo.packageName;
+                defaultBrowserClassName = activityInfo.name;
+                AppCenterLog.debug(LOG_TAG, "Default browser seems to be " + defaultBrowserPackageName + "/" + defaultBrowserClassName);
             }
+            String selectedPackageName = null;
+            String selectedClassName = null;
+            for (ResolveInfo browser : browsers) {
+                ActivityInfo activityInfo = browser.activityInfo;
+                if (activityInfo.packageName.equals(defaultBrowserPackageName) && activityInfo.name.equals(defaultBrowserClassName)) {
+                    selectedPackageName = defaultBrowserPackageName;
+                    selectedClassName = defaultBrowserClassName;
+                    AppCenterLog.debug(LOG_TAG, "And its not the picker.");
+                    break;
+                }
+            }
+            if (defaultBrowser != null && selectedPackageName == null) {
+                AppCenterLog.debug(LOG_TAG, "Default browser is actually a picker...");
+            }
+
+            /* If no default browser found, pick first one we can find. */
+            if (selectedPackageName == null) {
+                AppCenterLog.debug(LOG_TAG, "Picking first browser in list.");
+                ResolveInfo browser = browsers.iterator().next();
+                ActivityInfo activityInfo = browser.activityInfo;
+                selectedPackageName = activityInfo.packageName;
+                selectedClassName = activityInfo.name;
+            }
+
+            /* Launch generic browser. */
+            AppCenterLog.debug(LOG_TAG, "Launch browser=" + selectedPackageName + "/" + selectedClassName);
+            intent.setClassName(selectedPackageName, selectedClassName);
+            activity.startActivity(intent);
         }
+
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/BrowserUtils.java
@@ -37,6 +37,7 @@ class BrowserUtils {
      * @param activity activity from which to open browser.
      */
     static void openBrowser(@NonNull String url, @NonNull Activity activity) {
+
         /* Open a browser but we don't want a chooser U.I. to pop. */
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         List<ResolveInfo> browsers = activity.getPackageManager().queryIntentActivities(intent, 0);

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,6 +2,7 @@
 
 ext {
     versionCode = 41
+    // Original: 1.11.0
     versionName = '1.11.1'
     minSdkVersion = 16
     targetSdkVersion = 28

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,6 @@
 
 ext {
     versionCode = 41
-    // Original: 1.11.0
     versionName = '1.11.1'
     minSdkVersion = 16
     targetSdkVersion = 28


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Removed the code forcing Android SDK users to open chrome before other browser. Now we will first check for the default browser and then proceed to open that. 

## Related PRs or issues

List related PRs and other issues.

