### PR TITLE
Expose title message when background Push notification is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * **[Fix]** Fix exception if we receive deep link intent with setup failure before `onStart`.
 * **[Fix]** Fix checking updates for applications installed on corporate-owned single-use devices.
 
+### AppCenterPush
+
+* **[Feature]** Expose Title and Message when System/Background notification is pressed.
+
 ___
 
 ## Version 1.11.2

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -433,10 +433,9 @@ public class Push extends AbstractAppCenterService {
                 PushNotifier.handleNotification(context, pushIntent);
             }
 
-            if(mReceivedIntents == null){
+            if (mReceivedIntents == null) {
                 mReceivedIntents = new HashSet<>();
             }
-
             mReceivedIntents.add(pushIntent);
         } else {
             final PushNotification notification = new PushNotification(pushIntent);

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -380,7 +380,7 @@ public class Push extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
 
                 Intent currentPushIntent = null;
-                if (mReceivedIntents != null) {
+                if (mReceivedIntents != null && !mReceivedIntents.isEmpty()) {
                     for (Intent receivedIntent : mReceivedIntents) {
                         if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
                             currentPushIntent = receivedIntent;

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -80,6 +80,12 @@ public class Push extends AbstractAppCenterService {
     private String mFirstGoogleMessageId;
 
     /**
+     * Save Recived message Intent to generate push notification
+     * when click notification from background
+     */
+    private Intent mRecivedIntent;
+
+    /**
      * Current activity.
      */
     private Activity mActivity;
@@ -367,10 +373,18 @@ public class Push extends AbstractAppCenterService {
                 if (mFirstGoogleMessageId == null) {
                     mFirstGoogleMessageId = googleMessageId;
                 }
-                PushNotification notification = new PushNotification(intent);
+
                 AppCenterLog.info(LOG_TAG, "Clicked push message from background id=" + googleMessageId);
                 mLastGoogleMessageId = googleMessageId;
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
+
+                PushNotification notification;
+                if (mRecivedIntent != null && googleMessageId.equals(PushIntentUtils.getMessageId(mRecivedIntent))) {
+                    notification = new PushNotification(mRecivedIntent);
+                }
+                else {
+                    notification = new PushNotification(intent);
+                }
                 mInstanceListener.onPushNotificationReceived(activity, notification);
             }
         }
@@ -408,6 +422,8 @@ public class Push extends AbstractAppCenterService {
             } else {
                 PushNotifier.handleNotification(context, pushIntent);
             }
+
+            mRecivedIntent = pushIntent;
         } else {
             final PushNotification notification = new PushNotification(pushIntent);
             postOnUiThread(new Runnable() {

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -381,7 +381,7 @@ public class Push extends AbstractAppCenterService {
 
                 /* Try to get the received push intent via google message id. */
                 Intent currentPushIntent = mReceivedIntents.get(googleMessageId);
-                if(currentPushIntent == null){
+                if (currentPushIntent == null) {
                     currentPushIntent = intent;
                 }
                 PushNotification notification = new PushNotification(currentPushIntent);

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -380,11 +380,13 @@ public class Push extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
 
                 Intent currentPushIntent = null;
-                for (Intent receivedIntent : mReceivedIntents) {
-                    if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
-                        currentPushIntent = receivedIntent;
-                        mReceivedIntents.remove(currentPushIntent);
-                        break;
+                if (mReceivedIntents != null) {
+                    for (Intent receivedIntent : mReceivedIntents) {
+                        if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
+                            currentPushIntent = receivedIntent;
+                            mReceivedIntents.remove(currentPushIntent);
+                            break;
+                        }
                     }
                 }
 

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -112,6 +112,7 @@ public class Push extends AbstractAppCenterService {
     private Push() {
         mFactories = new HashMap<>();
         mFactories.put(PushInstallationLog.TYPE, new PushInstallationLogFactory());
+        mReceivedIntents = new HashSet<>();
     }
 
     /**
@@ -380,13 +381,11 @@ public class Push extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
 
                 Intent currentPushIntent = intent;
-                if (mReceivedIntents != null && !mReceivedIntents.isEmpty()) {
-                    for (Intent receivedIntent : mReceivedIntents) {
-                        if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
-                            currentPushIntent = receivedIntent;
-                            mReceivedIntents.remove(receivedIntent);
-                            break;
-                        }
+                for (Intent receivedIntent : mReceivedIntents) {
+                    if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
+                        currentPushIntent = receivedIntent;
+                        mReceivedIntents.remove(receivedIntent);
+                        break;
                     }
                 }
 
@@ -427,10 +426,6 @@ public class Push extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Background notifications are handled by Firebase SDK when integrated.");
             } else {
                 PushNotifier.handleNotification(context, pushIntent);
-            }
-
-            if (mReceivedIntents == null) {
-                mReceivedIntents = new HashSet<>();
             }
             mReceivedIntents.add(pushIntent);
         } else {

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -379,24 +379,18 @@ public class Push extends AbstractAppCenterService {
                 mLastGoogleMessageId = googleMessageId;
                 AppCenterLog.debug(LOG_TAG, "Push intent extras=" + intent.getExtras());
 
-                Intent currentPushIntent = null;
+                Intent currentPushIntent = intent;
                 if (mReceivedIntents != null && !mReceivedIntents.isEmpty()) {
                     for (Intent receivedIntent : mReceivedIntents) {
                         if (googleMessageId.equals(PushIntentUtils.getMessageId(receivedIntent))) {
                             currentPushIntent = receivedIntent;
-                            mReceivedIntents.remove(currentPushIntent);
+                            mReceivedIntents.remove(receivedIntent);
                             break;
                         }
                     }
                 }
 
-                PushNotification notification;
-                if (currentPushIntent != null) {
-                    notification = new PushNotification(currentPushIntent);
-                }
-                else {
-                    notification = new PushNotification(intent);
-                }
+                PushNotification notification = new PushNotification(currentPushIntent);
                 mInstanceListener.onPushNotificationReceived(activity, notification);
             }
         }

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
@@ -617,6 +617,32 @@ public class PushTest {
     }
 
     @Test
+    public void clickedFromBackgroundWithReceivedIntent() {
+
+        PushListener pushListener = mock(PushListener.class);
+        Push.setListener(pushListener);
+        start(Push.getInstance(), mock(Channel.class));
+
+        /* Mock new intent to contain push, but activity with no push in original activity.  */
+        Activity activity = mock(Activity.class);
+        when(activity.getIntent()).thenReturn(mock(Intent.class));
+
+        /* Mock some message. */
+        Intent pushIntent = createPushIntent("some title", "some message", null);
+        when(PushIntentUtils.getMessageId(pushIntent)).thenReturn("some id");
+        Push.getInstance().onMessageReceived(mContext, pushIntent);
+
+        /* Simulate we detect push in onCreate. */
+        Push.checkLaunchedFromNotification(activity, pushIntent);
+        ArgumentCaptor<PushNotification> captor = ArgumentCaptor.forClass(PushNotification.class);
+        verify(pushListener).onPushNotificationReceived(eq(activity), captor.capture());
+        PushNotification pushNotification = captor.getValue();
+        assertNotNull(pushNotification);
+        assertEquals("some title", pushNotification.getTitle());
+        assertEquals("some message", pushNotification.getMessage());
+    }
+
+    @Test
     public void validateCheckLaunchedFromNotification() {
         start(Push.getInstance(), mock(Channel.class));
         Push.checkLaunchedFromNotification(null, mock(Intent.class));


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

1. Add a private set to store the received push intents
2. Use message id to get current intent when click the notification from back end

## Related PRs or issues

[#817](https://github.com/Microsoft/AppCenter-SDK-DotNet/issues/817)
