### PR TITLE
Fix in-app update for MIUI 10

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/InstallerUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/InstallerUtils.java
@@ -38,6 +38,7 @@ class InstallerUtils {
         LOCAL_STORES.add("com.android.packageinstaller");
         LOCAL_STORES.add("com.google.android.packageinstaller");
         LOCAL_STORES.add("com.android.managedprovisioning");
+        LOCAL_STORES.add("com.miui.packageinstaller");
     }
 
     @VisibleForTesting

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AppStoreDetectionTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AppStoreDetectionTest.java
@@ -103,4 +103,14 @@ public class AppStoreDetectionTest {
         assertFalse(InstallerUtils.isInstalledFromAppStore(LOG_TAG, mContext));
         verify(mPackageManager).getInstallerPackageName(anyString());
     }
+
+    @Test
+    public void miUiLocalInstallerIsNotStore() {
+        when(mPackageManager.getInstallerPackageName(anyString())).thenReturn("com.miui.packageinstaller");
+        assertFalse(InstallerUtils.isInstalledFromAppStore(LOG_TAG, mContext));
+
+        /* Check cache. */
+        assertFalse(InstallerUtils.isInstalledFromAppStore(LOG_TAG, mContext));
+        verify(mPackageManager).getInstallerPackageName(anyString());
+    }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

From MIUI 10, it started to return `com.miui.packageinstaller` as application package name instead of null for local installed applications. It causes the problem that in-app update stops working because it treats application as installed from a store. So, 'com.miui.packageinstaller` should be added as know local stores to identify correctly that applicaiton is not installed from a store.

## Misc
Output of the app center logger with Verbose log level enabled (before fix): 
```
D/AppCenterDistribute: InstallerPackageName=com.miui.packageinstaller
I/AppCenterDistribute: Not checking in app updates as installed from a store.
```