### PR TITLE
Implement Identity.setConfigUrl and change default to prod

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -136,6 +136,21 @@ public class MainActivity extends AppCompatActivity {
             Distribute.setApiUrl(apiUrl);
         }
 
+        /* Set identity config url. */
+        String configUrl = getString(R.string.identity_config_url);
+        if (!TextUtils.isEmpty(configUrl)) {
+
+            /* TODO once Identity released to jCenter, use Identity.setConfigUrl directly. */
+            try {
+                Class<?> identity = Class.forName("com.microsoft.appcenter.identity.Identity");
+                identity.getMethod("setConfigUrl", String.class).invoke(null, configUrl);
+            } catch (ClassNotFoundException ignored) {
+            } catch (NoSuchMethodException ignored) {
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
         /* Set push sender ID the old way for testing without firebase lib. */
         setSenderId();
 

--- a/apps/sasquatch/src/main/res/values/env.xml
+++ b/apps/sasquatch/src/main/res/values/env.xml
@@ -4,5 +4,6 @@
     <string name="log_url" tools:ignore="MissingTranslation" />
     <string name="install_url" tools:ignore="MissingTranslation" />
     <string name="api_url" tools:ignore="MissingTranslation" />
+    <string name="identity_config_url" tools:ignore="MissingTranslation" />
     <string name="rum_key" tools:ignore="MissingTranslation" />
 </resources>

--- a/apps/sasquatch/src/projectDependency/res/values/env.xml
+++ b/apps/sasquatch/src/projectDependency/res/values/env.xml
@@ -4,5 +4,6 @@
     <string name="log_url" tools:ignore="MissingTranslation">https://in-integration.dev.avalanch.es</string>
     <string name="install_url" tools:ignore="MissingTranslation">https://install.portal-server-core-integration.dev.avalanch.es</string>
     <string name="api_url" tools:ignore="MissingTranslation">https://api-gateway-core-integration.dev.avalanch.es/v0.1</string>
+    <string name="identity_config_url" tools:ignore="MissingTranslation">https://config-integration.dev.avalanch.es</string>
     <string name="rum_key" tools:ignore="MissingTranslation">0123456789abcdef0123456789abcdff</string>
 </resources>

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
 
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -42,7 +41,6 @@ class DistributeUtils {
     /**
      * Scheme used to open the native Android tester app.
      */
-    @VisibleForTesting
     static final String TESTER_APP_PACKAGE_NAME = "com.microsoft.hockeyapp.testerapp";
 
     /**

--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Constants.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Constants.java
@@ -23,9 +23,14 @@ final class Constants {
     static final String IDENTITY_GROUP = "group_identity";
 
     /**
-     * URL pattern to get configuration file. Variable is appSecret.
+     * Base URL for remote configuration.
      */
-    static final String CONFIG_URL = "https://mobilecentersdkdev.blob.core.windows.net/identity/%s.json";
+    static final String DEFAULT_CONFIG_URL = "https://config.appcenter.ms";
+
+    /**
+     * Config url format. Variables are base url then appSecret.
+     */
+    static final String CONFIG_URL_FORMAT = "%s/identity/%s.json";
 
     /**
      * File path to store cached configuration in application files.

--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
@@ -50,7 +50,8 @@ import static com.microsoft.appcenter.identity.Constants.AUTHORITY_DEFAULT;
 import static com.microsoft.appcenter.identity.Constants.AUTHORITY_TYPE;
 import static com.microsoft.appcenter.identity.Constants.AUTHORITY_TYPE_B2C;
 import static com.microsoft.appcenter.identity.Constants.AUTHORITY_URL;
-import static com.microsoft.appcenter.identity.Constants.CONFIG_URL;
+import static com.microsoft.appcenter.identity.Constants.CONFIG_URL_FORMAT;
+import static com.microsoft.appcenter.identity.Constants.DEFAULT_CONFIG_URL;
 import static com.microsoft.appcenter.identity.Constants.FILE_PATH;
 import static com.microsoft.appcenter.identity.Constants.HEADER_E_TAG;
 import static com.microsoft.appcenter.identity.Constants.HEADER_IF_NONE_MATCH;
@@ -70,6 +71,11 @@ public class Identity extends AbstractAppCenterService {
      */
     @SuppressLint("StaticFieldLeak")
     private static Identity sInstance;
+
+    /**
+     * Current config base URL.
+     */
+    private String mConfigUrl = DEFAULT_CONFIG_URL;
 
     /**
      * Application context.
@@ -140,12 +146,23 @@ public class Identity extends AbstractAppCenterService {
     }
 
     /**
+     * Change the remote configuration base URL.
+     *
+     * @param configUrl configuration base URL.
+     */
+    @SuppressWarnings({"SameParameterValue", "WeakerAccess"})
+    // TODO Remove warning suppress after release.
+    public static void setConfigUrl(String configUrl) {
+        getInstance().setInstanceConfigUrl(configUrl);
+    }
+
+    /**
      * Check whether Identity service is enabled or not.
      *
      * @return future with result being <code>true</code> if enabled, <code>false</code> otherwise.
      * @see AppCenterFuture
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // TODO Remove warning suppress after release.
+    @SuppressWarnings("WeakerAccess") // TODO Remove warning suppress after release.
     public static AppCenterFuture<Boolean> isEnabled() {
         return getInstance().isInstanceEnabledAsync();
     }
@@ -156,7 +173,7 @@ public class Identity extends AbstractAppCenterService {
      * @param enabled <code>true</code> to enable, <code>false</code> to disable.
      * @return future with null result to monitor when the operation completes.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) // TODO Remove warning suppress after release.
+    @SuppressWarnings("WeakerAccess") // TODO Remove warning suppress after release.
     public static AppCenterFuture<Void> setEnabled(boolean enabled) {
         return getInstance().setInstanceEnabledAsync(enabled);
     }
@@ -245,6 +262,13 @@ public class Identity extends AbstractAppCenterService {
         mActivity = null;
     }
 
+    /**
+     * Implements {@link #setConfigUrl(String)} at instance level.
+     */
+    private synchronized void setInstanceConfigUrl(String configUrl) {
+        mConfigUrl = configUrl;
+    }
+
     private synchronized void removeTokenAndAccount() {
         mSignInDelayed = false;
         removeAccount(mTokenStorage.getHomeAccountId());
@@ -260,7 +284,7 @@ public class Identity extends AbstractAppCenterService {
         if (eTag != null) {
             headers.put(HEADER_IF_NONE_MATCH, eTag);
         }
-        String url = String.format(CONFIG_URL, mAppSecret);
+        String url = String.format(CONFIG_URL_FORMAT, mConfigUrl, mAppSecret);
         mGetConfigCall = httpClient.callAsync(url, METHOD_GET, headers, new HttpClient.CallTemplate() {
 
             @Override

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -166,14 +166,6 @@ public class IdentityTest extends AbstractIdentityTest {
         verify(channel, never()).addListener(any(Channel.Listener.class));
     }
 
-    @NonNull
-    private Channel start(Identity identity) {
-        Channel channel = mock(Channel.class);
-        identity.onStarting(mAppCenterHandler);
-        identity.onStarted(mock(Context.class), channel, APP_SECRET, null, true);
-        return channel;
-    }
-
     @Test
     public void downloadFullInvalidConfiguration() throws Exception {
 
@@ -1155,6 +1147,14 @@ public class IdentityTest extends AbstractIdentityTest {
         /* Check call. */
         String expectedUrl = configUrl + "/identity/" + APP_SECRET + ".json";
         verify(httpClient).callAsync(eq(expectedUrl), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+    }
+
+    @NonNull
+    private Channel start(Identity identity) {
+        Channel channel = mock(Channel.class);
+        identity.onStarting(mAppCenterHandler);
+        identity.onStarted(mock(Context.class), channel, APP_SECRET, null, true);
+        return channel;
     }
 
     @NonNull

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -86,34 +86,6 @@ public class IdentityTest extends AbstractIdentityTest {
     @Captor
     private ArgumentCaptor<Map<String, String>> mHeadersCaptor;
 
-    private static void mockSuccessfulHttpCall(JSONObject jsonConfig, HttpClientRetryer httpClient) throws JSONException {
-
-        /* Intercept parameters. */
-        ArgumentCaptor<HttpClient.CallTemplate> templateArgumentCaptor = ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
-        ArgumentCaptor<ServiceCallback> callbackArgumentCaptor = ArgumentCaptor.forClass(ServiceCallback.class);
-        String expectedUrl = Constants.DEFAULT_CONFIG_URL + "/identity/" + APP_SECRET + ".json";
-        verify(httpClient).callAsync(eq(expectedUrl), anyString(), anyMapOf(String.class, String.class), templateArgumentCaptor.capture(), callbackArgumentCaptor.capture());
-        ServiceCallback serviceCallback = callbackArgumentCaptor.getValue();
-        assertNotNull(serviceCallback);
-
-        /* Verify call template. */
-        assertNull(templateArgumentCaptor.getValue().buildRequestBody());
-
-        /* Verify no logging if verbose log not enabled (default). */
-        try {
-            templateArgumentCaptor.getValue().onBeforeCalling(new URL("https://mock"), new HashMap<String, String>());
-        } catch (MalformedURLException e) {
-            fail("test url should always be valid " + e.getMessage());
-        }
-        verifyStatic(never());
-        AppCenterLog.verbose(anyString(), anyString());
-
-        /* Simulate response. */
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("ETag", "mockETag");
-        serviceCallback.onCallSucceeded(jsonConfig.toString(), headers);
-    }
-
     @Test
     public void singleton() {
         Assert.assertSame(Identity.getInstance(), Identity.getInstance());
@@ -1171,5 +1143,33 @@ public class IdentityTest extends AbstractIdentityTest {
         when(authority.getString("type")).thenReturn("B2C");
         when(authority.getString("authority_url")).thenReturn("https://mock");
         return jsonConfig;
+    }
+
+    private static void mockSuccessfulHttpCall(JSONObject jsonConfig, HttpClientRetryer httpClient) throws JSONException {
+
+        /* Intercept parameters. */
+        ArgumentCaptor<HttpClient.CallTemplate> templateArgumentCaptor = ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
+        ArgumentCaptor<ServiceCallback> callbackArgumentCaptor = ArgumentCaptor.forClass(ServiceCallback.class);
+        String expectedUrl = Constants.DEFAULT_CONFIG_URL + "/identity/" + APP_SECRET + ".json";
+        verify(httpClient).callAsync(eq(expectedUrl), anyString(), anyMapOf(String.class, String.class), templateArgumentCaptor.capture(), callbackArgumentCaptor.capture());
+        ServiceCallback serviceCallback = callbackArgumentCaptor.getValue();
+        assertNotNull(serviceCallback);
+
+        /* Verify call template. */
+        assertNull(templateArgumentCaptor.getValue().buildRequestBody());
+
+        /* Verify no logging if verbose log not enabled (default). */
+        try {
+            templateArgumentCaptor.getValue().onBeforeCalling(new URL("https://mock"), new HashMap<String, String>());
+        } catch (MalformedURLException e) {
+            fail("test url should always be valid " + e.getMessage());
+        }
+        verifyStatic(never());
+        AppCenterLog.verbose(anyString(), anyString());
+
+        /* Simulate response. */
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("ETag", "mockETag");
+        serviceCallback.onCallSucceeded(jsonConfig.toString(), headers);
     }
 }

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -1130,7 +1130,7 @@ public class IdentityTest extends AbstractIdentityTest {
     }
 
     @NonNull
-    private JSONObject mockValidForAppCenterConfig() throws Exception {
+    private static JSONObject mockValidForAppCenterConfig() throws Exception {
         JSONObject jsonConfig = mock(JSONObject.class);
         when(jsonConfig.toString()).thenReturn("mockConfig");
         whenNew(JSONObject.class).withArguments("mockConfig").thenReturn(jsonConfig);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

* Add Identity.setConfigUrl to change remote configuration endpoint.
* Change default value for prod.
* AB#58365