### PR TITLE
Delete AuthToken from AppCenterIngestion and pass it from each batch

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -155,15 +155,6 @@ public class DefaultChannel implements Channel {
         mIngestions.add(mIngestion);
         mAppCenterHandler = appCenterHandler;
         mEnabled = true;
-        AuthTokenContext authTokenContext = AuthTokenContext.getInstance();
-        mIngestion.setAuthToken(authTokenContext.getAuthToken());
-        authTokenContext.addListener(new AbstractTokenContextListener() {
-
-            @Override
-            public void onNewAuthToken(String authToken) {
-                mIngestion.setAuthToken(authToken);
-            }
-        });
     }
 
     /**
@@ -525,7 +516,8 @@ public class DefaultChannel implements Channel {
             /* Send logs. */
             LogContainer logContainer = new LogContainer();
             logContainer.setLogs(batch);
-            groupState.mIngestion.sendAsync(mAppSecret, mInstallId, logContainer, new ServiceCallback() {
+            AuthTokenContext authTokenContext = AuthTokenContext.getInstance();
+            groupState.mIngestion.sendAsync(authTokenContext.getAuthToken(), mAppSecret, mInstallId, logContainer, new ServiceCallback() {
 
                 @Override
                 public void onCallSucceeded(String payload, Map<String, String> headers) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -27,7 +27,6 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.IdHelper;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 
 import java.io.IOException;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/AppCenterIngestion.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/AppCenterIngestion.java
@@ -84,11 +84,6 @@ public class AppCenterIngestion implements Ingestion {
     private String mLogUrl;
 
     /**
-     * Authentication token current value.
-     */
-    private String mAuthToken;
-
-    /**
      * Init.
      *
      * @param context       any context.
@@ -112,21 +107,10 @@ public class AppCenterIngestion implements Ingestion {
     }
 
     @Override
-    public synchronized void setAuthToken(@NonNull String authToken) {
-        mAuthToken = authToken;
-    }
-
-    @Override
-    public synchronized String getAuthToken() {
-        return mAuthToken;
-    }
-
-    @Override
-    public ServiceCall sendAsync(String appSecret, UUID installId, LogContainer logContainer, final ServiceCallback serviceCallback) throws IllegalArgumentException {
+    public ServiceCall sendAsync(String authToken, String appSecret, UUID installId, LogContainer logContainer, final ServiceCallback serviceCallback) throws IllegalArgumentException {
         Map<String, String> headers = new HashMap<>();
         headers.put(INSTALL_ID, installId.toString());
         headers.put(APP_SECRET, appSecret);
-        String authToken = getAuthToken();
         if (authToken != null) {
             headers.put(AUTHORIZATION_HEADER, String.format(AUTH_TOKEN_FORMAT, authToken));
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/Ingestion.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/Ingestion.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.appcenter.ingestion;
 
-import android.support.annotation.NonNull;
-
 import com.microsoft.appcenter.http.ServiceCall;
 import com.microsoft.appcenter.http.ServiceCallback;
 import com.microsoft.appcenter.ingestion.models.LogContainer;
@@ -22,13 +20,13 @@ public interface Ingestion extends Closeable {
     /**
      * Send logs to the Ingestion service.
      *
-     * @param authToken       value of authorization token.
+     * @param authToken       value of authorization token (optional).
      * @param appSecret       a unique and secret key used to identify the application.
      * @param installId       install identifier.
      * @param logContainer    payload.
      * @param serviceCallback the async ServiceCallback to handle successful and failed responses.
      * @return the {@link ServiceCall} object
-     * @throws IllegalArgumentException thrown if callback is null
+     * @throws IllegalArgumentException thrown if callback is null.
      */
     ServiceCall sendAsync(String authToken, String appSecret, UUID installId, LogContainer logContainer, ServiceCallback serviceCallback) throws IllegalArgumentException;
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/Ingestion.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/Ingestion.java
@@ -22,6 +22,7 @@ public interface Ingestion extends Closeable {
     /**
      * Send logs to the Ingestion service.
      *
+     * @param authToken       value of authorization token.
      * @param appSecret       a unique and secret key used to identify the application.
      * @param installId       install identifier.
      * @param logContainer    payload.
@@ -29,7 +30,7 @@ public interface Ingestion extends Closeable {
      * @return the {@link ServiceCall} object
      * @throws IllegalArgumentException thrown if callback is null
      */
-    ServiceCall sendAsync(String appSecret, UUID installId, LogContainer logContainer, ServiceCallback serviceCallback) throws IllegalArgumentException;
+    ServiceCall sendAsync(String authToken, String appSecret, UUID installId, LogContainer logContainer, ServiceCallback serviceCallback) throws IllegalArgumentException;
 
     /**
      * Update log URL.
@@ -42,18 +43,4 @@ public interface Ingestion extends Closeable {
      * Make ingestion active again after closing.
      */
     void reopen();
-
-    /**
-     * Sets the value of authorization token.
-     *
-     * @param authToken value of authorization token.
-     */
-    void setAuthToken(@NonNull String authToken);
-
-    /**
-     * Get the value of authorization token.
-     *
-     * @return value of authorization token.
-     */
-    String getAuthToken();
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/OneCollectorIngestion.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/OneCollectorIngestion.java
@@ -114,7 +114,7 @@ public class OneCollectorIngestion implements Ingestion {
     }
 
     @Override
-    public ServiceCall sendAsync(String appSecret, UUID installId, LogContainer logContainer, ServiceCallback serviceCallback) throws IllegalArgumentException {
+    public ServiceCall sendAsync(String authToken, String appSecret, UUID installId, LogContainer logContainer, ServiceCallback serviceCallback) throws IllegalArgumentException {
 
         /* Gather API keys from logs. */
         Map<String, String> headers = new HashMap<>();
@@ -196,19 +196,6 @@ public class OneCollectorIngestion implements Ingestion {
     @Override
     public void close() throws IOException {
         mHttpClient.close();
-    }
-
-    @Override
-    public void setAuthToken(@NonNull String authToken) {
-
-        /* Not supported. */
-    }
-
-    @Override
-    public String getAuthToken() {
-
-        /* Not supported. */
-        return null;
     }
 
     /**

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
@@ -86,11 +86,11 @@ public class AbstractDefaultChannelTest {
             @Override
             public Object answer(InvocationOnMock invocation) {
                 Object[] args = invocation.getArguments();
-                if (args[3] instanceof ServiceCallback) {
+                if (args[4] instanceof ServiceCallback) {
                     if (e == null)
-                        ((ServiceCallback) invocation.getArguments()[3]).onCallSucceeded("", null);
+                        ((ServiceCallback) invocation.getArguments()[4]).onCallSucceeded("", null);
                     else
-                        ((ServiceCallback) invocation.getArguments()[3]).onCallFailed(e);
+                        ((ServiceCallback) invocation.getArguments()[4]).onCallFailed(e);
                 }
                 return null;
             }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelAlternateIngestionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelAlternateIngestionTest.java
@@ -85,8 +85,8 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
         channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
 
         /* Verify that we have called sendAsync on the ingestion. */
-        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* The counter should be 0 now as we sent data. */
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
@@ -122,16 +122,16 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
         channel.addGroup(oneCollectorGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, alternateIngestion, null);
 
         /* App center previous log not sent yet. */
-        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* One collector previous log sent. */
-        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Enqueuing 1 new event for app center. */
         channel.enqueue(mock(Log.class), appCenterGroup, Flags.DEFAULTS);
 
         /* Not sent. */
-        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify we didn't persist the log since AppCenter not started with app secret. */
         verify(mockPersistence, never()).putLog(any(Log.class), eq(appCenterGroup), eq(Flags.PERSISTENCE_NORMAL));
@@ -140,13 +140,13 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
         channel.enqueue(mock(Log.class), oneCollectorGroup, Flags.DEFAULTS);
 
         /* Verify that we have called sendAsync on the alternate ingestion a second time. */
-        verify(alternateIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we can now send logs to app center after we have set app secret. */
         channel.setAppSecret("testAppSecret");
         channel.enqueue(mock(Log.class), appCenterGroup, Flags.DEFAULTS);
-        verify(defaultIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -169,11 +169,11 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
 
         /* Verify that we can now send logs to app center after we have set app secret. */
         channel.setAppSecret("testAppSecret");
-        verify(defaultIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* If we add a one collector group it also resumes. */
         channel.addGroup(oneCollectorGroup, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, alternateIngestion, null);
-        verify(alternateIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -200,14 +200,14 @@ public class DefaultChannelAlternateIngestionTest extends AbstractDefaultChannel
 
         /* Verify that no log is sent even if we set app secret while channel is disabled. */
         channel.setAppSecret("testAppSecret");
-        verify(defaultIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(alternateIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Enable channel. */
         channel.setEnabled(true);
 
         /* Verify that now logs are sent when channel is enabled. */
-        verify(defaultIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(alternateIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(defaultIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(alternateIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelCallbacksTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelCallbacksTest.java
@@ -40,8 +40,6 @@ public class DefaultChannelCallbacksTest {
         String mockToken = UUIDUtils.randomUUID().toString();
         new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mock(Handler.class));
         AuthTokenContext.getInstance().setAuthToken(mockToken, "mock-id");
-        verify(ingestion, times(1)).setAuthToken(isNull(String.class));
-        verify(ingestion, times(1)).setAuthToken(eq(mockToken));
     }
 
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelPauseResumeTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelPauseResumeTest.java
@@ -47,7 +47,7 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         Channel.GroupListener mockListener = mock(Channel.GroupListener.class);
 
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer(50));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -66,7 +66,7 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         /* 50 logs are persisted but never being sent to Ingestion. */
         assertEquals(50, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mockPersistence, times(50)).putLog(any(Log.class), eq(TEST_GROUP), eq(Flags.PERSISTENCE_NORMAL));
-        verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, never()).onBeforeSending(any(Log.class));
         verify(mockListener, never()).onSuccess(any(Log.class));
@@ -80,7 +80,7 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
 
         /* Verify channel starts sending logs. */
         verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, times(50)).onBeforeSending(any(Log.class));
         verify(mockListener, times(50)).onSuccess(any(Log.class));
@@ -153,7 +153,7 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         verify(persistence).putLog(log, TEST_GROUP, Flags.PERSISTENCE_NORMAL);
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(persistence, never()).countLogs(TEST_GROUP);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Pausing a second time has no effect. */
         channel.pauseGroup(TEST_GROUP, targetToken);
@@ -163,17 +163,17 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         Log otherLog = mock(Log.class);
         when(otherLog.getTransmissionTargetTokens()).thenReturn(Collections.singleton("iKey2-apiKey2"));
         channel.enqueue(otherLog, TEST_GROUP, Flags.DEFAULTS);
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         reset(ingestion);
 
         /* Resume token. */
         channel.resumeGroup(TEST_GROUP, targetToken);
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Sending more logs works now. */
         reset(ingestion);
         channel.enqueue(log, TEST_GROUP, Flags.DEFAULTS);
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Calling resume a second time has 0 effect. */
         reset(persistence);
@@ -183,7 +183,7 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         verifyZeroInteractions(ingestion);
 
         /* AppCenter ingestion never used. */
-        verify(appCenterIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(appCenterIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -216,15 +216,15 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         /* Verify persisted but not incrementing and checking logs. */
         verify(persistence).putLog(log, TEST_GROUP, Flags.PERSISTENCE_NORMAL);
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Resume group should not send the log. */
         channel.resumeGroup(TEST_GROUP, null);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Resume token, send the log now. */
         channel.resumeGroup(TEST_GROUP, targetToken);
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelRaceConditionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelRaceConditionTest.java
@@ -83,7 +83,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         afterCallSemaphore.acquireUninterruptibly();
 
         /* Verify ingestion not sent. */
-        verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         when(mockPersistence.getLogs(anyString(), anyListOf(String.class), eq(1), anyListOf(Log.class))).then(getGetLogsAnswer(1));
         when(mockPersistence.getLogs(anyString(), anyListOf(String.class), eq(CLEAR_BATCH_SIZE), anyListOf(Log.class))).then(getGetLogsAnswer(0));
         AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
 
             @Override
             public Object answer(final InvocationOnMock invocation) {
@@ -106,7 +106,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
                     @Override
                     public void run() {
                         beforeCallSemaphore.acquireUninterruptibly();
-                        ((ServiceCallback) invocation.getArguments()[3]).onCallSucceeded("", null);
+                        ((ServiceCallback) invocation.getArguments()[4]).onCallSucceeded("", null);
                         afterCallSemaphore.release();
                     }
                 }.start();
@@ -151,7 +151,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         when(mockPersistence.getLogs(anyString(), anyListOf(String.class), eq(CLEAR_BATCH_SIZE), anyListOf(Log.class))).then(getGetLogsAnswer(0));
         AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
         final Exception mockException = new IOException();
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
 
             @Override
             public Object answer(final InvocationOnMock invocation) {
@@ -160,7 +160,7 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
                     @Override
                     public void run() {
                         beforeCallSemaphore.acquireUninterruptibly();
-                        ((ServiceCallback) invocation.getArguments()[3]).onCallFailed(mockException);
+                        ((ServiceCallback) invocation.getArguments()[4]).onCallFailed(mockException);
                         afterCallSemaphore.release();
                     }
                 }.start();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -80,7 +80,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer(50)).then(getGetLogsAnswer(1)).then(getGetLogsAnswer(2));
 
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
 
         AuthTokenContext mockAuthTokenContext = mock(AuthTokenContext.class);
         when(mockAuthTokenContext.getAuthToken()).thenReturn("");
@@ -105,7 +105,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(50)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
 
         /* Verify that we have called sendAsync on the ingestion. */
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have called deleteLogs on the Persistence. */
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
@@ -126,7 +126,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
         assertEquals(1, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mockPersistence, times(51)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, times(50)).onSuccess(any(Log.class));
 
@@ -136,7 +136,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         runnable.set(null);
 
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        verify(mockIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, times(2)).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, times(51)).onSuccess(any(Log.class));
 
@@ -145,7 +145,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
         assertEquals(2, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mockPersistence, times(53)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
-        verify(mockIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, times(2)).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, times(51)).onSuccess(any(Log.class));
 
@@ -154,7 +154,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         runnable.get().run();
 
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        verify(mockIngestion, times(3)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, times(3)).deleteLogs(any(String.class), any(String.class));
         verify(mockListener, times(53)).onSuccess(any(Log.class));
 
@@ -175,7 +175,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), Matchers.<ArrayList<Log>>any())).then(getGetLogsAnswer(40));
 
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -218,11 +218,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer()).then(getGetLogsAnswer(49)).then(getGetLogsAnswer());
 
         final List<ServiceCallback> callbacks = new ArrayList<>();
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
             public Object answer(InvocationOnMock invocation) {
                 Object[] args = invocation.getArguments();
-                if (args[3] instanceof ServiceCallback) {
-                    callbacks.add((ServiceCallback) invocation.getArguments()[3]);
+                if (args[4] instanceof ServiceCallback) {
+                    callbacks.add((ServiceCallback) invocation.getArguments()[4]);
                 }
                 return null;
             }
@@ -241,7 +241,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         /* Verify all logs stored, N requests sent, not log deleted yet. */
         verify(mockPersistence, times(200)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
-        verify(mockIngestion, times(3)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
 
         /* Make 1 of the call succeed. Verify log deleted. */
@@ -249,7 +249,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
 
         /* The request N+1 is now unlocked. */
-        verify(mockIngestion, times(4)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(4)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Unlock all requests and check logs deleted. */
         for (int i = 1; i < 4; i++)
@@ -269,11 +269,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer());
 
         final List<ServiceCallback> callbacks = new ArrayList<>();
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(new Answer<Object>() {
             public Object answer(InvocationOnMock invocation) {
                 Object[] args = invocation.getArguments();
-                if (args[3] instanceof ServiceCallback) {
-                    callbacks.add((ServiceCallback) invocation.getArguments()[3]);
+                if (args[4] instanceof ServiceCallback) {
+                    callbacks.add((ServiceCallback) invocation.getArguments()[4]);
                 }
                 return null;
             }
@@ -290,7 +290,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         /* Verify all logs stored, N requests sent, not log deleted yet. */
         verify(mockPersistence, times(100)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
-        verify(mockIngestion, times(3)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
 
         /* Make 1 of the call succeed. Verify log deleted. */
@@ -298,7 +298,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
 
         /* The request N+1 is now unlocked. */
-        verify(mockIngestion, times(4)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(4)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Unlock all requests and check logs deleted. */
         for (int i = 1; i < 4; i++)
@@ -323,7 +323,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                 .then(getGetLogsAnswer(50))
                 .then(getGetLogsAnswer(50))
                 .then(getGetLogsAnswer(20));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new SocketException())).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new SocketException())).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -339,7 +339,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(50)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
 
         /* Verify that we have called sendAsync on the ingestion. */
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have not called deleteLogs on the Persistence. */
         verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
@@ -374,7 +374,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Verify that we have called sendAsync on the ingestion 3 times total. */
-        verify(mockIngestion, times(3)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have called deleteLogs on the Persistence (2 successful batches, the first call was a recoverable failure). */
         verify(mockPersistence, times(2)).deleteLogs(any(String.class), any(String.class));
@@ -401,7 +401,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                 /* Second 50 logs will be used for clearing pending states. */
                 .then(getGetLogsAnswer(50))
                 .then(getGetLogsAnswer(20));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(403))).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(403))).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
@@ -417,7 +417,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(50)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
 
         /* Verify that we have called sendAsync on the ingestion. */
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that the Channel is disabled. */
         assertFalse(channel.isEnabled());
@@ -460,7 +460,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Verify that we have called sendAsync on the ingestion 2 times total: 1 earlier failure then 1 success. */
-        verify(mockIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have called deleteLogs on the Persistence for the successful batch after re-enabling. */
         verify(mockPersistence).deleteLogs(any(String.class), any(String.class));
@@ -479,7 +479,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         Channel.GroupListener mockListener = mock(Channel.GroupListener.class);
 
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer());
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -492,7 +492,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(2)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
 
         /* Verify that we have called sendAsync on the ingestion twice as batch size is 1. */
-        verify(mockIngestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have called deleteLogs on the Persistence. */
         verify(mockPersistence, times(2)).deleteLogs(any(String.class), any(String.class));
@@ -518,7 +518,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         Channel.GroupListener mockListener = mock(Channel.GroupListener.class);
 
         when(mockPersistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class))).then(getGetLogsAnswer(1));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new SocketException())).then(getSendAsyncAnswer());
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new SocketException())).then(getSendAsyncAnswer());
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -532,7 +532,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(logNumber)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
 
         /* Verify that we have called sendAsync on the ingestion once for the first item, but not more than that. */
-        verify(mockIngestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have not called deleteLogs on the Persistence. */
         verify(mockPersistence, never()).deleteLogs(any(String.class), any(String.class));
@@ -555,7 +555,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.setEnabled(true);
 
         /* Verify that we have called sendAsync on the ingestion n+1 times total: 1 failure before re-enabling, n success after. */
-        verify(mockIngestion, times(logNumber + 1)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, times(logNumber + 1)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
 
         /* Verify that we have called deleteLogs on the Persistence n times. */
         verify(mockPersistence, times(logNumber)).deleteLogs(any(String.class), any(String.class));
@@ -583,7 +583,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         when(mockPersistence.countLogs(anyString())).thenReturn(30);
         when(mockPersistence.getLogs(anyString(), anyListOf(String.class), anyInt(), anyListOf(Log.class))).thenAnswer(getGetLogsAnswer(10));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class)))
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class)))
                 /* Simulate waiting for response for the first batch. */
                 .then(new Answer<Object>() {
                     @Override
@@ -617,7 +617,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         when(mockPersistence.countLogs(anyString())).thenReturn(3);
         when(mockPersistence.getLogs(anyString(), anyListOf(String.class), anyInt(), anyListOf(Log.class))).thenAnswer(getGetLogsAnswer(1));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class)))
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class)))
                 /* Simulate waiting for response for the first batch. */
                 .then(new Answer<Object>() {
                     @Override
@@ -661,7 +661,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         }
         verify(mockPersistence, times(10)).putLog(any(Log.class), eq(TEST_GROUP), eq(PERSISTENCE_NORMAL));
         verify(mockPersistence, times(10)).putLog(any(Log.class), eq(TEST_GROUP + "2"), eq(PERSISTENCE_NORMAL));
-        verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
@@ -690,7 +690,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mAppCenterHandler).removeCallbacks(any(Runnable.class));
         verify(ingestion).close();
         verify(persistence).deleteLogs(TEST_GROUP);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(listener).onGloballyEnabled(false);
 
         /* Enable and send a new log. */
@@ -700,7 +700,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertNotNull(runnable.get());
         runnable.get().run();
         verify(ingestion).reopen();
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(listener).onGloballyEnabled(true);
     }
 
@@ -710,12 +710,12 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         Persistence persistence = mock(Persistence.class);
         final DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mAppCenterHandler);
         when(persistence.getLogs(anyString(), anyListOf(String.class), anyInt(), anyListOf(Log.class))).thenAnswer(getGetLogsAnswer(1));
-        when(ingestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).thenAnswer(new Answer<Void>() {
+        when(ingestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).thenAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
 
                 /* Simulate a service disabled in the middle of network transaction. */
-                ServiceCallback callback = (ServiceCallback) invocation.getArguments()[3];
+                ServiceCallback callback = (ServiceCallback) invocation.getArguments()[4];
                 channel.removeGroup(TEST_GROUP);
                 callback.onCallSucceeded("", null);
                 return null;
@@ -737,11 +737,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(persistence.getLogs(anyString(), anyListOf(String.class), anyInt(), anyListOf(Log.class))).thenAnswer(getGetLogsAnswer(3));
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(3, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         assertNotNull(runnable.get());
         runnable.get().run();
-        verify(ingestion).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
     }
@@ -756,11 +756,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(persistence.getLogs(anyString(), anyListOf(String.class), anyInt(), anyListOf(Log.class))).thenAnswer(getGetLogsAnswer(50)).thenAnswer(getGetLogsAnswer(50)).thenAnswer(getGetLogsAnswer(3));
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
-        verify(ingestion, times(2)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(3, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         assertNotNull(runnable.get());
         runnable.get().run();
-        verify(ingestion, times(3)).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
     }
@@ -783,7 +783,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(persistence).deleteLogs(TEST_GROUP);
         assertNotNull(runnable.get());
         runnable.get().run();
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -818,11 +818,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(persistence.countLogs(anyString())).thenReturn(2);
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, ingestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(2, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         assertNotNull(runnable.get());
         runnable.get().run();
-        verify(ingestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
     }
@@ -840,7 +840,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                 .then(getGetLogsAnswer(DefaultChannel.CLEAR_BATCH_SIZE - 1))
                 /* Logs from here will be used another group to skip callbacks. */
                 .then(getGetLogsAnswer(DefaultChannel.CLEAR_BATCH_SIZE));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(403)));
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(403)));
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
@@ -870,7 +870,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                 .then(getGetLogsAnswer(DefaultChannel.CLEAR_BATCH_SIZE));
 
         /* Make first call hang, and the second call return a fatal error. */
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).thenReturn(null).then(getSendAsyncAnswer(new HttpException(403)));
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).thenReturn(null).then(getSendAsyncAnswer(new HttpException(403)));
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 1, 1, MAX_PARALLEL_BATCHES, null, null);
@@ -896,7 +896,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         when(mockPersistence.getLogs(eq(TEST_GROUP), anyListOf(String.class), anyInt(), anyListOf(Log.class)))
                 .then(getGetLogsAnswer(1));
-        when(mockIngestion.sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(503)));
+        when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer(new HttpException(503)));
 
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/AppCenterIngestionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/AppCenterIngestionTest.java
@@ -103,10 +103,9 @@ public class AppCenterIngestionTest {
         ingestion.setLogUrl("http://mock");
         String appSecret = UUIDUtils.randomUUID().toString();
         String authToken = UUIDUtils.randomUUID().toString();
-        ingestion.setAuthToken(authToken);
         UUID installId = UUIDUtils.randomUUID();
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(appSecret, installId, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken, appSecret, installId, container, serviceCallback));
 
         /* Verify call to http client. */
         HashMap<String, String> expectedHeaders = new HashMap<>();
@@ -116,7 +115,7 @@ public class AppCenterIngestionTest {
         verify(mHttpClient).callAsync(eq("http://mock" + AppCenterIngestion.API_PATH), eq(METHOD_POST), eq(expectedHeaders), notNull(HttpClient.CallTemplate.class), eq(serviceCallback));
         assertNotNull(callTemplate.get());
         assertEquals("mockPayload", callTemplate.get().buildRequestBody());
-        assertEquals(authToken, ingestion.getAuthToken());
+        assertEquals(authToken, authToken);
         
         /* Verify close. */
         ingestion.close();
@@ -157,10 +156,9 @@ public class AppCenterIngestionTest {
         ingestion.setLogUrl("http://mock");
         String appSecret = UUIDUtils.randomUUID().toString();
         String authToken = UUIDUtils.randomUUID().toString();
-        ingestion.setAuthToken(authToken);
         UUID installId = UUIDUtils.randomUUID();
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(appSecret, installId, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken, appSecret, installId, container, serviceCallback));
 
         /* Verify call to http client. */
         HashMap<String, String> expectedHeaders = new HashMap<>();
@@ -255,8 +253,7 @@ public class AppCenterIngestionTest {
         });
         AppCenterIngestion ingestion = new AppCenterIngestion(mock(Context.class), mock(LogSerializer.class));
         ingestion.setLogUrl("http://mock");
-        ingestion.setAuthToken(authToken);
-        assertEquals(call, ingestion.sendAsync(appSecret, UUIDUtils.randomUUID(), mock(LogContainer.class), mock(ServiceCallback.class)));
+        assertEquals(call, ingestion.sendAsync(authToken, appSecret, UUIDUtils.randomUUID(), mock(LogContainer.class), mock(ServiceCallback.class)));
         return callTemplate.get();
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/OneCollectorIngestionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/OneCollectorIngestionTest.java
@@ -162,10 +162,9 @@ public class OneCollectorIngestionTest {
         /* Test calling code. */
         OneCollectorIngestion ingestion = new OneCollectorIngestion(mock(Context.class), serializer);
         ingestion.setLogUrl("http://mock");
-        ingestion.setAuthToken("fake-token");
-        assertNull(ingestion.getAuthToken());
+        String authToken = "fake-token";
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(null, null, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
 
         /* Verify call to http client. */
         HashMap<String, String> expectedHeaders = new HashMap<>();
@@ -236,7 +235,8 @@ public class OneCollectorIngestionTest {
         OneCollectorIngestion ingestion = new OneCollectorIngestion(mock(Context.class), serializer);
         ingestion.setLogUrl("http://mock");
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(null, null, container, serviceCallback));
+        String authToken = "fake-token";
+        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
 
         /* Verify call to http client. */
         Map<String, String> headers = mHeadersCaptor.getValue();
@@ -279,7 +279,8 @@ public class OneCollectorIngestionTest {
         OneCollectorIngestion ingestion = new OneCollectorIngestion(mock(Context.class), serializer);
         ingestion.setLogUrl("http://mock");
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(null, null, container, serviceCallback));
+        String authToken = "fake-token";
+        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
 
         /* Verify call to http client was made without headers as JSON failed. */
         Map<String, String> headers = mHeadersCaptor.getValue();
@@ -312,7 +313,8 @@ public class OneCollectorIngestionTest {
         OneCollectorIngestion ingestion = new OneCollectorIngestion(mock(Context.class), serializer);
         ingestion.setLogUrl("http://mock");
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(null, null, container, serviceCallback));
+        String authToken = "fake-token";
+        assertEquals(call, ingestion.sendAsync(authToken, null, null, container, serviceCallback));
 
         /* Verify call to http client. */
         assertNotNull(callTemplate.getValue());
@@ -397,7 +399,8 @@ public class OneCollectorIngestionTest {
         when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), callTemplate.capture(), any(ServiceCallback.class))).thenReturn(call);
         OneCollectorIngestion ingestion = new OneCollectorIngestion(mock(Context.class), mock(LogSerializer.class));
         ingestion.setLogUrl("http://mock");
-        assertEquals(call, ingestion.sendAsync(null, null, mock(LogContainer.class), mock(ServiceCallback.class)));
+        String authToken = "fake-token";
+        assertEquals(call, ingestion.sendAsync(authToken, null, null, mock(LogContainer.class), mock(ServiceCallback.class)));
         return callTemplate.getValue();
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/OneCollectorIngestionTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/OneCollectorIngestionTest.java
@@ -164,7 +164,7 @@ public class OneCollectorIngestionTest {
         ingestion.setLogUrl("http://mock");
         String authToken = "fake-token";
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
-        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken, null, null, container, serviceCallback));
 
         /* Verify call to http client. */
         HashMap<String, String> expectedHeaders = new HashMap<>();
@@ -186,19 +186,19 @@ public class OneCollectorIngestionTest {
     }
 
     @Test
-    public void passTicketsDebug() throws Exception {
+    public void passTicketsDebug() {
         Constants.APPLICATION_DEBUGGABLE = true;
         Map<String, String> headers = passTickets();
         assertEquals("true", headers.get(OneCollectorIngestion.STRICT));
     }
 
     @Test
-    public void passTicketsRelease() throws Exception {
+    public void passTicketsRelease() {
         Map<String, String> headers = passTickets();
         assertNull(headers.get(OneCollectorIngestion.STRICT));
     }
 
-    private Map<String, String> passTickets() throws Exception {
+    private Map<String, String> passTickets() {
 
         /* Build some payload. */
         final CommonSchemaLog log1 = mock(CommonSchemaLog.class);
@@ -236,7 +236,7 @@ public class OneCollectorIngestionTest {
         ingestion.setLogUrl("http://mock");
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
         String authToken = "fake-token";
-        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken, null, null, container, serviceCallback));
 
         /* Verify call to http client. */
         Map<String, String> headers = mHeadersCaptor.getValue();
@@ -280,7 +280,7 @@ public class OneCollectorIngestionTest {
         ingestion.setLogUrl("http://mock");
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
         String authToken = "fake-token";
-        assertEquals(call, ingestion.sendAsync(authToken,null, null, container, serviceCallback));
+        assertEquals(call, ingestion.sendAsync(authToken, null, null, container, serviceCallback));
 
         /* Verify call to http client was made without headers as JSON failed. */
         Map<String, String> headers = mHeadersCaptor.getValue();
@@ -374,7 +374,7 @@ public class OneCollectorIngestionTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void onBeforeCallingWithAnotherLogLevel() throws Exception {
+    public void onBeforeCallingWithAnotherLogLevel() {
 
         /* Mock instances. */
         String apiKey = UUIDUtils.randomUUID().toString();
@@ -391,7 +391,7 @@ public class OneCollectorIngestionTest {
         AppCenterLog.verbose(anyString(), anyString());
     }
 
-    private HttpClient.CallTemplate getCallTemplate() throws Exception {
+    private HttpClient.CallTemplate getCallTemplate() {
 
         /* Configure mock HTTP to get an instance of IngestionCallTemplate. */
         ServiceCall call = mock(ServiceCall.class);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -16,7 +16,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -36,7 +36,7 @@ public class AuthTokenContextTest {
     public void setAuthTokenTest() {
 
         /* Mock context listener. */
-        AuthTokenContext.Listener mockListener = mock(AuthTokenContext.Listener.class);
+        AuthTokenContext.Listener mockListener = spy(AbstractTokenContextListener.class);
 
         /* Set new auth token. */
         mAuthTokenContext.addListener(mockListener);


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

To avoid sending incorrect token for logs we should remove `mAuthToken` from `AppCenterIngestion` and pass it as a parameter to each batch of logs on sending.

## Related PRs or issues

AB#58501
