### PR TITLE
Temporarily revert msal to 0.2.1-SNAPSHOT

### DIFF
--- a/sdk/appcenter-identity/build.gradle
+++ b/sdk/appcenter-identity/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     api project(':sdk:appcenter')
 
     //noinspection GradleDependency
-    api 'com.microsoft.identity.client:msal:0.2.2-SNAPSHOT'
+    api 'com.microsoft.identity.client:msal:0.2.1-SNAPSHOT'
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Temporarily revert msal to 0.2.1-SNAPSHOT
0.2.2 last snapshot breaks sign in with timezone parsing error.
0.2.1 works but not on Facebook...
