### PR TITLE
Data storage offline read API

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Constants.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Constants.java
@@ -27,6 +27,26 @@ public final class Constants {
     public static final String TIMESTAMP_FIELD_NAME = "_ts";
 
     /**
+     * Pending operation CREATE value.
+     */
+    public static final String PENDING_OPERATION_CREATE_VALUE = "CREATE";
+
+    /**
+     * Pending operation REPLACE value.
+     */
+    public static final String PENDING_OPERATION_REPLACE_VALUE = "REPLACE";
+
+    /**
+     * Pending operation DELETE value.
+     */
+    public static final String PENDING_OPERATION_DELETE_VALUE = "DELETE";
+
+    /**
+     * Pending operation NULL value.
+     */
+    public static final String PENDING_OPERATION_NULL_VALUE = "NULL";
+
+    /**
      * Base URL to call token exchange service.
      */
     static final String DEFAULT_API_URL = "https://api.appcenter.ms/v0.1"; //TODO This is not the right url.

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
@@ -22,6 +22,7 @@ import com.microsoft.appcenter.utils.storage.SQLiteUtils;
 import java.util.Calendar;
 
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
+import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_CREATE_VALUE;
 
 class LocalDocumentStorage {
 
@@ -77,21 +78,6 @@ class LocalDocumentStorage {
     private static final String PENDING_OPERATION_COLUMN_NAME = "pending_operation";
 
     /**
-     * Pending operation CREATE value.
-     */
-    private static final String PENDING_OPERATION_CREATE_VALUE = "CREATE";
-
-    /**
-     * Pending operation REPLACE value.
-     */
-    private static final String PENDING_OPERATION_REPLACE_VALUE = "REPLACE";
-
-    /**
-     * Pending operation DELETE value.
-     */
-    private static final String PENDING_OPERATION_DELETE_VALUE = "DELETE";
-
-    /**
      * Current version of the schema.
      */
     private static final int VERSION = 1;
@@ -113,18 +99,22 @@ class LocalDocumentStorage {
     }
 
     <T> void write(Document<T> document, WriteOptions writeOptions) {
-        AppCenterLog.debug(LOG_TAG, String.format("Trying to replace %s:%s document to cache", document.getPartition(), document.getId()));
-        Calendar now = Calendar.getInstance();
-        Calendar expiresAt = now;
+        write(document, writeOptions, PENDING_OPERATION_CREATE_VALUE);
+    }
+
+    <T> void write(Document<T> document, WriteOptions writeOptions, String pendingOperationValue) {
+        AppCenterLog.debug(LOG_TAG, String.format("Trying to write %s:%s document to cache", document.getPartition(), document.getId()));
+        Calendar expiresAt = Calendar.getInstance();
         expiresAt.add(Calendar.SECOND, writeOptions.getDeviceTimeToLive());
         ContentValues values = getContentValues(
-                document.getPartition(), document.getId(),
+                document.getPartition(),
+                document.getId(),
                 document,
                 document.getEtag(),
                 expiresAt.getTimeInMillis(),
-                now.getTimeInMillis(),
-                now.getTimeInMillis(),
-                PENDING_OPERATION_CREATE_VALUE);
+                expiresAt.getTimeInMillis(),
+                expiresAt.getTimeInMillis(),
+                pendingOperationValue);
         mDatabaseManager.replace(values);
     }
 

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -40,6 +40,7 @@ import static com.microsoft.appcenter.http.DefaultHttpClient.METHOD_POST;
 import static com.microsoft.appcenter.http.HttpUtils.createHttpClient;
 import static com.microsoft.appcenter.storage.Constants.DEFAULT_API_URL;
 import static com.microsoft.appcenter.storage.Constants.LOG_TAG;
+import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_NULL_VALUE;
 import static com.microsoft.appcenter.storage.Constants.SERVICE_NAME;
 import static com.microsoft.appcenter.storage.Constants.STORAGE_GROUP;
 
@@ -546,7 +547,7 @@ public class Storage extends AbstractAppCenterService {
 
     private synchronized <T> void completeFutureAndRemovePendingCall(T value, DefaultAppCenterFuture<T> result) {
         result.complete(value);
-        mLocalDocumentStorage.write((Document)value, new WriteOptions());
+        mLocalDocumentStorage.write((Document)value, new WriteOptions(), PENDING_OPERATION_NULL_VALUE);
         mPendingCalls.remove(result);
     }
 

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -546,6 +546,7 @@ public class Storage extends AbstractAppCenterService {
 
     private synchronized <T> void completeFutureAndRemovePendingCall(T value, DefaultAppCenterFuture<T> result) {
         result.complete(value);
+        mLocalDocumentStorage.write((Document)value, new WriteOptions());
         mPendingCalls.remove(result);
     }
 

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
@@ -59,11 +59,11 @@ public final class Utils {
     }
 
     /**
-     * Handle API call failure.
+     * Log the exception from a failed API call.
      *
      * @param e Exception to display in the log.
      */
-    public static synchronized void handleApiCallFailure(Exception e) {
+    public static synchronized void logApiCallFailure(Exception e) {
         AppCenterLog.error(Constants.LOG_TAG, "Failed to call App Center APIs", e);
         if (!HttpUtils.isRecoverableError(e)) {
             if (e instanceof HttpException) {

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/TokenExchange.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/TokenExchange.java
@@ -28,7 +28,7 @@ import static com.microsoft.appcenter.Constants.AUTHORIZATION_HEADER;
 import static com.microsoft.appcenter.Constants.AUTH_TOKEN_FORMAT;
 import static com.microsoft.appcenter.http.DefaultHttpClient.METHOD_POST;
 import static com.microsoft.appcenter.storage.Constants.LOG_TAG;
-import static com.microsoft.appcenter.storage.Utils.handleApiCallFailure;
+import static com.microsoft.appcenter.storage.Utils.logApiCallFailure;
 
 public class TokenExchange {
 
@@ -109,7 +109,7 @@ public class TokenExchange {
 
         @Override
         public void onCallFailed(Exception e) {
-            handleApiCallFailure(e);
+            logApiCallFailure(e);
             completeFuture(e);
         }
 

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -11,6 +11,7 @@ import android.database.sqlite.SQLiteQueryBuilder;
 
 import com.microsoft.appcenter.storage.models.BaseOptions;
 import com.microsoft.appcenter.storage.models.Document;
+import com.microsoft.appcenter.storage.models.DocumentError;
 import com.microsoft.appcenter.storage.models.ReadOptions;
 import com.microsoft.appcenter.storage.models.WriteOptions;
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -25,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 
+import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_NULL_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -66,10 +68,19 @@ public class LocalDocumentStorageTest {
     }
 
     @Test
-    public void upsertGetsCalledInWrite() {
+    public void updateGetsCalledInWrite() {
         mLocalDocumentStorage.write(new Document<>("Test value", PARTITION, DOCUMENT_ID), new WriteOptions());
-        ArgumentCaptor<ContentValues> values = ArgumentCaptor.forClass(ContentValues.class);
-        verify(mDatabaseManager).replace(values.capture());
+        ArgumentCaptor<ContentValues> argumentCaptor = ArgumentCaptor.forClass(ContentValues.class);
+        verify(mDatabaseManager).replace(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+    }
+
+    @Test
+    public void updateGetsCalledInWriteWithPendingOperation() {
+        mLocalDocumentStorage.write(new Document<>("Test value", PARTITION, DOCUMENT_ID), new WriteOptions(), PENDING_OPERATION_NULL_VALUE);
+        ArgumentCaptor<ContentValues> argumentCaptor = ArgumentCaptor.forClass(ContentValues.class);
+        verify(mDatabaseManager).replace(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
     }
 
     @Test
@@ -79,7 +90,7 @@ public class LocalDocumentStorageTest {
         assertNotNull(doc);
         assertNull(doc.getDocument());
         assertTrue(doc.failed());
-        assertNotNull(doc.getError());
+        assertEquals(DocumentError.class, doc.getError().getClass());
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -90,7 +90,7 @@ public class LocalDocumentStorageTest {
     }
 
     @Test
-    public void verifyOptionsContstructors() {
+    public void verifyOptionsConstructors() {
         assertEquals(BaseOptions.INFINITE, ReadOptions.CreateInfiniteCacheOption().getDeviceTimeToLive());
         assertEquals(BaseOptions.NO_CACHE, ReadOptions.CreateNoCacheOption().getDeviceTimeToLive());
         assertEquals(BaseOptions.INFINITE, WriteOptions.CreateInfiniteCacheOption().getDeviceTimeToLive());

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -18,6 +18,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.storage.DatabaseManager;
 import com.microsoft.appcenter.utils.storage.SQLiteUtils;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +31,7 @@ import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_NULL_V
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -91,6 +93,7 @@ public class LocalDocumentStorageTest {
         assertNull(doc.getDocument());
         assertTrue(doc.failed());
         assertEquals(DocumentError.class, doc.getError().getClass());
+        assertThat(doc.getError().getError().getMessage(), CoreMatchers.containsString("Failed to read from cache."));
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
@@ -29,6 +29,7 @@ import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.hamcrest.CoreMatchers;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -421,25 +422,10 @@ public class StorageTest extends AbstractStorageTest {
     }
 
     @Test
-    public void readEndToEnd() throws Exception {
+    public void readEndToEndWithNetwork() throws Exception {
         AppCenterFuture<Document<TestDocument>> doc = Storage.read(PARTITION, DOCUMENT_ID, TestDocument.class);
 
-        ArgumentCaptor<HttpClient.CallTemplate> tokenExchangeCallTemplateCallbackArgumentCaptor =
-                ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
-        ArgumentCaptor<TokenExchange.TokenExchangeServiceCallback> tokenExchangeServiceCallbackArgumentCaptor =
-                ArgumentCaptor.forClass(TokenExchange.TokenExchangeServiceCallback.class);
-        verifyNoMoreInteractions(mLocalDocumentStorage);
-        verify(mHttpClient, times(1)).callAsync(
-                endsWith(TokenExchange.GET_TOKEN_PATH_FORMAT),
-                eq(METHOD_POST),
-                anyMapOf(String.class, String.class),
-                tokenExchangeCallTemplateCallbackArgumentCaptor.capture(),
-                tokenExchangeServiceCallbackArgumentCaptor.capture());
-        tokenExchangeCallTemplateCallbackArgumentCaptor.getValue().buildRequestBody();
-        tokenExchangeCallTemplateCallbackArgumentCaptor.getValue().onBeforeCalling(null, new HashMap<String, String>());
-        TokenExchange.TokenExchangeServiceCallback tokenExchangeServiceCallback = tokenExchangeServiceCallbackArgumentCaptor.getValue();
-        assertNotNull(tokenExchangeServiceCallback);
-        tokenExchangeServiceCallback.onCallSucceeded(tokenExchangeResponsePayload, new HashMap<String, String>());
+        setupAndVerifyTokenExchangeCall();
 
         ArgumentCaptor<HttpClient.CallTemplate> cosmosDbCallTemplateCallbackArgumentCaptor =
                 ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
@@ -470,16 +456,60 @@ public class StorageTest extends AbstractStorageTest {
         TestDocument testDocument = testCosmosDocument.getDocument();
         assertNotNull(testDocument);
         assertEquals(TEST_FIELD_VALUE, testDocument.test);
+    }
 
-        /* The test passes individually, but not in a suit. Need to figure out which mocks do not get reset. */
-        when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
-        Storage.read(PARTITION, DOCUMENT_ID, TestDocument.class);
+    private void setupAndVerifyTokenExchangeCall() throws JSONException {
+        ArgumentCaptor<HttpClient.CallTemplate> tokenExchangeCallTemplateCallbackArgumentCaptor =
+                ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
+        ArgumentCaptor<TokenExchange.TokenExchangeServiceCallback> tokenExchangeServiceCallbackArgumentCaptor =
+                ArgumentCaptor.forClass(TokenExchange.TokenExchangeServiceCallback.class);
+        verifyNoMoreInteractions(mLocalDocumentStorage);
+        verify(mHttpClient, times(1)).callAsync(
+                endsWith(TokenExchange.GET_TOKEN_PATH_FORMAT),
+                eq(METHOD_POST),
+                anyMapOf(String.class, String.class),
+                tokenExchangeCallTemplateCallbackArgumentCaptor.capture(),
+                tokenExchangeServiceCallbackArgumentCaptor.capture());
+        tokenExchangeCallTemplateCallbackArgumentCaptor.getValue().buildRequestBody();
+        tokenExchangeCallTemplateCallbackArgumentCaptor.getValue().onBeforeCalling(null, new HashMap<String, String>());
+        TokenExchange.TokenExchangeServiceCallback tokenExchangeServiceCallback = tokenExchangeServiceCallbackArgumentCaptor.getValue();
+        assertNotNull(tokenExchangeServiceCallback);
+        tokenExchangeServiceCallback.onCallSucceeded(tokenExchangeResponsePayload, new HashMap<String, String>());
+    }
+
+    @Test
+    public void readFailedCosmosDbCallFailed() throws JSONException {
+        AppCenterFuture<Document<TestDocument>> doc = Storage.read(PARTITION, DOCUMENT_ID, TestDocument.class);
+
+        setupAndVerifyTokenExchangeCall();
+
+        ArgumentCaptor<HttpClient.CallTemplate> cosmosDbCallTemplateCallbackArgumentCaptor =
+                ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
+        ArgumentCaptor<ServiceCallback> cosmosDbServiceCallbackArgumentCaptor =
+                ArgumentCaptor.forClass(ServiceCallback.class);
+        verify(mHttpClient, times(1)).callAsync(
+                endsWith(CosmosDb.getDocumentBaseUrl(DATABASE_NAME, COLLECTION_NAME, DOCUMENT_ID)),
+                eq(METHOD_GET),
+                anyMapOf(String.class, String.class),
+                cosmosDbCallTemplateCallbackArgumentCaptor.capture(),
+                cosmosDbServiceCallbackArgumentCaptor.capture());
+        cosmosDbCallTemplateCallbackArgumentCaptor.getValue().buildRequestBody();
+        cosmosDbCallTemplateCallbackArgumentCaptor.getValue().onBeforeCalling(null, new HashMap<String, String>());
+        ServiceCallback cosmosDbServiceCallback = cosmosDbServiceCallbackArgumentCaptor.getValue();
+        assertNotNull(cosmosDbServiceCallback);
+        cosmosDbServiceCallback.onCallFailed(new Exception("Cosmos db exception."));
+
+        /*
+         *  No retries and Cosmos DB does not get called.
+         */
         verifyNoMoreInteractions(mHttpClient);
-        verify(mLocalDocumentStorage).read(
-                eq(PARTITION),
-                eq(DOCUMENT_ID),
-                eq(testDocument.getClass()),
-                any(ReadOptions.class));
+        assertNotNull(doc);
+        assertNotNull(doc.get());
+        assertNull(doc.get().getDocument());
+        assertNotNull(doc.get().getError());
+        assertThat(
+                doc.get().getError().getError().getMessage(),
+                CoreMatchers.containsString("Cosmos db exception."));
     }
 
     @Test
@@ -553,6 +583,18 @@ public class StorageTest extends AbstractStorageTest {
         assertThat(
                 doc.get().getError().getError().getMessage(),
                 CoreMatchers.containsString(exceptionMessage));
+    }
+
+    @Test
+    public void readWithNoNetwork() {
+        when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
+        Storage.read(PARTITION, DOCUMENT_ID, TestDocument.class);
+        verifyNoMoreInteractions(mHttpClient);
+        verify(mLocalDocumentStorage).read(
+                eq(PARTITION),
+                eq(DOCUMENT_ID),
+                eq(TestDocument.class),
+                any(ReadOptions.class));
     }
 
     @Test


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Data storage read API for offline.

`Storage.read` API will read file from cosmos db and cache the file in local storage. In the event of no network ("offline"), `Storage.read` API will read from cache.

## Misc

Still missing some unit test coverage for `LocalDocumentStorage.read` API.
