### PR TITLE
Add automatic token refresh when tokens expire or about to expire.

### DIFF
--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
@@ -125,7 +125,7 @@ public class Identity extends AbstractAppCenterService {
      */
     private DefaultAppCenterFuture<SignInResult> mPendingSignInFuture;
 
-    private AuthTokenContext.Listener mOnTokenRequiresRefreshing = new AbstractTokenContextListener() {
+    private AuthTokenContext.Listener mAuthTokenContextListener = new AbstractTokenContextListener() {
 
         @Override
         public void onTokenRequiresRefresh(String homeAccountId) {
@@ -224,7 +224,7 @@ public class Identity extends AbstractAppCenterService {
     @Override
     protected synchronized void applyEnabledState(boolean enabled) {
         if (enabled) {
-            AuthTokenContext.getInstance().addListener(mOnTokenRequiresRefreshing);
+            AuthTokenContext.getInstance().addListener(mAuthTokenContextListener);
 
             /* Load cached configuration in case APIs are called early. */
             loadConfigurationFromCache();
@@ -232,7 +232,7 @@ public class Identity extends AbstractAppCenterService {
             /* Download the latest configuration in background. */
             downloadConfiguration();
         } else {
-            AuthTokenContext.getInstance().removeListener(mOnTokenRequiresRefreshing);
+            AuthTokenContext.getInstance().removeListener(mAuthTokenContextListener);
             if (mGetConfigCall != null) {
                 mGetConfigCall.cancel();
                 mGetConfigCall = null;

--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
@@ -133,7 +133,7 @@ public class Identity extends AbstractAppCenterService {
             if (account != null) {
                 silentSignIn(account);
             } else {
-                AppCenterLog.warn(LOG_TAG, "Account is changed, reset to anonymous sending.");
+                AppCenterLog.info(LOG_TAG, "Account is changed, reset to anonymous sending.");
                 AuthTokenContext.getInstance().setAuthToken(null, null, null);
             }
         }

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -24,6 +24,8 @@ import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.UUIDUtils;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
+import com.microsoft.appcenter.utils.context.AuthTokenContext;
+import com.microsoft.appcenter.utils.context.AuthTokenInfo;
 import com.microsoft.appcenter.utils.storage.FileManager;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 import com.microsoft.identity.client.AuthenticationCallback;
@@ -45,6 +47,7 @@ import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.io.File;
@@ -52,6 +55,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -662,7 +666,7 @@ public class IdentityTest extends AbstractIdentityTest {
         verify(publicClientApplication).acquireTokenSilentAsync(notNull(String[].class), any(IAccount.class),
                 any(String.class), eq(true), notNull(AuthenticationCallback.class));
         verify(publicClientApplication, times(2)).acquireToken(same(activity), notNull(String[].class), notNull(AuthenticationCallback.class));
-        verify(mAuthTokenContext, times(2)).setAuthToken(eq(mockIdToken), eq(mockHomeAccountId), any(Date.class) );
+        verify(mAuthTokenContext, times(2)).setAuthToken(eq(mockIdToken), eq(mockHomeAccountId), any(Date.class));
     }
 
     @Test
@@ -1043,6 +1047,63 @@ public class IdentityTest extends AbstractIdentityTest {
         /* Sign out should clear token. */
         Identity.signOut();
         verify(mAuthTokenContext).setAuthToken(isNull(String.class), isNull(String.class), isNull(Date.class));
+    }
+
+    @Test
+    public void testListenerCalledOnTokenRefreshAccountIsNull() throws Exception {
+        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
+        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+
+        /* Mock authentication lib. */
+        PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
+        whenNew(PublicClientApplication.class).withAnyArguments().thenReturn(publicClientApplication);
+        mockReadyToSignIn();
+        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        listenerArgumentCaptor.getValue().onTokenRequiresRefresh("accountId");
+        List<AuthTokenInfo> tokenInfoList = Collections.singletonList(new AuthTokenInfo("token", null, new Date()));
+        AuthTokenInfo tokenInfo = tokenInfoList.get(0);
+        when(publicClientApplication.getAccount(anyString(), anyString())).thenReturn(null);
+        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(tokenInfo);
+
+        /* Check token is cleared when account is null. */
+        verify(mAuthTokenContext).setAuthToken(isNull(String.class), isNull(String.class), isNull(Date.class));
+    }
+
+    @Test
+    public void testListenerCalledOnTokenRefreshAccount() throws Exception {
+        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
+        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+
+        /* Mock authentication lib. */
+        PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
+        whenNew(PublicClientApplication.class).withAnyArguments().thenReturn(publicClientApplication);
+        HttpClientRetryer httpClient = mock(HttpClientRetryer.class);
+        whenNew(HttpClientRetryer.class).withAnyArguments().thenReturn(httpClient);
+        Identity identity = Identity.getInstance();
+
+        start(identity);
+
+        /* Download configuration. */
+        mockSuccessfulHttpCall(mockValidForAppCenterConfig(), httpClient);
+
+        /* Mock foreground. */
+        identity.onActivityResumed(mock(Activity.class));
+
+        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        IAccount account = mock(IAccount.class);
+        IAccountIdentifier accountIdentifier = mock(IAccountIdentifier.class);
+        when(accountIdentifier.getIdentifier()).thenReturn("accountId");
+        when(account.getHomeAccountIdentifier()).thenReturn(accountIdentifier);
+        when(publicClientApplication.getAccount(eq("accountId"), anyString())).thenReturn(account);
+        when(publicClientApplication.getAccount(anyString(), anyString())).thenReturn(account);
+
+        listenerArgumentCaptor.getValue().onTokenRequiresRefresh("randomAsccountId");
+        List<AuthTokenInfo> tokenInfoList = Collections.singletonList(new AuthTokenInfo("token", null, new Date()));
+        AuthTokenInfo tokenInfo = tokenInfoList.get(0);
+        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(tokenInfo);
+
+        /* Check token is cleared when account is null. */
+        PowerMockito.verifyPrivate(identity).invoke("silentSignIn", account);
     }
 
     @Test

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -47,7 +47,6 @@ import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.io.File;
@@ -72,6 +71,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMapOf;
@@ -1103,7 +1103,7 @@ public class IdentityTest extends AbstractIdentityTest {
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(tokenInfo);
 
         /* Check token is cleared when account is null. */
-        PowerMockito.verifyPrivate(identity).invoke("silentSignIn", account);
+        verify(publicClientApplication).acquireTokenSilentAsync(any(String[].class), any(IAccount.class), anyString(), anyBoolean(), any(AuthenticationCallback.class));
     }
 
     @Test

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -469,6 +469,9 @@ public class DefaultChannel implements Channel {
                 authToken = authTokenInfo.getAuthToken();
                 startTime = authTokenInfo.getStartTime();
                 endTime = authTokenInfo.getEndTime();
+
+                /* Check if token is about to expired or about to expire, and refresh it if necessary. */
+                authTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
             } else {
                 authToken = null;
             }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AbstractTokenContextListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AbstractTokenContextListener.java
@@ -17,4 +17,9 @@ public abstract class AbstractTokenContextListener implements AuthTokenContext.L
     @Override
     public void onNewUser(String authToken) {
     }
+
+    @Override
+    public void onTokenRequiresRefresh(String homeAccountId) {
+    }
+
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -285,7 +285,7 @@ public class AuthTokenContext {
         }
         AuthTokenHistoryEntry lastToken = history.get(history.size() - 1);
         boolean isLastToken = (authTokenInfo.getAuthToken() != null && authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
-        boolean isAboutToExpire = authTokenInfo.isExpiresSoon();
+        boolean isAboutToExpire = authTokenInfo.isAboutToExpire();
         if (!isLastToken || !isAboutToExpire) {
             return;
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -280,7 +280,7 @@ public class AuthTokenContext {
      */
     public synchronized void checkIfTokenNeedsToBeRefreshed(AuthTokenInfo authTokenInfo) {
         List<AuthTokenHistoryEntry> history = getHistory();
-        if (history == null || history.size()==0) {
+        if (history == null || history.size() == 0) {
             return;
         }
         AuthTokenHistoryEntry lastToken = history.get(history.size() - 1);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -280,11 +280,11 @@ public class AuthTokenContext {
      */
     public synchronized void checkIfTokenNeedsToBeRefreshed(AuthTokenInfo authTokenInfo) {
         List<AuthTokenHistoryEntry> history = getHistory();
-        if (history == null || history.size() == 0) {
+        if (history == null || history.size() == 0 || authTokenInfo == null) {
             return;
         }
         AuthTokenHistoryEntry lastToken = history.get(history.size() - 1);
-        boolean isLastToken = (authTokenInfo.getAuthToken()!=null && authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
+        boolean isLastToken = (authTokenInfo.getAuthToken() != null && authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
         boolean isAboutToExpire = authTokenInfo.isExpiresSoon();
         if (!isLastToken || !isAboutToExpire) {
             return;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -286,7 +286,6 @@ public class AuthTokenContext {
         if (!isLastToken || !isAboutToExpire) {
             return;
         }
-
         for (Listener listener : mListeners) {
             listener.onTokenRequiresRefresh(lastToken.getHomeAccountId());
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -284,7 +284,7 @@ public class AuthTokenContext {
             return;
         }
         AuthTokenHistoryEntry lastToken = history.get(history.size() - 1);
-        boolean isLastToken = (authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
+        boolean isLastToken = (authTokenInfo.getAuthToken()!=null && authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
         boolean isAboutToExpire = authTokenInfo.isExpiresSoon();
         if (!isLastToken || !isAboutToExpire) {
             return;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -280,6 +280,9 @@ public class AuthTokenContext {
      */
     public synchronized void checkIfTokenNeedsToBeRefreshed(AuthTokenInfo authTokenInfo) {
         List<AuthTokenHistoryEntry> history = getHistory();
+        if (history == null || history.size()==0) {
+            return;
+        }
         AuthTokenHistoryEntry lastToken = history.get(history.size() - 1);
         boolean isLastToken = (authTokenInfo.getAuthToken().equals(lastToken.getAuthToken()));
         boolean isAboutToExpire = authTokenInfo.isExpiresSoon();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
@@ -12,6 +12,9 @@ import java.util.Date;
  */
 public class AuthTokenInfo {
 
+    /**
+     * Time till expiration (in seconds) when we assume token is about to expire and can refresh token.
+     */
     private static final int EXPIRATION_OFFSET_TO_REFRESH_SEC = 10 * 60;
 
     /**
@@ -54,10 +57,15 @@ public class AuthTokenInfo {
     /**
      * Returns true if token is about to expire.
      *
-     * @return boolean, true if expires soon
+     * @return boolean, true if expires soon.
      */
     public boolean isExpiresSoon() {
-        return (new Date().getTime() + EXPIRATION_OFFSET_TO_REFRESH_SEC * 1000) >= this.mEndTime.getTime();
+        if (mEndTime == null) {
+            return false;
+        }
+        Date currentDate = new Date();
+        currentDate.setTime(currentDate.getTime() + EXPIRATION_OFFSET_TO_REFRESH_SEC * 1000);
+        return currentDate.after(mEndTime);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
@@ -66,7 +66,7 @@ public class AuthTokenInfo {
         }
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.SECOND, EXPIRATION_OFFSET_TO_REFRESH_SEC);
-        return calendar.after(mEndTime);
+        return calendar.getTime().after(mEndTime);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.appcenter.utils.context;
 
+import java.util.Calendar;
 import java.util.Date;
 
 /**
@@ -63,9 +64,9 @@ public class AuthTokenInfo {
         if (mEndTime == null) {
             return false;
         }
-        Date currentDate = new Date();
-        currentDate.setTime(currentDate.getTime() + EXPIRATION_OFFSET_TO_REFRESH_SEC * 1000);
-        return currentDate.after(mEndTime);
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, EXPIRATION_OFFSET_TO_REFRESH_SEC);
+        return calendar.after(mEndTime);
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
@@ -12,6 +12,8 @@ import java.util.Date;
  */
 public class AuthTokenInfo {
 
+    private static final int EXPIRATION_OFFSET_TO_REFRESH_SEC = 10 * 60;
+
     /**
      * Auth token (<code>null</code> for anonymous).
      */
@@ -47,6 +49,15 @@ public class AuthTokenInfo {
         mAuthToken = authToken;
         mStartTime = startTime;
         mEndTime = endTime;
+    }
+
+    /**
+     * Returns true if token is about to expire.
+     *
+     * @return boolean, true if expires soon
+     */
+    public boolean isExpiresSoon() {
+        return (new Date().getTime() + EXPIRATION_OFFSET_TO_REFRESH_SEC * 1000) >= this.mEndTime.getTime();
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenInfo.java
@@ -60,7 +60,7 @@ public class AuthTokenInfo {
      *
      * @return boolean, true if expires soon.
      */
-    public boolean isExpiresSoon() {
+    boolean isAboutToExpire() {
         if (mEndTime == null) {
             return false;
         }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/CustomPropertiesTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/CustomPropertiesTest.java
@@ -232,9 +232,9 @@ public class CustomPropertiesTest {
     }
 
     @Test
-    public void maxPropertiesCount(){
+    public void maxPropertiesCount() {
         CustomProperties properties = new CustomProperties();
-        for (int i = 0; i < CustomProperties.MAX_PROPERTIES_COUNT; i++){
+        for (int i = 0; i < CustomProperties.MAX_PROPERTIES_COUNT; i++) {
             properties.set("key" + i, "value" + i);
         }
         assertEquals(CustomProperties.MAX_PROPERTIES_COUNT, properties.getProperties().size());

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import static com.microsoft.appcenter.utils.context.AuthTokenContext.PREFERENCE_KEY_TOKEN_HISTORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.any;
@@ -153,6 +152,19 @@ public class AuthTokenContextTest {
     public void historyEmptyString() {
         when(SharedPreferencesManager.getString(eq(PREFERENCE_KEY_TOKEN_HISTORY), isNull(String.class))).thenReturn("");
         assertNull(mAuthTokenContext.getHistory());
+    }
+
+    @Test
+    public void tokenRefreshOnNull() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, -60);
+        mAuthTokenContext.setAuthToken("authToken1", "accountId1", calendar.getTime());
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
+        mAuthTokenContext.addListener(listener);
+
+        /* Check that we receive callback call. */
+        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(null);
+        verify(listener, times(1)).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -161,10 +161,21 @@ public class AuthTokenContextTest {
         mAuthTokenContext.setAuthToken("authToken1", "accountId1", calendar.getTime());
         AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
         mAuthTokenContext.addListener(listener);
-
-        /* Check that we receive callback call. */
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(null);
-        verify(listener, times(1)).onTokenRequiresRefresh(notNull(String.class));
+        verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
+    }
+
+    @Test
+    public void tokenRefreshOnNullToken() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, -60);
+        mAuthTokenContext.setAuthToken("authToken1", "accountId1", calendar.getTime());
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
+        mAuthTokenContext.addListener(listener);
+        AuthTokenInfo mockTokenInfo = mock(AuthTokenInfo.class);
+        when(mockTokenInfo.getAuthToken()).thenReturn(null);
+        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(mockTokenInfo);
+        verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -163,28 +164,12 @@ public class AuthTokenContextTest {
         mAuthTokenContext.setAuthToken("authToken2", "accountId2", calendar.getTime());
         List<AuthTokenInfo> tokenInfoList = mAuthTokenContext.getAuthTokenValidityList();
         AuthTokenInfo authTokenInfo = tokenInfoList.get(tokenInfoList.size() - 1);
-        final boolean[] isCallbackCalled = {false};
-        AuthTokenContext.Listener listener = new AuthTokenContext.Listener() {
-            @Override
-            public void onNewAuthToken(String authToken) {
-
-            }
-
-            @Override
-            public void onNewUser(String authToken) {
-
-            }
-
-            @Override
-            public void onTokenRequiresRefresh(String homeAccountId) {
-                isCallbackCalled[0] = true;
-            }
-        };
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
         mAuthTokenContext.addListener(listener);
 
         /* Check that we receive callback call. */
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
-        assertTrue(isCallbackCalled[0]);
+        verify(listener, times(1)).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test
@@ -197,23 +182,7 @@ public class AuthTokenContextTest {
         mAuthTokenContext.setAuthToken("authToken2", "accountId", calendar.getTime());
         List<AuthTokenInfo> tokenInfoList = mAuthTokenContext.getAuthTokenValidityList();
         AuthTokenInfo authTokenInfo = tokenInfoList.get(tokenInfoList.size() - 1);
-        final boolean[] isCallbackCalled = {false};
-        AuthTokenContext.Listener listener = new AuthTokenContext.Listener() {
-            @Override
-            public void onNewAuthToken(String authToken) {
-
-            }
-
-            @Override
-            public void onNewUser(String authToken) {
-
-            }
-
-            @Override
-            public void onTokenRequiresRefresh(String homeAccountId) {
-                isCallbackCalled[0] = true;
-            }
-        };
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
         mAuthTokenContext.addListener(listener);
 
         /* Token not expired check. */
@@ -222,7 +191,7 @@ public class AuthTokenContextTest {
         /* Token is not last check. */
         authTokenInfo = tokenInfoList.get(tokenInfoList.size() - 2);
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
-        Assert.assertFalse(isCallbackCalled[0]);
+        verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test
@@ -231,49 +200,19 @@ public class AuthTokenContextTest {
         List<AuthTokenInfo> tokenInfoList = mAuthTokenContext.getAuthTokenValidityList();
         AuthTokenInfo authTokenInfo = tokenInfoList.get(tokenInfoList.size() - 1);
         final boolean[] isCallbackCalled = {false};
-        AuthTokenContext.Listener listener = new AuthTokenContext.Listener() {
-            @Override
-            public void onNewAuthToken(String authToken) {
-
-            }
-
-            @Override
-            public void onNewUser(String authToken) {
-
-            }
-
-            @Override
-            public void onTokenRequiresRefresh(String homeAccountId) {
-                isCallbackCalled[0] = true;
-            }
-        };
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
 
         /* If expires date is null, we should not be able to reach that method. */
         mAuthTokenContext.addListener(listener);
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
         Assert.assertFalse(isCallbackCalled[0]);
+        verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test
     public void tokenRefreshCheckNoHistoryOrHistoryIsNull() {
         AuthTokenInfo authTokenInfoMock = mock(AuthTokenInfo.class);
-        final boolean[] isCallbackCalled = {false};
-        AuthTokenContext.Listener listener = new AuthTokenContext.Listener() {
-            @Override
-            public void onNewAuthToken(String authToken) {
-
-            }
-
-            @Override
-            public void onNewUser(String authToken) {
-
-            }
-
-            @Override
-            public void onTokenRequiresRefresh(String homeAccountId) {
-                isCallbackCalled[0] = true;
-            }
-        };
+        AuthTokenContext.Listener listener = spy(AbstractTokenContextListener.class);
         mAuthTokenContext.addListener(listener);
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfoMock);
         List<AuthTokenHistoryEntry> dummyList = new ArrayList<>(0);
@@ -282,7 +221,7 @@ public class AuthTokenContextTest {
 
         /* If we have null or empty history, we should not be able to reach that method. */
         verify(authTokenInfoMock, Mockito.never()).isExpiresSoon();
-        Assert.assertFalse(isCallbackCalled[0]);
+        verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -176,7 +176,7 @@ public class AuthTokenContextTest {
     public void tokenRefreshCheckNotExpiresOrNotLast() {
         Date tokenEndTime = new Date();
         Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, 86400);
+        calendar.add(Calendar.HOUR, 24);
         mAuthTokenContext.setAuthToken("authToken1", "accountId", calendar.getTime());
         calendar.add(Calendar.SECOND, 1);
         mAuthTokenContext.setAuthToken("authToken2", "accountId", calendar.getTime());

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -243,7 +243,7 @@ public class AuthTokenContextTest {
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfoMock);
 
         /* If we have null or empty history, we should not be able to reach that method. */
-        verify(authTokenInfoMock, Mockito.never()).isExpiresSoon();
+        verify(authTokenInfoMock, Mockito.never()).isAboutToExpire();
         verify(listener, never()).onTokenRequiresRefresh(notNull(String.class));
     }
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

We need to silently refresh the identity token in the background, so users don’t have to sign in as often.

## Related PRs or issues

[AB#57848](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=57848)
[AB#58506](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=58506)