### PR TITLE
Add @NonNull annotation to DocumentError's constructor

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -403,7 +403,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
 
                     @Override
                     public void onCallSucceeded(String payload, Map<String, String> headers) {
-                        completeFutureAndSaveToLocalStorage(Utils.parseDocument(payload, documentType), result, null);
+                        completeFutureAndSaveToLocalStorage(Utils.parseDocument(payload, documentType), result);
                     }
 
                     @Override
@@ -696,9 +696,9 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
         mPendingCalls.remove(future);
     }
 
-    private synchronized <T> void completeFutureAndSaveToLocalStorage(T value, DefaultAppCenterFuture<T> future, String pendingOperationValue) {
+    private synchronized <T> void completeFutureAndSaveToLocalStorage(T value, DefaultAppCenterFuture<T> future) {
         future.complete(value);
-        mLocalDocumentStorage.write((Document)value, new WriteOptions(), pendingOperationValue);
+        mLocalDocumentStorage.write((Document)value, new WriteOptions(), null);
         mPendingCalls.remove(future);
     }
 

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/DocumentError.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/DocumentError.java
@@ -5,6 +5,8 @@
 
 package com.microsoft.appcenter.storage.models;
 
+import android.support.annotation.NonNull;
+
 /**
  * Details of the remote operation execution failures.
  */
@@ -16,7 +18,7 @@ public class DocumentError {
      * @param exception that occurred during the network state change.
      */
     @SuppressWarnings("WeakerAccess")
-    public DocumentError(Throwable exception) {
+    public DocumentError(@NonNull Throwable exception) {
         this.exception = exception;
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

1. Add @NonNull annotation to DocumentError's constructor.
2. Simplified a parameter in Storage that only used once. No functional change.
