### PR TITLE
Rename Document.getError() to .getDocumentError()

### DIFF
--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -76,7 +76,7 @@ public class LocalDocumentStorageAndroidTest {
         Document<String> deletedDocument = mLocalDocumentStorage.read(PARTITION, ID, String.class, new ReadOptions());
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
-        assertNotNull(deletedDocument.getError());
+        assertNotNull(deletedDocument.getDocumentError());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class LocalDocumentStorageAndroidTest {
         Document<String> deletedDocument = mLocalDocumentStorage.read(PARTITION, ID, String.class, new ReadOptions(1));
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
-        assertNotNull(deletedDocument.getError());
+        assertNotNull(deletedDocument.getDocumentError());
     }
 
     @Test

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/Document.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/Document.java
@@ -74,7 +74,7 @@ public class Document<T> {
      *
      * @return Document error.
      */
-    public DocumentError getError() {
+    public DocumentError getDocumentError() {
         return documentError;
     }
 
@@ -143,6 +143,6 @@ public class Document<T> {
      * @return whether the document has an error associated with it
      */
     public boolean failed() {
-        return this.getError() != null;
+        return this.getDocumentError() != null;
     }
 }

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -105,8 +105,8 @@ public class LocalDocumentStorageTest {
         assertNotNull(doc);
         assertNull(doc.getDocument());
         assertTrue(doc.failed());
-        assertEquals(DocumentError.class, doc.getError().getClass());
-        assertThat(doc.getError().getError().getMessage(), CoreMatchers.containsString(LocalDocumentStorage.FAILED_TO_READ_FROM_CACHE));
+        assertEquals(DocumentError.class, doc.getDocumentError().getClass());
+        assertThat(doc.getDocumentError().getError().getMessage(), CoreMatchers.containsString(LocalDocumentStorage.FAILED_TO_READ_FROM_CACHE));
     }
 
     @Test(expected = RuntimeException.class)
@@ -124,8 +124,8 @@ public class LocalDocumentStorageTest {
         assertNotNull(doc);
         assertNull(doc.getDocument());
         assertTrue(doc.failed());
-        assertEquals(DocumentError.class, doc.getError().getClass());
-        assertThat(doc.getError().getError().getMessage(), CoreMatchers.containsString(LocalDocumentStorage.FAILED_TO_READ_FROM_CACHE));
+        assertEquals(DocumentError.class, doc.getDocumentError().getClass());
+        assertThat(doc.getDocumentError().getError().getMessage(), CoreMatchers.containsString(LocalDocumentStorage.FAILED_TO_READ_FROM_CACHE));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class LocalDocumentStorageTest {
         when(mDatabaseManager.replace(any(ContentValues.class))).thenReturn(-1L);
         Document<String> doc = mLocalDocumentStorage.createOrUpdate(PARTITION, DOCUMENT_ID, "test", String.class, new WriteOptions());
         assertNotNull(doc);
-        assertNotNull(doc.getError().getError());
+        assertNotNull(doc.getDocumentError().getError());
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
@@ -275,7 +275,7 @@ public class StorageTest extends AbstractStorageTest {
         assertEquals(3, documents.size());
         assertEquals(firstPartDocuments.get(0).getId(), documents.get(0).getId());
         assertEquals(secondPartDocuments.get(0).getId(), documents.get(2).getId());
-        assertNotNull(iterator.next().getError());
+        assertNotNull(iterator.next().getDocumentError());
 
         /* Verify not throws exception. */
         iterator.remove();
@@ -351,7 +351,7 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(testCosmosDocument);
         assertEquals(PARTITION, testCosmosDocument.getPartition());
         assertEquals(DOCUMENT_ID, testCosmosDocument.getId());
-        assertNull(testCosmosDocument.getError());
+        assertNull(testCosmosDocument.getDocumentError());
         assertNotNull(testCosmosDocument.getEtag());
         assertNotEquals(0L, testCosmosDocument.getTimestamp());
 
@@ -376,7 +376,7 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(testCosmosDocument);
         assertEquals(PARTITION, testCosmosDocument.getPartition());
         assertEquals(DOCUMENT_ID, testCosmosDocument.getId());
-        assertNull(testCosmosDocument.getError());
+        assertNull(testCosmosDocument.getDocumentError());
         assertNotNull(testCosmosDocument.getEtag());
         assertNotEquals(0L, testCosmosDocument.getTimestamp());
 
@@ -397,9 +397,9 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(doc);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNotNull(doc.get().getError());
+        assertNotNull(doc.get().getDocumentError());
         assertThat(
-                doc.get().getError().getError().getMessage(),
+                doc.get().getDocumentError().getError().getMessage(),
                 CoreMatchers.containsString("Cosmos db exception."));
     }
 
@@ -439,9 +439,9 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(doc);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNotNull(doc.get().getError());
+        assertNotNull(doc.get().getDocumentError());
         assertThat(
-                doc.get().getError().getError().getMessage(),
+                doc.get().getDocumentError().getError().getMessage(),
                 CoreMatchers.containsString(tokenExchangeFailedResponsePayload));
     }
 
@@ -459,9 +459,9 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(doc);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNotNull(doc.get().getError());
+        assertNotNull(doc.get().getDocumentError());
         assertThat(
-                doc.get().getError().getError().getMessage(),
+                doc.get().getDocumentError().getError().getMessage(),
                 CoreMatchers.containsString(exceptionMessage));
     }
 
@@ -490,7 +490,7 @@ public class StorageTest extends AbstractStorageTest {
         verifyNoMoreInteractions(mLocalDocumentStorage);
         assertEquals(PARTITION, testCosmosDocument.getPartition());
         assertEquals(DOCUMENT_ID, testCosmosDocument.getId());
-        assertNull(testCosmosDocument.getError());
+        assertNull(testCosmosDocument.getDocumentError());
         assertNotNull(testCosmosDocument.getEtag());
         assertNotEquals(0L, testCosmosDocument.getTimestamp());
 
@@ -527,9 +527,9 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(doc);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNotNull(doc.get().getError());
+        assertNotNull(doc.get().getDocumentError());
         assertThat(
-                doc.get().getError().getError().getMessage(),
+                doc.get().getDocumentError().getError().getMessage(),
                 CoreMatchers.containsString(exceptionMessage));
     }
 
@@ -541,7 +541,7 @@ public class StorageTest extends AbstractStorageTest {
         verifyNoMoreInteractions(mLocalDocumentStorage);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNull(doc.get().getError());
+        assertNull(doc.get().getDocumentError());
     }
 
     @Test
@@ -557,9 +557,9 @@ public class StorageTest extends AbstractStorageTest {
         assertNotNull(doc);
         assertNotNull(doc.get());
         assertNull(doc.get().getDocument());
-        assertNotNull(doc.get().getError());
+        assertNotNull(doc.get().getDocumentError());
         assertThat(
-                doc.get().getError().getError().getMessage(),
+                doc.get().getDocumentError().getError().getMessage(),
                 CoreMatchers.containsString(exceptionMessage));
     }
 

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/UtilsTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/UtilsTest.java
@@ -18,7 +18,7 @@ public class UtilsTest {
     @Test
     public void canParseWhenDocumentMalformed() {
         Document<TestDocument> document = Utils.parseDocument("{}", TestDocument.class);
-        assertNotNull(document.getError());
+        assertNotNull(document.getDocumentError());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Storage android sdk’s `Document` class has a method `getError()` that returns a `DocumentError` object which itself has a method `getError()` for the inner storage exception. In order to get the inner exception, you will have to do `doc.getError().getError()`. 

This PR renames `getError()` to `getDocumentError()`.


