### PR TITLE
Move all disk read/writes to background thread

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.support.annotation.VisibleForTesting;
+import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.storage.exception.StorageException;
 import com.microsoft.appcenter.storage.models.Document;
@@ -27,6 +28,7 @@ import java.util.List;
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_CREATE_VALUE;
 
+@WorkerThread
 class LocalDocumentStorage {
 
     /**

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -7,8 +7,10 @@ package com.microsoft.appcenter.storage;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
+import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
 import com.microsoft.appcenter.channel.Channel;
@@ -82,7 +84,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
     /**
      * Current event listener.
      */
-    private DataStoreEventListener mEventListener;
+    private volatile DataStoreEventListener mEventListener;
 
     /**
      * Authorization listener for {@link AuthTokenContext}.
@@ -382,8 +384,14 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                         }
                     });
         } else {
-            Document<T> cachedDocument = mLocalDocumentStorage.read(partition, documentId, documentType, readOptions);
-            result.complete(cachedDocument);
+            postAsyncGetter(new Runnable() {
+
+                @Override
+                public void run() {
+                    Document<T> cachedDocument = mLocalDocumentStorage.read(partition, documentId, documentType, readOptions);
+                    result.complete(cachedDocument);
+                }
+            }, result, null);
         }
         return result;
     }
@@ -401,9 +409,16 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 null,
                 new ServiceCallback() {
 
+                    @MainThread
                     @Override
-                    public void onCallSucceeded(String payload, Map<String, String> headers) {
-                        completeFutureAndSaveToLocalStorage(Utils.parseDocument(payload, documentType), result);
+                    public void onCallSucceeded(final String payload, Map<String, String> headers) {
+                        post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                completeFutureAndSaveToLocalStorage(Utils.parseDocument(payload, documentType), result);
+                            }
+                        });
                     }
 
                     @Override
@@ -495,8 +510,14 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                         }
                     });
         } else {
-            Document<T> createdOrUpdatedDocument = mLocalDocumentStorage.createOrUpdate(partition, documentId, document, documentType, writeOptions);
-            result.complete(createdOrUpdatedDocument);
+            postAsyncGetter(new Runnable() {
+
+                @Override
+                public void run() {
+                    Document<T> createdOrUpdatedDocument = mLocalDocumentStorage.createOrUpdate(partition, documentId, document, documentType, writeOptions);
+                    result.complete(createdOrUpdatedDocument);
+                }
+            }, result, null);
         }
         return result;
     }
@@ -517,6 +538,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                         callCosmosDbCreateOrUpdateApi(tokenResult, pendingOperation);
                     }
 
+                    @MainThread
                     @Override
                     public void completeFuture(Exception e) {
                         notifyListenerAndUpdateOperationOnFailure(
@@ -543,11 +565,18 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 CosmosDb.getUpsertAdditionalHeader(),
                 new ServiceCallback() {
 
+                    @MainThread
                     @Override
-                    public void onCallSucceeded(String payload, Map<String, String> headers) {
-                        Document<T> cosmosDbDocument = Utils.parseDocument(payload, documentType);
-                        completeFuture(cosmosDbDocument, result);
-                        mLocalDocumentStorage.write(cosmosDbDocument, writeOptions);
+                    public void onCallSucceeded(final String payload, Map<String, String> headers) {
+                        post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                Document<T> cosmosDbDocument = Utils.parseDocument(payload, documentType);
+                                completeFuture(cosmosDbDocument, result);
+                                mLocalDocumentStorage.write(cosmosDbDocument, writeOptions);
+                            }
+                        });
                     }
 
                     @Override
@@ -570,11 +599,13 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 CosmosDb.getUpsertAdditionalHeader(),
                 new ServiceCallback() {
 
+                    @MainThread
                     @Override
                     public void onCallSucceeded(String payload, Map<String, String> headers) {
                         notifyListenerAndUpdateOperationOnSuccess(payload, pendingOperation);
                     }
 
+                    @MainThread
                     @Override
                     public void onCallFailed(Exception e) {
                         notifyListenerAndUpdateOperationOnFailure(
@@ -592,7 +623,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 new TokenExchange.TokenExchangeServiceCallback() {
 
                     @Override
-                    public void callCosmosDb(final TokenResult tokenResult) {
+                    public void callCosmosDb(TokenResult tokenResult) {
                         callCosmosDbDeleteApi(tokenResult, documentId, result);
                     }
 
@@ -615,6 +646,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                         callCosmosDbDeleteApi(tokenResult, pendingOperation);
                     }
 
+                    @MainThread
                     @Override
                     public void completeFuture(Exception e) {
                         notifyListenerAndUpdateOperationOnFailure(
@@ -633,10 +665,17 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 null,
                 new ServiceCallback() {
 
+                    @MainThread
                     @Override
                     public void onCallSucceeded(String payload, Map<String, String> headers) {
-                        completeFuture(new Document<Void>(), result);
-                        mLocalDocumentStorage.delete(tokenResult.partition(), documentId);
+                        post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                completeFuture(new Document<Void>(), result);
+                                mLocalDocumentStorage.delete(tokenResult.partition(), documentId);
+                            }
+                        });
                     }
 
                     @Override
@@ -656,11 +695,13 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
                 null,
                 new ServiceCallback() {
 
+                    @MainThread
                     @Override
                     public void onCallSucceeded(String payload, Map<String, String> headers) {
                         notifyListenerAndUpdateOperationOnSuccess(payload, pendingOperation);
                     }
 
+                    @MainThread
                     @Override
                     public void onCallFailed(Exception e) {
                         notifyListenerAndUpdateOperationOnFailure(
@@ -696,6 +737,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
         mPendingCalls.remove(future);
     }
 
+    @WorkerThread
     private synchronized <T> void completeFutureAndSaveToLocalStorage(T value, DefaultAppCenterFuture<T> future) {
         future.complete(value);
         mLocalDocumentStorage.write((Document) value, new WriteOptions(), null);
@@ -714,47 +756,61 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
         mPendingCalls.remove(future);
     }
 
-    private synchronized void notifyListenerAndUpdateOperationOnSuccess(String cosmosDbResponsePayload, PendingOperation pendingOperation) {
-        String etag = Utils.getEtag(cosmosDbResponsePayload);
-        pendingOperation.setEtag(etag);
-        pendingOperation.setDocument(cosmosDbResponsePayload);
-        if (mEventListener != null) {
-            mEventListener.onDataStoreOperationResult(
-                    pendingOperation.getOperation(),
-                    new DocumentMetadata(
-                            pendingOperation.getPartition(),
-                            pendingOperation.getDocumentId(),
-                            etag),
-                    null);
-        }
-        mLocalDocumentStorage.updateLocalCopy(pendingOperation);
+    private void notifyListenerAndUpdateOperationOnSuccess(final String cosmosDbResponsePayload, final PendingOperation pendingOperation) {
+        post(new Runnable() {
+
+            @Override
+            public void run() {
+                String etag = Utils.getEtag(cosmosDbResponsePayload);
+                pendingOperation.setEtag(etag);
+                pendingOperation.setDocument(cosmosDbResponsePayload);
+                DataStoreEventListener eventListener = mEventListener;
+                if (eventListener != null) {
+                    eventListener.onDataStoreOperationResult(
+                            pendingOperation.getOperation(),
+                            new DocumentMetadata(
+                                    pendingOperation.getPartition(),
+                                    pendingOperation.getDocumentId(),
+                                    etag),
+                            null);
+                }
+                mLocalDocumentStorage.updateLocalCopy(pendingOperation);
+            }
+        });
     }
 
-    private synchronized void notifyListenerAndUpdateOperationOnFailure(StorageException e, PendingOperation pendingOperation) {
-        AppCenterLog.error(LOG_TAG, "Remote operation failed", e);
-        boolean deleteLocalCopy = false;
-        if (e.getCause() instanceof HttpException) {
-            switch (((HttpException) e.getCause()).getStatusCode()) {
+    private void notifyListenerAndUpdateOperationOnFailure(final StorageException e, final PendingOperation pendingOperation) {
+        post(new Runnable() {
 
-                /* The document was removed on the server. */
-                case 404:
-                case 409:
+            @Override
+            public void run() {
+                AppCenterLog.error(LOG_TAG, "Remote operation failed", e);
+                boolean deleteLocalCopy = false;
+                if (e.getCause() instanceof HttpException) {
+                    switch (((HttpException) e.getCause()).getStatusCode()) {
 
-                    /* Partition and document_id combination is already present in the DB. */
-                    deleteLocalCopy = true;
-                    break;
+                        /* The document was removed on the server. */
+                        case 404:
+                        case 409:
+
+                            /* Partition and document_id combination is already present in the DB. */
+                            deleteLocalCopy = true;
+                            break;
+                    }
+                }
+                DataStoreEventListener eventListener = mEventListener;
+                if (eventListener != null) {
+                    eventListener.onDataStoreOperationResult(
+                            pendingOperation.getOperation(),
+                            null,
+                            new DocumentError(e));
+                }
+                if (deleteLocalCopy) {
+                    mLocalDocumentStorage.delete(pendingOperation);
+                } else {
+                    mLocalDocumentStorage.updateLocalCopy(pendingOperation);
+                }
             }
-        }
-        if (mEventListener != null) {
-            mEventListener.onDataStoreOperationResult(
-                    pendingOperation.getOperation(),
-                    null,
-                    new DocumentError(e));
-        }
-        if (deleteLocalCopy) {
-            mLocalDocumentStorage.delete(pendingOperation);
-        } else {
-            mLocalDocumentStorage.updateLocalCopy(pendingOperation);
-        }
+        });
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Move all disk read/writes to background threads to avoid strict mode errors.
Every other module already does that.