### PR TITLE
Use access token if ID token is null

### DIFF
--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
@@ -581,7 +581,17 @@ public class Identity extends AbstractAppCenterService {
                 IAccount account = authenticationResult.getAccount();
                 String homeAccountId = account.getHomeAccountIdentifier().getIdentifier();
                 Date expiresOn = authenticationResult.getExpiresOn();
-                AuthTokenContext.getInstance().setAuthToken(authenticationResult.getIdToken(), homeAccountId, expiresOn);
+                String token = authenticationResult.getIdToken();
+                if (token == null) {
+
+                    /*
+                     * Fallback to using an access token, as MSAL sometimes return null for this.
+                     * access token is @NonNull.
+                     */
+                    AppCenterLog.warn(LOG_TAG, "Sign-in result does not contain ID token, using access token.");
+                    token = authenticationResult.getAccessToken();
+                }
+                AuthTokenContext.getInstance().setAuthToken(token, homeAccountId, expiresOn);
                 String accountId = account.getAccountIdentifier().getIdentifier();
                 AppCenterLog.info(LOG_TAG, "User sign-in succeeded.");
                 completeSignIn(new UserInformation(accountId), null);
@@ -589,7 +599,7 @@ public class Identity extends AbstractAppCenterService {
         });
     }
 
-    private void handleSignInError(final MsalException exception) {
+    private void handleSignInError(final Exception exception) {
         post(new Runnable() {
 
             @Override

--- a/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
+++ b/sdk/appcenter-identity/src/main/java/com/microsoft/appcenter/identity/Identity.java
@@ -599,7 +599,7 @@ public class Identity extends AbstractAppCenterService {
         });
     }
 
-    private void handleSignInError(final Exception exception) {
+    private void handleSignInError(final MsalException exception) {
         post(new Runnable() {
 
             @Override

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/AbstractIdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/AbstractIdentityTest.java
@@ -30,6 +30,8 @@ import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 
+import java.util.Date;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -129,6 +131,7 @@ abstract public class AbstractIdentityTest {
         when(accountIdentifier.getIdentifier()).thenReturn(accountId);
         when(account.getAccountIdentifier()).thenReturn(accountIdentifier);
         when(mockResult.getAccount()).thenReturn(account);
+        when(mockResult.getExpiresOn()).thenReturn(new Date());
         return mockResult;
     }
 }

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -286,7 +286,7 @@ public class IdentityTest extends AbstractIdentityTest {
         verifyStatic();
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void signInThenDownloadValidConfigurationThenForegroundThenSilentSignIn() throws Exception {
 
         /* Mock JSON. */
@@ -328,6 +328,13 @@ public class IdentityTest extends AbstractIdentityTest {
 
         /* Sign in. */
         AppCenterFuture<SignInResult> future = Identity.signIn();
+
+        /* Simulate success. */
+        ArgumentCaptor<AuthenticationCallback> callbackCaptor = ArgumentCaptor.forClass(AuthenticationCallback.class);
+        verify(publicClientApplication).acquireTokenSilentAsync(any(String[].class), notNull(IAccount.class), isNull(String.class), eq(true), callbackCaptor.capture());
+        callbackCaptor.getValue().onSuccess(mockAuthResult(mockIdToken, mockAccountId, mockHomeAccountId));
+
+        /* Verify. */
         assertNotNull(future);
         assertNotNull(future.get());
         assertNull(future.get().getException());

--- a/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
+++ b/sdk/appcenter-identity/src/test/java/com/microsoft/appcenter/identity/IdentityTest.java
@@ -286,7 +286,7 @@ public class IdentityTest extends AbstractIdentityTest {
         verifyStatic();
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void signInThenDownloadValidConfigurationThenForegroundThenSilentSignIn() throws Exception {
 
         /* Mock JSON. */


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Work around for null ID token returned from MSAL.
Since they mark it as `@Nullable` we have to use the `@NonNull` access token as a fallback.

[AB#59718](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=59718)