### PR TITLE
Fix incorrect writeOptions apply

### DIFF
--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -187,4 +187,12 @@ public class LocalDocumentStorageAndroidTest {
         assertEquals(Constants.PENDING_OPERATION_REPLACE_VALUE, operation.getOperation());
         assertTrue(operation.getDocument().contains("Test2"));
     }
+
+    @Test
+    public void createUnExpiredDocument() {
+        mLocalDocumentStorage.createOrUpdateOffline(PARTITION, ID, "Test", String.class, new WriteOptions(WriteOptions.INFINITE));
+        Document<String> document = mLocalDocumentStorage.read(PARTITION, ID, String.class, null);
+        assertNull(document.getDocumentError());
+        assertEquals("Test", document.getDocument());
+    }
 }

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/ReadOptions.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/ReadOptions.java
@@ -30,6 +30,9 @@ public class ReadOptions extends BaseOptions {
      * @return whether a document is expired.
      */
     public static boolean isExpired(long expiredAt) {
+        if (expiredAt == BaseOptions.INFINITE) {
+            return false;
+        }
         return Calendar.getInstance().getTimeInMillis() >= expiredAt;
     }
 }

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -182,7 +182,8 @@ public class LocalDocumentStorageTest {
 
     @Test
     public void optionsExpirationTest() {
-        ReadOptions readOptions = new ReadOptions(1);
-        assertTrue(ReadOptions.isExpired(-1));
+        ReadOptions readOptions = new ReadOptions(2);
+        assertTrue(ReadOptions.isExpired(1));
+        assertFalse(ReadOptions.isExpired(-1));
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix the writeOptions bug, that did not honor the infinite options, and do not update when nocache

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
