### PR TITLE
Purge token cache on user logout

### DIFF
--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -40,7 +39,7 @@ public class LocalDocumentStorageAndroidTest {
 
     private static final String ID = "id";
 
-    private static final long NOW = Calendar.getInstance().getTimeInMillis();
+    private static final long NOW = System.currentTimeMillis();
 
     private static final String USER_TABLE_NAME = Utils.getUserTableName("123");
 

--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -40,7 +40,11 @@ public class LocalDocumentStorageAndroidTest {
 
     private static final String ID = "id";
 
-    private static final long mNow = Calendar.getInstance().getTimeInMillis();
+    private static final long NOW = Calendar.getInstance().getTimeInMillis();
+
+    private static final String USER_TABLE_NAME = Utils.getUserTableName("123");
+
+    private static final String READ_ONLY_TABLE_NAME = Utils.getTableName(Constants.READONLY, "123");
 
     /**
      * Context instance.
@@ -49,10 +53,6 @@ public class LocalDocumentStorageAndroidTest {
     private static Context sContext;
 
     private LocalDocumentStorage mLocalDocumentStorage;
-
-    private static String sUserTableName = Utils.getUserTableName("123");
-
-    private static String sReadOnlyTableName = Utils.getTableName(Constants.READONLY, "123");
 
     @BeforeClass
     public static void setUpClass() {
@@ -64,7 +64,7 @@ public class LocalDocumentStorageAndroidTest {
         SharedPreferencesManager.initialize(sContext);
         AuthTokenContext.initialize(sContext);
         AuthTokenContext.getInstance().setAuthToken(UUIDUtils.randomUUID().toString(), UUIDUtils.randomUUID().toString(), new Date());
-        mLocalDocumentStorage = new LocalDocumentStorage(sContext, sUserTableName);
+        mLocalDocumentStorage = new LocalDocumentStorage(sContext, USER_TABLE_NAME);
     }
 
     @After
@@ -77,15 +77,15 @@ public class LocalDocumentStorageAndroidTest {
     @Test
     public void writeReadDelete() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOnline(sUserTableName, document, new WriteOptions());
-        Document<String> cachedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions());
+        Document<String> cachedDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(cachedDocument);
         assertEquals(document.getDocument(), cachedDocument.getDocument());
         assertFalse(document.failed());
         assertFalse(document.isFromCache());
         assertTrue(cachedDocument.isFromCache());
-        mLocalDocumentStorage.deleteOnline(sUserTableName, Constants.READONLY, ID);
-        Document<String> deletedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.deleteOnline(USER_TABLE_NAME, Constants.READONLY, ID);
+        Document<String> deletedDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
         assertNotNull(deletedDocument.getDocumentError());
@@ -96,7 +96,7 @@ public class LocalDocumentStorageAndroidTest {
 
         /* Write a document and mock device ttl to be already expired a few seconds ago. */
         Document<String> document = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOnline(sUserTableName, document, new WriteOptions() {
+        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions() {
 
             @Override
             public int getDeviceTimeToLive() {
@@ -105,7 +105,7 @@ public class LocalDocumentStorageAndroidTest {
         });
 
         /* Read with a TTL of 1 second: already expired. */
-        Document<String> deletedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions(1));
+        Document<String> deletedDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions(1));
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
         assertNotNull(deletedDocument.getDocumentError());
@@ -114,7 +114,7 @@ public class LocalDocumentStorageAndroidTest {
     @Test
     public void updateLocalCopyDeletesExpiredOperation() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
-        mLocalDocumentStorage.writeOffline(sUserTableName, document, new WriteOptions() {
+        mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, document, new WriteOptions() {
 
             @Override
             public int getDeviceTimeToLive() {
@@ -122,33 +122,33 @@ public class LocalDocumentStorageAndroidTest {
             }
         });
 
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
 
         mLocalDocumentStorage.updatePendingOperation(operations.get(0));
 
-        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(0, operations.size());
     }
 
     @Test
     public void updateLocalCopyReplacesNotExpiredOperation() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
-        mLocalDocumentStorage.writeOffline(sUserTableName, document, new WriteOptions(10));
+        mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, document, new WriteOptions(10));
 
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
 
         mLocalDocumentStorage.updatePendingOperation(operations.get(0));
 
-        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
     }
 
     @Test
     public void createDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
-        Document<String> createdDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
+        Document<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(createdDocument);
         assertEquals("Test", createdDocument.getDocument());
     }
@@ -156,13 +156,13 @@ public class LocalDocumentStorageAndroidTest {
     @Test
     public void resetDatabase() {
         /* Create a user table and app table (readonly), and add a document to each. */
-        mLocalDocumentStorage.createTableIfDoesNotExist(sUserTableName);
+        mLocalDocumentStorage.createTableIfDoesNotExist(USER_TABLE_NAME);
         Document<String> userDocument = new Document<>(TEST_VALUE, Constants.USER, ID);
         Document<String> appDocument = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOffline(sUserTableName, userDocument, new WriteOptions());
-        mLocalDocumentStorage.writeOffline(sReadOnlyTableName, appDocument, new WriteOptions());
-        Document<String> cachedUserDocument = mLocalDocumentStorage.read(sUserTableName, Constants.USER, ID, String.class, new ReadOptions());
-        Document<String> cachedAppDocument = mLocalDocumentStorage.read(sReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, userDocument, new WriteOptions());
+        mLocalDocumentStorage.writeOffline(READ_ONLY_TABLE_NAME, appDocument, new WriteOptions());
+        Document<String> cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, new ReadOptions());
+        Document<String> cachedAppDocument = mLocalDocumentStorage.read(READ_ONLY_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
 
         /* Verify to documents were added to the tables and there were no errors. */
         assertNotNull(cachedUserDocument);
@@ -174,8 +174,8 @@ public class LocalDocumentStorageAndroidTest {
 
         /* Reset the database. */
         mLocalDocumentStorage.resetDatabase();
-        cachedUserDocument = mLocalDocumentStorage.read(sUserTableName, Constants.USER, ID, String.class, new ReadOptions());
-        cachedAppDocument = mLocalDocumentStorage.read(sReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, new ReadOptions());
+        cachedAppDocument = mLocalDocumentStorage.read(READ_ONLY_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
 
         /* Verify that reading the documents gives an error and their contents are null. */
         assertNotNull(cachedUserDocument);
@@ -190,32 +190,32 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void updateDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test1", String.class, new WriteOptions());
-        Document<String> createdDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.READONLY, ID, "Test1", String.class, new WriteOptions());
+        Document<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(createdDocument);
         assertEquals("Test1", createdDocument.getDocument());
     }
 
     @Test
     public void deleteOfflineAddsOnePendingOperation() {
-        mLocalDocumentStorage.markForDeletion(sUserTableName, Constants.USER, ID);
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        mLocalDocumentStorage.markForDeletion(USER_TABLE_NAME, Constants.USER, ID);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
     }
 
     @Test
     public void createAndDeleteOffline() {
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(0, operations.size());
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
-        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
-        boolean updated = mLocalDocumentStorage.markForDeletion(sUserTableName, Constants.USER, ID);
+        boolean updated = mLocalDocumentStorage.markForDeletion(USER_TABLE_NAME, Constants.USER, ID);
         assertTrue(updated);
-        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_DELETE_VALUE, operation.getOperation());
@@ -223,14 +223,14 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void createAndUpdateOffline() {
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
         assertTrue(operation.getDocument().contains("Test"));
-        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test2", String.class, new WriteOptions());
-        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test2", String.class, new WriteOptions());
+        operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_REPLACE_VALUE, operation.getOperation());
@@ -239,16 +239,16 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void createUnExpiredDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions(WriteOptions.INFINITE));
-        Document<String> document = mLocalDocumentStorage.read(mUserTableName, Constants.USER, ID, String.class, null);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions(WriteOptions.INFINITE));
+        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, null);
         assertNull(document.getDocumentError());
         assertEquals("Test", document.getDocument());
     }
 
     @Test
     public void createDocumentWithoutOverflowException() {
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions(999999999));
-        Document<String> document = mLocalDocumentStorage.read(mUserTableName, Constants.USER, ID, String.class, null);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions(999999999));
+        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, null);
         assertNull(document.getDocumentError());
         assertEquals("Test", document.getDocument());
     }

--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -155,6 +155,7 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void resetDatabase() {
+        
         /* Create a user table and app table (readonly), and add a document to each. */
         mLocalDocumentStorage.createTableIfDoesNotExist(USER_TABLE_NAME);
         Document<String> userDocument = new Document<>(TEST_VALUE, Constants.USER, ID);

--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -50,8 +50,9 @@ public class LocalDocumentStorageAndroidTest {
 
     private LocalDocumentStorage mLocalDocumentStorage;
 
-    private static String mUserTableName = Utils.getUserTableName("123");
-    private static String mReadOnlyTableName = Utils.getTableName(Constants.READONLY, "123");
+    private static String sUserTableName = Utils.getUserTableName("123");
+
+    private static String sReadOnlyTableName = Utils.getTableName(Constants.READONLY, "123");
 
     @BeforeClass
     public static void setUpClass() {
@@ -63,7 +64,7 @@ public class LocalDocumentStorageAndroidTest {
         SharedPreferencesManager.initialize(sContext);
         AuthTokenContext.initialize(sContext);
         AuthTokenContext.getInstance().setAuthToken(UUIDUtils.randomUUID().toString(), UUIDUtils.randomUUID().toString(), new Date());
-        mLocalDocumentStorage = new LocalDocumentStorage(sContext, mUserTableName);
+        mLocalDocumentStorage = new LocalDocumentStorage(sContext, sUserTableName);
     }
 
     @After
@@ -76,15 +77,15 @@ public class LocalDocumentStorageAndroidTest {
     @Test
     public void writeReadDelete() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOnline(mUserTableName, document, new WriteOptions());
-        Document<String> cachedDocument = mLocalDocumentStorage.read(mUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.writeOnline(sUserTableName, document, new WriteOptions());
+        Document<String> cachedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(cachedDocument);
         assertEquals(document.getDocument(), cachedDocument.getDocument());
         assertFalse(document.failed());
         assertFalse(document.isFromCache());
         assertTrue(cachedDocument.isFromCache());
-        mLocalDocumentStorage.deleteOnline(mUserTableName, Constants.READONLY, ID);
-        Document<String> deletedDocument = mLocalDocumentStorage.read(mUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.deleteOnline(sUserTableName, Constants.READONLY, ID);
+        Document<String> deletedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
         assertNotNull(deletedDocument.getDocumentError());
@@ -95,7 +96,7 @@ public class LocalDocumentStorageAndroidTest {
 
         /* Write a document and mock device ttl to be already expired a few seconds ago. */
         Document<String> document = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOnline(mUserTableName, document, new WriteOptions() {
+        mLocalDocumentStorage.writeOnline(sUserTableName, document, new WriteOptions() {
 
             @Override
             public int getDeviceTimeToLive() {
@@ -104,7 +105,7 @@ public class LocalDocumentStorageAndroidTest {
         });
 
         /* Read with a TTL of 1 second: already expired. */
-        Document<String> deletedDocument = mLocalDocumentStorage.read(mUserTableName, Constants.READONLY, ID, String.class, new ReadOptions(1));
+        Document<String> deletedDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions(1));
         assertNotNull(deletedDocument);
         assertNull(deletedDocument.getDocument());
         assertNotNull(deletedDocument.getDocumentError());
@@ -113,7 +114,7 @@ public class LocalDocumentStorageAndroidTest {
     @Test
     public void updateLocalCopyDeletesExpiredOperation() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
-        mLocalDocumentStorage.writeOffline(mUserTableName, document, new WriteOptions() {
+        mLocalDocumentStorage.writeOffline(sUserTableName, document, new WriteOptions() {
 
             @Override
             public int getDeviceTimeToLive() {
@@ -121,55 +122,62 @@ public class LocalDocumentStorageAndroidTest {
             }
         });
 
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
 
         mLocalDocumentStorage.updatePendingOperation(operations.get(0));
 
-        operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(0, operations.size());
     }
 
     @Test
     public void updateLocalCopyReplacesNotExpiredOperation() {
         Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
-        mLocalDocumentStorage.writeOffline(mUserTableName, document, new WriteOptions(10));
+        mLocalDocumentStorage.writeOffline(sUserTableName, document, new WriteOptions(10));
 
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
 
         mLocalDocumentStorage.updatePendingOperation(operations.get(0));
 
-        operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
     }
 
     @Test
     public void createDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
-        Document<String> createdDocument = mLocalDocumentStorage.read(mUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
+        Document<String> createdDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(createdDocument);
         assertEquals("Test", createdDocument.getDocument());
     }
 
     @Test
     public void resetDatabase() {
-        mLocalDocumentStorage.createTableIfDoesNotExist(mUserTableName);
+        /* Create a user table and app table (readonly), and add a document to each. */
+        mLocalDocumentStorage.createTableIfDoesNotExist(sUserTableName);
         Document<String> userDocument = new Document<>(TEST_VALUE, Constants.USER, ID);
         Document<String> appDocument = new Document<>(TEST_VALUE, Constants.READONLY, ID);
-        mLocalDocumentStorage.writeOffline(mUserTableName, userDocument, new WriteOptions());
-        mLocalDocumentStorage.writeOffline(mReadOnlyTableName, appDocument, new WriteOptions());
-        Document<String> cachedUserDocument = mLocalDocumentStorage.read(mUserTableName, Constants.USER, ID, String.class, new ReadOptions());
-        Document<String> cachedAppDocument = mLocalDocumentStorage.read(mReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.writeOffline(sUserTableName, userDocument, new WriteOptions());
+        mLocalDocumentStorage.writeOffline(sReadOnlyTableName, appDocument, new WriteOptions());
+        Document<String> cachedUserDocument = mLocalDocumentStorage.read(sUserTableName, Constants.USER, ID, String.class, new ReadOptions());
+        Document<String> cachedAppDocument = mLocalDocumentStorage.read(sReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+
+        /* Verify to documents were added to the tables and there were no errors. */
         assertNotNull(cachedUserDocument);
         assertNotNull(cachedAppDocument);
         assertNull(cachedUserDocument.getDocumentError());
         assertNull(cachedAppDocument.getDocumentError());
         assertNotNull(cachedUserDocument.getDocument());
         assertNotNull(cachedAppDocument.getDocument());
+
+        /* Reset the database. */
         mLocalDocumentStorage.resetDatabase();
-        cachedUserDocument = mLocalDocumentStorage.read(mUserTableName, Constants.USER, ID, String.class, new ReadOptions());
-        cachedAppDocument = mLocalDocumentStorage.read(mReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        cachedUserDocument = mLocalDocumentStorage.read(sUserTableName, Constants.USER, ID, String.class, new ReadOptions());
+        cachedAppDocument = mLocalDocumentStorage.read(sReadOnlyTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+
+        /* Verify that reading the documents gives an error and their contents are null. */
         assertNotNull(cachedUserDocument);
         assertNotNull(cachedAppDocument);
         assertNotNull(cachedUserDocument.getDocumentError());
@@ -182,32 +190,32 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void updateDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.READONLY, ID, "Test1", String.class, new WriteOptions());
-        Document<String> createdDocument = mLocalDocumentStorage.read(mUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test", String.class, new WriteOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.READONLY, ID, "Test1", String.class, new WriteOptions());
+        Document<String> createdDocument = mLocalDocumentStorage.read(sUserTableName, Constants.READONLY, ID, String.class, new ReadOptions());
         assertNotNull(createdDocument);
         assertEquals("Test1", createdDocument.getDocument());
     }
 
     @Test
     public void deleteOfflineAddsOnePendingOperation() {
-        mLocalDocumentStorage.markForDeletion(mUserTableName, Constants.USER, ID);
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        mLocalDocumentStorage.markForDeletion(sUserTableName, Constants.USER, ID);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
     }
 
     @Test
     public void createAndDeleteOffline() {
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(0, operations.size());
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
-        operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
-        boolean updated = mLocalDocumentStorage.markForDeletion(mUserTableName, Constants.USER, ID);
+        boolean updated = mLocalDocumentStorage.markForDeletion(sUserTableName, Constants.USER, ID);
         assertTrue(updated);
-        operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
         operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_DELETE_VALUE, operation.getOperation());
@@ -215,14 +223,14 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void createAndUpdateOffline() {
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
-        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
         assertTrue(operation.getDocument().contains("Test"));
-        mLocalDocumentStorage.createOrUpdateOffline(mUserTableName, Constants.USER, ID, "Test2", String.class, new WriteOptions());
-        operations = mLocalDocumentStorage.getPendingOperations(mUserTableName);
+        mLocalDocumentStorage.createOrUpdateOffline(sUserTableName, Constants.USER, ID, "Test2", String.class, new WriteOptions());
+        operations = mLocalDocumentStorage.getPendingOperations(sUserTableName);
         assertEquals(1, operations.size());
         operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_REPLACE_VALUE, operation.getOperation());

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
@@ -115,6 +115,13 @@ class LocalDocumentStorage {
         mDatabaseManager.createTable(userTable, SCHEMA);
     }
 
+    /**
+     * Delete the database and create a new, empty one.
+     */
+    void resetDatabase() {
+        mDatabaseManager.resetDatabase();
+    }
+
     <T> void writeOffline(String table, Document<T> document, WriteOptions writeOptions) {
         write(table, document, writeOptions, PENDING_OPERATION_CREATE_VALUE);
     }

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -254,6 +254,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
             public void onNewUser(UserInformation userInfo) {
                 if (userInfo == null) {
                     TokenManager.getInstance().removeAllCachedTokens();
+                    mLocalDocumentStorage.resetDatabase();
                 } else {
                     String userTable = Utils.getUserTableName(userInfo.getAccountId());
                     mLocalDocumentStorage.createTableIfDoesNotExist(userTable);

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -256,7 +256,7 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
             @Override
             public void onNewUser(UserInformation userInfo) {
                 if (userInfo == null) {
-                    TokenManager.getInstance().removeAllCachedTokens();
+                    mTokenManager.removeAllCachedTokens();
                     mLocalDocumentStorage.resetDatabase();
                 } else {
                     String userTable = Utils.getUserTableName(userInfo.getAccountId());

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
@@ -20,7 +20,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -49,9 +48,9 @@ public class AuthTokenTests extends AbstractStorageTest {
         AuthTokenContext.getInstance().setAuthToken(null, null, null);
 
         /* Verify. */
-        verify(mTokenManager).removeAllCachedTokens();
+        verify(mLocalDocumentStorage).resetDatabase();
         verify(mLocalDocumentStorage, never()).createTableIfDoesNotExist(anyString());
-        SharedPreferencesManager.remove(matches("partitionName [0-9]"));
+        verify(mTokenManager).removeAllCachedTokens();
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
@@ -51,16 +51,11 @@ public class AuthTokenTests extends AbstractStorageTest {
         when(SharedPreferencesManager.getStringSet(eq(PREFERENCE_PARTITION_NAMES))).thenReturn(partitionNames);
         Storage.setEnabled(true);
         AuthTokenContext.getInstance().setAuthToken(null, null, null);
-<<<<<<< HEAD
 
         /* Verify. */
         verify(mLocalDocumentStorage).resetDatabase();
         verify(mLocalDocumentStorage, never()).createTableIfDoesNotExist(anyString());
         verify(mTokenManager).removeAllCachedTokens();
-=======
-        verifyStatic(times((10)));
-        SharedPreferencesManager.remove(matches(PREFERENCE_PARTITION_PREFIX + "partitionName [0-9]"));
->>>>>>> develop
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
@@ -19,9 +19,7 @@ import java.util.Set;
 
 import static com.microsoft.appcenter.storage.Constants.PREFERENCE_PARTITION_NAMES;
 import static com.microsoft.appcenter.storage.Constants.PREFERENCE_PARTITION_PREFIX;
-
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.never;
@@ -31,31 +29,29 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-@PrepareForTest({TokenManager.class})
+@PrepareForTest(TokenManager.class)
 public class AuthTokenTests extends AbstractStorageTest {
 
     @Test
     public void tokenClearedOnSignOut() {
 
-        /* Setup token manager. */
-        mockStatic(TokenManager.class);
-        TokenManager mTokenManager = mock(TokenManager.class);
-        when(TokenManager.getInstance()).thenReturn(mTokenManager);
-
         /* Add partitions. */
         Set<String> partitionNames = new HashSet<>();
         for (int i = 0; i < 10; i++) {
-            partitionNames.add("partitionName " + i);
+            partitionNames.add("partitionName" + i);
         }
         partitionNames.add(Constants.READONLY);
-        when(SharedPreferencesManager.getStringSet(eq(PREFERENCE_PARTITION_NAMES))).thenReturn(partitionNames);
+        when(SharedPreferencesManager.getStringSet(PREFERENCE_PARTITION_NAMES)).thenReturn(partitionNames);
         Storage.setEnabled(true);
         AuthTokenContext.getInstance().setAuthToken(null, null, null);
 
         /* Verify. */
         verify(mLocalDocumentStorage).resetDatabase();
         verify(mLocalDocumentStorage, never()).createTableIfDoesNotExist(anyString());
-        verify(mTokenManager).removeAllCachedTokens();
+        for (int i = 0; i < 10; i++) {
+            verifyStatic();
+            SharedPreferencesManager.remove(PREFERENCE_PARTITION_PREFIX + "partitionName" + i);
+        }
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AuthTokenTests.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.microsoft.appcenter.storage.Constants.PARTITION_NAMES;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,13 @@ public class AuthTokenTests extends AbstractStorageTest {
 
     @Test
     public void tokenClearedOnSignOut() {
+
+        /* Setup token manager. */
+        mockStatic(TokenManager.class);
+        TokenManager mTokenManager = mock(TokenManager.class);
+        when(TokenManager.getInstance()).thenReturn(mTokenManager);
+
+        /* Add partitions. */
         Set<String> partitionNames = new HashSet<>();
         for (int i = 0; i < 10; i++) {
             partitionNames.add("partitionName " + i);
@@ -39,7 +47,10 @@ public class AuthTokenTests extends AbstractStorageTest {
         when(SharedPreferencesManager.getStringSet(eq(PARTITION_NAMES))).thenReturn(partitionNames);
         Storage.setEnabled(true);
         AuthTokenContext.getInstance().setAuthToken(null, null, null);
-        verifyStatic(times((10)));
+
+        /* Verify. */
+        verify(mTokenManager).removeAllCachedTokens();
+        verify(mLocalDocumentStorage, never()).createTableIfDoesNotExist(anyString());
         SharedPreferencesManager.remove(matches("partitionName [0-9]"));
     }
 
@@ -75,6 +86,7 @@ public class AuthTokenTests extends AbstractStorageTest {
         AuthTokenContext.getInstance().setAuthToken("mock-token", "mock-user", new Date(Long.MAX_VALUE));
 
         /* Verify. */
-        verify(mTokenManager, times(0)).removeAllCachedTokens();
+        verify(mTokenManager, never()).removeAllCachedTokens();
+        verify(mLocalDocumentStorage).createTableIfDoesNotExist(anyString());
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -17,6 +17,7 @@ import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.telecom.Call;
 import android.text.TextUtils;
 
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -153,6 +154,18 @@ public class DatabaseManager implements Closeable {
 
     private void dropTable(@NonNull SQLiteDatabase db, @NonNull String table) {
         db.execSQL(String.format("DROP TABLE `%s`", table));
+    }
+
+    /**
+     * Delete the database and then create a new, empty one.
+     */
+    public void resetDatabase() {
+        close();
+        mContext.deleteDatabase(mDatabase);
+
+
+        /* Call getDatabase to recreate database. */
+        getDatabase();
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -163,7 +163,6 @@ public class DatabaseManager implements Closeable {
         close();
         mContext.deleteDatabase(mDatabase);
 
-
         /* Call getDatabase to recreate database. */
         getDatabase();
     }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?

## Description

Delete the local cache for document storage when a user logs out, and then recreate a new, empty database.

## Misc

[AB#59537](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=59537)