### PR TITLE
Rename constant RETRY_AFTER_MS_KEY to X_MS_RETRY_AFTER_MS_HEADER

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClient.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClient.java
@@ -39,9 +39,9 @@ public class DefaultHttpClient implements HttpClient, DefaultHttpClientCallTask.
     public static final String METHOD_DELETE = "DELETE";
 
     /**
-     * Retry after milliseconds duration header key.
+     * Retry after milliseconds duration header.
      */
-    static final String RETRY_AFTER_MS_KEY = "x-ms-retry-after-ms";
+    static final String X_MS_RETRY_AFTER_MS_HEADER = "x-ms-retry-after-ms";
 
     /**
      * Content type header key.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.microsoft.appcenter.http.DefaultHttpClient.RETRY_AFTER_MS_KEY;
+import static com.microsoft.appcenter.http.DefaultHttpClient.X_MS_RETRY_AFTER_MS_HEADER;
 
 /**
  * Decorator managing retries.
@@ -100,7 +100,7 @@ public class HttpClientRetryer extends HttpClientDecorator {
                 long delay = 0;
                 if (e instanceof HttpException) {
                     HttpException httpException = (HttpException) e;
-                    String retryAfterMs = httpException.getHeaders().get(RETRY_AFTER_MS_KEY);
+                    String retryAfterMs = httpException.getHeaders().get(X_MS_RETRY_AFTER_MS_HEADER);
                     if (retryAfterMs != null) {
                         delay = Long.parseLong(retryAfterMs);
                     }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientRetryerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/HttpClientRetryerTest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import static com.microsoft.appcenter.http.DefaultHttpClient.CONTENT_TYPE_KEY;
 import static com.microsoft.appcenter.http.DefaultHttpClient.CONTENT_TYPE_VALUE;
-import static com.microsoft.appcenter.http.DefaultHttpClient.RETRY_AFTER_MS_KEY;
+import static com.microsoft.appcenter.http.DefaultHttpClient.X_MS_RETRY_AFTER_MS_HEADER;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
@@ -181,7 +181,7 @@ public class HttpClientRetryerTest {
         long retryAfterMS = 1234;
         Map<String, String> responseHeader = new HashMap<>();
         responseHeader.put(CONTENT_TYPE_KEY, CONTENT_TYPE_VALUE);
-        responseHeader.put(RETRY_AFTER_MS_KEY, Long.toString(retryAfterMS));
+        responseHeader.put(X_MS_RETRY_AFTER_MS_HEADER, Long.toString(retryAfterMS));
         final HttpException expectedException = new HttpException(429, "call hit the retry limit", responseHeader);
 
         final ServiceCallback callback = mock(ServiceCallback.class);


### PR DESCRIPTION


<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

DefaultHttpClient has a constant `RETRY_AFTER_MS_KEY` for `"x-ms-retry-after-ms"` http header. The naming is confusing as `KEY` suffix seems to be referring to key-value pair data structure which stores the headers, which shouldn't be part of the constant name.