### PR TITLE
Change default device time-to-live from 1 hour to 1 day

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/BaseOptions.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/BaseOptions.java
@@ -18,14 +18,14 @@ public abstract class BaseOptions {
     public static final int NO_CACHE = 0;
 
     /**
-     * Default caching value of one hour.
+     * Default caching value of one day.
      */
-    public static final int DEFAULT_ONE_HOUR = 60 * 60;
+    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24;
 
     private int mTtl;
 
     BaseOptions() {
-        this(DEFAULT_ONE_HOUR);
+        this(DEFAULT_EXPIRATION);
     }
 
     BaseOptions(int ttl) {
@@ -36,7 +36,7 @@ public abstract class BaseOptions {
     }
 
     /**
-     * @return document time-to-live in seconds (default to 1 hour)
+     * @return document time-to-live in seconds (default to one day).
      */
     public int getDeviceTimeToLive() {
         return mTtl;

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/BaseOptions.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/models/BaseOptions.java
@@ -20,12 +20,12 @@ public abstract class BaseOptions {
     /**
      * Default caching value of one day.
      */
-    public static final int DEFAULT_EXPIRATION = 60 * 60 * 24;
+    public static final int DEFAULT_EXPIRATION_IN_SECONDS = 60 * 60 * 24;
 
     private int mTtl;
 
     BaseOptions() {
-        this(DEFAULT_EXPIRATION);
+        this(DEFAULT_EXPIRATION_IN_SECONDS);
     }
 
     BaseOptions(int ttl) {

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/NetworkStateChangeStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/NetworkStateChangeStorageTest.java
@@ -53,7 +53,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -96,7 +96,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -136,7 +136,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                         RESOLVED_USER_PARTITION,
                         DOCUMENT_ID,
                         document,
-                        BaseOptions.DEFAULT_ONE_HOUR);
+                        BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -180,7 +180,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                             RESOLVED_USER_PARTITION,
                             DOCUMENT_ID,
                             "document",
-                            BaseOptions.DEFAULT_ONE_HOUR));
+                            BaseOptions.DEFAULT_EXPIRATION));
                 }});
         mStorage.onNetworkStateUpdated(true);
         verifyZeroInteractions(mHttpClient);
@@ -212,7 +212,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -240,7 +240,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -275,7 +275,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -309,7 +309,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/NetworkStateChangeStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/NetworkStateChangeStorageTest.java
@@ -53,7 +53,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -96,7 +96,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -136,7 +136,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                         RESOLVED_USER_PARTITION,
                         DOCUMENT_ID,
                         document,
-                        BaseOptions.DEFAULT_EXPIRATION);
+                        BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -180,7 +180,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                             RESOLVED_USER_PARTITION,
                             DOCUMENT_ID,
                             "document",
-                            BaseOptions.DEFAULT_EXPIRATION));
+                            BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS));
                 }});
         mStorage.onNetworkStateUpdated(true);
         verifyZeroInteractions(mHttpClient);
@@ -212,7 +212,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -240,7 +240,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -275,7 +275,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);
@@ -309,7 +309,7 @@ public class NetworkStateChangeStorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_EXPIRATION);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
                 new ArrayList<PendingOperation>() {{
                     add(pendingOperation);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Change default device time-to-live from 1 hour to 1 day.

(https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/60094)
