### PR TITLE
Add the pending operation when activity resume

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Storage.java
@@ -6,6 +6,7 @@
 package com.microsoft.appcenter.storage;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
@@ -278,19 +279,30 @@ public class Storage extends AbstractAppCenterService implements NetworkStateHel
 
                 /* If device comes back online. */
                 if (connected) {
-                    for (PendingOperation po : mLocalDocumentStorage.getPendingOperations(Utils.getUserTableName())) {
-                        if (PENDING_OPERATION_CREATE_VALUE.equals(po.getOperation()) ||
-                                PENDING_OPERATION_REPLACE_VALUE.equals(po.getOperation())) {
-                            instanceCreateOrUpdate(po);
-                        } else if (PENDING_OPERATION_DELETE_VALUE.equals(po.getOperation())) {
-                            instanceDelete(po);
-                        } else {
-                            AppCenterLog.debug(LOG_TAG, String.format("Pending operation '%s' is not supported", po.getOperation()));
-                        }
-                    }
+                    processPendingOperations();
                 }
             }
         });
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        if (mNetworkStateHelper.isNetworkConnected()) {
+            processPendingOperations();
+        }
+    }
+
+    private void processPendingOperations() {
+        for (PendingOperation po : mLocalDocumentStorage.getPendingOperations(Utils.getUserTableName())) {
+            if (PENDING_OPERATION_CREATE_VALUE.equals(po.getOperation()) ||
+                    PENDING_OPERATION_REPLACE_VALUE.equals(po.getOperation())) {
+                instanceCreateOrUpdate(po);
+            } else if (PENDING_OPERATION_DELETE_VALUE.equals(po.getOperation())) {
+                instanceDelete(po);
+            } else {
+                AppCenterLog.debug(LOG_TAG, String.format("Pending operation '%s' is not supported", po.getOperation()));
+            }
+        }
     }
 
     /**

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
@@ -955,7 +955,7 @@ public class StorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         Mockito.when(mNetworkStateHelper.isNetworkConnected()).thenReturn(true);
 
         Mockito.when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(
@@ -993,7 +993,7 @@ public class StorageTest extends AbstractStorageTest {
                 RESOLVED_USER_PARTITION,
                 DOCUMENT_ID,
                 "document",
-                BaseOptions.DEFAULT_ONE_HOUR);
+                BaseOptions.DEFAULT_EXPIRATION_IN_SECONDS);
         Mockito.when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
 
         Mockito.when(mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME)).thenReturn(


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Add the pending operation when activity resume

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
