### PR TITLE
Delete document from cache after successful sync of delete operation

### DIFF
--- a/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-storage/src/androidTest/java/com/microsoft/appcenter/storage/LocalDocumentStorageAndroidTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import java.util.Date;
 import java.util.List;
 
+import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_DELETE_VALUE;
+import static com.microsoft.appcenter.storage.Constants.USER;
 import static com.microsoft.appcenter.storage.LocalDocumentStorage.FAILED_TO_READ_FROM_CACHE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -130,7 +132,7 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void updateLocalCopyDeletesExpiredOperation() {
-        Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
+        Document<String> document = new Document<>(TEST_VALUE, USER, ID);
         mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, document, new WriteOptions() {
 
             @Override
@@ -150,7 +152,7 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void updateLocalCopyReplacesNotExpiredOperation() {
-        Document<String> document = new Document<>(TEST_VALUE, Constants.USER, ID);
+        Document<String> document = new Document<>(TEST_VALUE, USER, ID);
         mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, document, new WriteOptions(10));
 
         List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
@@ -172,14 +174,14 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void resetDatabase() {
-        
+
         /* Create a user table and app table (readonly), and add a document to each. */
         mLocalDocumentStorage.createTableIfDoesNotExist(USER_TABLE_NAME);
-        Document<String> userDocument = new Document<>(TEST_VALUE, Constants.USER, ID);
+        Document<String> userDocument = new Document<>(TEST_VALUE, USER, ID);
         Document<String> appDocument = new Document<>(TEST_VALUE, Constants.READONLY, ID);
         mLocalDocumentStorage.writeOffline(USER_TABLE_NAME, userDocument, new WriteOptions());
         mLocalDocumentStorage.writeOffline(READ_ONLY_TABLE_NAME, appDocument, new WriteOptions());
-        Document<String> cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, new ReadOptions());
+        Document<String> cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, String.class, new ReadOptions());
         Document<String> cachedAppDocument = mLocalDocumentStorage.read(READ_ONLY_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
 
         /* Verify to documents were added to the tables and there were no errors. */
@@ -192,7 +194,7 @@ public class LocalDocumentStorageAndroidTest {
 
         /* Reset the database. */
         mLocalDocumentStorage.resetDatabase();
-        cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, new ReadOptions());
+        cachedUserDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, String.class, new ReadOptions());
         cachedAppDocument = mLocalDocumentStorage.read(READ_ONLY_TABLE_NAME, Constants.READONLY, ID, String.class, new ReadOptions());
 
         /* Verify that reading the documents gives an error and their contents are null. */
@@ -217,7 +219,7 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void deleteOfflineAddsOnePendingOperation() {
-        mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, Constants.USER, ID);
+        mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, USER, ID);
         List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
     }
@@ -226,28 +228,28 @@ public class LocalDocumentStorageAndroidTest {
     public void createAndDeleteOffline() {
         List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(0, operations.size());
-        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, USER, ID, "Test", String.class, new WriteOptions());
         operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
-        boolean updated = mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, Constants.USER, ID);
+        boolean updated = mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, USER, ID);
         assertTrue(updated);
         operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         operation = operations.get(0);
-        assertEquals(Constants.PENDING_OPERATION_DELETE_VALUE, operation.getOperation());
+        assertEquals(PENDING_OPERATION_DELETE_VALUE, operation.getOperation());
     }
 
     @Test
     public void createAndUpdateOffline() {
-        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, USER, ID, "Test", String.class, new WriteOptions());
         List<PendingOperation> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         PendingOperation operation = operations.get(0);
         assertEquals(Constants.PENDING_OPERATION_CREATE_VALUE, operation.getOperation());
         assertTrue(operation.getDocument().contains("Test"));
-        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test2", String.class, new WriteOptions());
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, USER, ID, "Test2", String.class, new WriteOptions());
         operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);
         assertEquals(1, operations.size());
         operation = operations.get(0);
@@ -257,17 +259,33 @@ public class LocalDocumentStorageAndroidTest {
 
     @Test
     public void createUnExpiredDocument() {
-        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions(WriteOptions.INFINITE));
-        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, null);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, USER, ID, "Test", String.class, new WriteOptions(WriteOptions.INFINITE));
+        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, String.class, null);
         assertNull(document.getDocumentError());
         assertEquals("Test", document.getDocument());
     }
 
     @Test
     public void createDocumentWithoutOverflowException() {
-        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, Constants.USER, ID, "Test", String.class, new WriteOptions(999999999));
-        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, Constants.USER, ID, String.class, null);
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, USER, ID, "Test", String.class, new WriteOptions(999999999));
+        Document<String> document = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, String.class, null);
         assertNull(document.getDocumentError());
         assertEquals("Test", document.getDocument());
+    }
+
+    @Test
+    public void syncDeleteOperationMustRemoveFromCache() {
+
+        /* If a document is marked for deletion. */
+        mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, USER, ID);
+        Document<Void> document = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, Void.class, null);
+        assertNull(document.getDocumentError());
+
+        /* When we delete after coming back online. */
+        mLocalDocumentStorage.updatePendingOperation(new PendingOperation(USER_TABLE_NAME, PENDING_OPERATION_DELETE_VALUE, USER, ID, null, Long.MAX_VALUE));
+
+        /* Then the entry is removed from cache. */
+        document = mLocalDocumentStorage.read(USER_TABLE_NAME, USER, ID, Void.class, null);
+        assertNotNull(document.getDocumentError());
     }
 }

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/LocalDocumentStorage.java
@@ -30,6 +30,7 @@ import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 import static com.microsoft.appcenter.Constants.DATABASE;
 import static com.microsoft.appcenter.Constants.READONLY_TABLE;
 import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_CREATE_VALUE;
+import static com.microsoft.appcenter.storage.Constants.PENDING_OPERATION_DELETE_VALUE;
 import static com.microsoft.appcenter.storage.Constants.READONLY;
 import static com.microsoft.appcenter.storage.Constants.USER;
 
@@ -232,7 +233,7 @@ class LocalDocumentStorage {
      */
     boolean deleteOffline(String table, String partition, String documentId) {
         Document<Void> writeDocument = new Document<>(null, partition, documentId);
-        return write(table, writeDocument, new WriteOptions(), Constants.PENDING_OPERATION_DELETE_VALUE) > 0;
+        return write(table, writeDocument, new WriteOptions(), PENDING_OPERATION_DELETE_VALUE) > 0;
     }
 
     /**
@@ -330,7 +331,7 @@ class LocalDocumentStorage {
          * clear the pending_operation column, update eTag, download_time and document columns.
          */
         long now = System.currentTimeMillis();
-        if (operation.getExpirationTime() <= now) {
+        if (operation.getExpirationTime() <= now || PENDING_OPERATION_DELETE_VALUE.equals(operation.getOperation())) {
             deletePendingOperation(operation);
         } else {
             mDatabaseManager.replace(operation.getTable(), getContentValues(operation, now));

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
@@ -12,8 +12,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.microsoft.appcenter.http.HttpException;
-import com.microsoft.appcenter.http.HttpUtils;
 import com.microsoft.appcenter.storage.exception.StorageException;
 import com.microsoft.appcenter.storage.models.Document;
 import com.microsoft.appcenter.storage.models.Page;
@@ -105,12 +103,6 @@ public class Utils {
      */
     public static synchronized void logApiCallFailure(Exception e) {
         AppCenterLog.error(LOG_TAG, "Failed to call App Center APIs", e);
-        if (!HttpUtils.isRecoverableError(e)) {
-            if (e instanceof HttpException) {
-                HttpException httpException = (HttpException) e;
-                AppCenterLog.error(LOG_TAG, "Exception", httpException);
-            }
-        }
     }
 
     static String removeAccountIdFromPartitionName(String partition) {

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/TokenExchange.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/TokenExchange.java
@@ -98,7 +98,7 @@ public class TokenExchange {
 
         private final TokenManager mTokenManager;
 
-        public TokenExchangeServiceCallback(TokenManager tokenManager) {
+        protected TokenExchangeServiceCallback(TokenManager tokenManager) {
             mTokenManager = tokenManager;
         }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Delete document from cache after successful sync of delete operation

## Related PRs or issues

[AB#60223](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=60223)