### PR TITLE
Fix JSON parsing to use UTC ISO dates in storage module

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
@@ -27,6 +27,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 
 import java.lang.reflect.Type;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ public class Utils {
 
     private static class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
 
-        private final SimpleDateFormat mDateFormat;
+        private final DateFormat mDateFormat;
 
         DateAdapter() {
             mDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
@@ -61,12 +62,12 @@ public class Utils {
         }
 
         @Override
-        public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+        public synchronized JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
             return new JsonPrimitive(mDateFormat.format(src));
         }
 
         @Override
-        public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        public synchronized Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             try {
                 return mDateFormat.parse(json.getAsString());
             } catch (ParseException e) {

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Utils.java
@@ -8,10 +8,17 @@ package com.microsoft.appcenter.storage;
 import android.support.annotation.NonNull;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.microsoft.appcenter.storage.exception.StorageException;
 import com.microsoft.appcenter.storage.models.Document;
 import com.microsoft.appcenter.storage.models.Page;
@@ -19,8 +26,14 @@ import com.microsoft.appcenter.storage.models.TokenResult;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static com.microsoft.appcenter.Constants.READONLY_TABLE;
 import static com.microsoft.appcenter.Constants.USER_TABLE_FORMAT;
@@ -34,9 +47,33 @@ import static com.microsoft.appcenter.storage.Constants.USER;
 
 public class Utils {
 
-    private static final Gson sGson = new Gson();
+    private static final Gson sGson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).create();
 
     private static final JsonParser sParser = new JsonParser();
+
+    private static class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+
+        private final SimpleDateFormat mDateFormat;
+
+        DateAdapter() {
+            mDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+            mDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
+        @Override
+        public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(mDateFormat.format(src));
+        }
+
+        @Override
+        public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            try {
+                return mDateFormat.parse(json.getAsString());
+            } catch (ParseException e) {
+                throw new JsonParseException(e);
+            }
+        }
+    }
 
     static <T> Document<T> parseDocument(String cosmosDbPayload, Class<T> documentType) {
         JsonObject body;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix JSON parsing to use UTC ISO dates in storage module