### PR TITLE
Adding uriEncoding for CosmosDB calls.

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
@@ -92,9 +92,9 @@ public class CosmosDb {
 
 
     public static String getDocumentBaseUrl(String databaseName, String collectionName, String documentId) {
-        return String.format(DOCUMENT_DB_DATABASE_URL_SUFFIX, databaseName) + "/" +
-                String.format(DOCUMENT_DB_COLLECTION_URL_SUFFIX, collectionName) + "/" +
-                DOCUMENT_DB_DOCUMENT_URL_PREFIX + (documentId == null ? "" : '/' + documentId);
+        return String.format(DOCUMENT_DB_DATABASE_URL_SUFFIX, urlEncode(databaseName)) + "/" +
+                String.format(DOCUMENT_DB_COLLECTION_URL_SUFFIX, urlEncode(collectionName)) + "/" +
+                DOCUMENT_DB_DOCUMENT_URL_PREFIX + (documentId == null ? "" : '/' + urlEncode(documentId));
     }
 
     private static String getDocumentUrl(TokenResult tokenResult, String documentId) {

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
@@ -62,7 +62,10 @@ public class CosmosDb {
     }
 
     private static String urlEncode(String url) {
-        return urlEncode(url, "UTF-8");
+        if(url != null) {
+            return urlEncode(url, "UTF-8");
+        }
+        return "null";
     }
 
     public static String urlEncode(String url, String enc) {

--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/client/CosmosDb.java
@@ -5,12 +5,15 @@
 
 package com.microsoft.appcenter.storage.client;
 
+import android.support.annotation.VisibleForTesting;
+
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.ServiceCall;
 import com.microsoft.appcenter.http.ServiceCallback;
 import com.microsoft.appcenter.storage.Constants;
 import com.microsoft.appcenter.storage.models.TokenResult;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
@@ -62,17 +65,20 @@ public class CosmosDb {
     }
 
     private static String urlEncode(String url) {
-        if(url != null) {
+
+        /* TODO validate TokenResult has all required fields non null then get rid of the if. */
+        if (url != null) {
             return urlEncode(url, "UTF-8");
         }
-        return "null";
+        return null;
     }
 
+    @VisibleForTesting
     public static String urlEncode(String url, String enc) {
         try {
             return URLEncoder.encode(url, enc);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("failed to encode url " + url, e);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("Failed to encode url " + url, e);
         }
     }
 

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AbstractStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AbstractStorageTest.java
@@ -77,9 +77,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 })
 abstract public class AbstractStorageTest {
 
-    protected static final String DATABASE_NAME = "mbaas";
+    static final String DATABASE_NAME = "mbaas";
 
-    protected static final String COLLECTION_NAME = "appcenter";
+    static final String COLLECTION_NAME = "appcenter";
 
     static final String ACCOUNT_ID = "bd45f90e-6eb1-4c47-817e-e59b82b5c03d";
 

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AbstractStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/AbstractStorageTest.java
@@ -77,9 +77,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 })
 abstract public class AbstractStorageTest {
 
-    private static final String DATABASE_NAME = "mbaas";
+    protected static final String DATABASE_NAME = "mbaas";
 
-    private static final String COLLECTION_NAME = "appcenter";
+    protected static final String COLLECTION_NAME = "appcenter";
 
     static final String ACCOUNT_ID = "bd45f90e-6eb1-4c47-817e-e59b82b5c03d";
 

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
@@ -558,27 +558,24 @@ public class StorageTest extends AbstractStorageTest {
     @Test
     public void readCosmosDbCallEncodeDocumentId() throws JSONException, UnsupportedEncodingException {
         String documentID = "Test Document";
-        AppCenterFuture<Document<TestDocument>> doc = Storage.read(USER, documentID, TestDocument.class);
-
+        Storage.read(USER, documentID, TestDocument.class);
         verifyTokenExchangeFlow(TOKEN_EXCHANGE_USER_PAYLOAD, null);
 
-        // verify that document base Uri is properly constructed by CosmosDb.getDocumentBaseUrl method
+        /* Verify that document base Uri is properly constructed by CosmosDb.getDocumentBaseUrl method. */
         String expectedUri = String.format("dbs/%s", DATABASE_NAME) + "/" +
                 String.format("colls/%s", COLLECTION_NAME) + "/" +
                 "docs" + '/' + URLEncoder.encode(documentID, "UTF-8");
         assertEquals(expectedUri, CosmosDb.getDocumentBaseUrl(DATABASE_NAME, COLLECTION_NAME, documentID));
 
-        // now verify that actual call was properly encoded
-        ArgumentCaptor<HttpClient.CallTemplate> cosmosDbCallTemplateCallbackArgumentCaptor =
-                ArgumentCaptor.forClass(HttpClient.CallTemplate.class);
+        /* Now verify that actual call was properly encoded. */
         ArgumentCaptor<ServiceCallback> cosmosDbServiceCallbackArgumentCaptor =
                 ArgumentCaptor.forClass(ServiceCallback.class);
         verify(mHttpClient).callAsync(
                 endsWith(CosmosDb.getDocumentBaseUrl(DATABASE_NAME, COLLECTION_NAME, documentID)),
                 eq(METHOD_GET),
                 anyMapOf(String.class, String.class),
-                cosmosDbCallTemplateCallbackArgumentCaptor.capture(),
-                cosmosDbServiceCallbackArgumentCaptor.capture());
+                any(HttpClient.CallTemplate.class),
+                notNull(ServiceCallback.class));
     }
 
     @Test

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/StorageTest.java
@@ -568,8 +568,6 @@ public class StorageTest extends AbstractStorageTest {
         assertEquals(expectedUri, CosmosDb.getDocumentBaseUrl(DATABASE_NAME, COLLECTION_NAME, documentID));
 
         /* Now verify that actual call was properly encoded. */
-        ArgumentCaptor<ServiceCallback> cosmosDbServiceCallbackArgumentCaptor =
-                ArgumentCaptor.forClass(ServiceCallback.class);
         verify(mHttpClient).callAsync(
                 endsWith(CosmosDb.getDocumentBaseUrl(DATABASE_NAME, COLLECTION_NAME, documentID)),
                 eq(METHOD_GET),


### PR DESCRIPTION
Following scenario test fails:
1. Create a document with document id that contains spaces (e.g. "Test Document").
2. Retrieve all documents (Storage.list) - make sure the new document is present and its id is "Test Document"
3. Call Storage.read with that document id results in 400 error.

The issue is that we construct DocumentDB Uri without escaping strings that can contain unencoded URI values (e.g. spaces or slashes). 

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
