### PR TITLE
Fix a bug where database cursor is not closed

### DIFF
--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -134,6 +134,18 @@ public class LocalDocumentStorageTest {
     }
 
     @Test
+    public void readClosesDatabaseCursor() {
+        when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenReturn(mCursor);
+        when(mDatabaseManager.nextValues(mCursor)).thenReturn(null);
+        Document<String> doc = mLocalDocumentStorage.read(mUserTableName, PARTITION, DOCUMENT_ID, String.class, ReadOptions.createNoCacheOptions());
+        assertNotNull(doc);
+        assertNull(doc.getDocument());
+        assertTrue(doc.hasFailed());
+        assertEquals(DocumentError.class, doc.getDocumentError().getClass());
+        verify(mCursor).close();
+    }
+
+    @Test
     public void readReturnsErrorObjectOnDbRuntimeException() {
         when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenThrow(new RuntimeException());
         Document<String> doc = mLocalDocumentStorage.read(mUserTableName, PARTITION, DOCUMENT_ID, String.class, ReadOptions.createNoCacheOptions());

--- a/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-storage/src/test/java/com/microsoft/appcenter/storage/LocalDocumentStorageTest.java
@@ -136,7 +136,6 @@ public class LocalDocumentStorageTest {
     @Test
     public void readClosesDatabaseCursor() {
         when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenReturn(mCursor);
-        when(mDatabaseManager.nextValues(mCursor)).thenReturn(null);
         Document<String> doc = mLocalDocumentStorage.read(mUserTableName, PARTITION, DOCUMENT_ID, String.class, ReadOptions.createNoCacheOptions());
         assertNotNull(doc);
         assertNull(doc.getDocument());


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix a bug where database cursor is not closed.

```
StrictMode policy violation: android.os.strictmode.SqliteObjectLeakedViolation: Finalizing a Cursor that has not been deactivated or closed. database = /data/user/0/com.microsoft.appcenter.sasquatch.project/databases/com.microsoft.appcenter.documents, table = user_228374e1b08a4c72b2227ce097f0e5c7_documents, query = SELECT * FROM user_228374e1b08a4c72b2227ce097f0e5c7_documents WHERE (partition = ? AND document_id = ?) ORDER BY expiration_time DESC
        at android.os.StrictMode.onSqliteObjectLeaked(StrictMode.java:1956)
        at android.database.sqlite.SQLiteCursor.finalize(SQLiteCursor.java:285)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:250)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:237)
        at java.lang.Daemons$Daemon.run(Daemons.java:103)
        at java.lang.Thread.run(Thread.java:764)
     Caused by: android.database.sqlite.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
        at android.database.sqlite.SQLiteCursor.<init>(SQLiteCursor.java:103)
        at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:52)
        at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1408)
        at android.database.sqlite.SQLiteQueryBuilder.query(SQLiteQueryBuilder.java:399)
        at android.database.sqlite.SQLiteQueryBuilder.query(SQLiteQueryBuilder.java:294)
        at com.microsoft.appcenter.utils.storage.DatabaseManager.getCursor(DatabaseManager.java:456)
        at com.microsoft.appcenter.storage.LocalDocumentStorage.read(LocalDocumentStorage.java:300)
        at com.microsoft.appcenter.storage.Storage$3.run(Storage.java:381)
        at com.microsoft.appcenter.AbstractAppCenterService$6.run(AbstractAppCenterService.java:340)
        at com.microsoft.appcenter.AbstractAppCenterService$4.run(AbstractAppCenterService.java:306)
        at com.microsoft.appcenter.AppCenter$7.run(AppCenter.java:722)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.os.HandlerThread.run(HandlerThread.java:65)
```
