### PR TITLE
Fix the default Prod token exchange URL

### DIFF
--- a/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Constants.java
+++ b/sdk/appcenter-storage/src/main/java/com/microsoft/appcenter/storage/Constants.java
@@ -46,7 +46,7 @@ public final class Constants {
     /**
      * Base URL to call token exchange service.
      */
-    static final String DEFAULT_API_URL = "https://api.appcenter.ms/v0.1"; //TODO This is not the right url.
+    static final String DEFAULT_API_URL = "https://tokens.appcenter.ms/v0.1";
 
     /**
      * Name of the service.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Sasquatch calls `[MSDataStore setTokenExchangeUrl:kMSIntTokenExchangeUrl];` with INT token exchange URL today, hence the incorrect "https://api.appcenter.ms/v0.1" URL is not used.

Let's fix the default token exchange. We can remove the `setTokenExchangeUrl:` call once token exchange is ready in Prod.

Same change as https://github.com/Microsoft/AppCenter-SDK-Apple/pull/1531.
