### PR TITLE
Fix getJsonValue to return only the customer object and not wrapper / Fix delete document in sasquatch.

### DIFF
--- a/apps/sasquatch/src/projectDependency/java/com/microsoft/appcenter/sasquatch/activities/DataActivity.java
+++ b/apps/sasquatch/src/projectDependency/java/com/microsoft/appcenter/sasquatch/activities/DataActivity.java
@@ -27,12 +27,12 @@ import android.widget.Toast;
 import com.microsoft.appcenter.data.Data;
 import com.microsoft.appcenter.data.DefaultPartitions;
 import com.microsoft.appcenter.data.models.DocumentWrapper;
+import com.microsoft.appcenter.data.models.Page;
+import com.microsoft.appcenter.data.models.PaginatedDocuments;
 import com.microsoft.appcenter.sasquatch.R;
 import com.microsoft.appcenter.sasquatch.activities.data.AppDocumentListAdapter;
 import com.microsoft.appcenter.sasquatch.activities.data.CustomItemAdapter;
 import com.microsoft.appcenter.sasquatch.activities.data.TestDocument;
-import com.microsoft.appcenter.data.models.Page;
-import com.microsoft.appcenter.data.models.PaginatedDocuments;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 
 import java.util.ArrayList;
@@ -200,7 +200,7 @@ public class DataActivity extends AppCompatActivity {
 
             @Override
             public void onRemoveClick(final int position) {
-                Data.delete(DefaultPartitions.USER_DOCUMENTS, mAdapterUser.getItem(position)).thenAccept(new AppCenterConsumer<DocumentWrapper<Void>>() {
+                Data.delete(mAdapterUser.getItem(position), DefaultPartitions.USER_DOCUMENTS).thenAccept(new AppCenterConsumer<DocumentWrapper<Void>>() {
 
                     @Override
                     public void accept(DocumentWrapper<Void> voidDocument) {

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -633,7 +633,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                 null,
                 mHttpClient,
                 METHOD_POST,
-                new DocumentWrapper<>(document, partition, documentId).getJsonValue(),
+                new DocumentWrapper<>(document, partition, documentId).toString(),
                 additionalHeaders,
                 new ServiceCallback() {
 

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -139,7 +139,7 @@ class LocalDocumentStorage {
         ContentValues values = getContentValues(
                 document.getPartition(),
                 document.getId(),
-                document.getJsonValue(),
+                document.toString(),
                 document.getETag(),
                 writeOptions.getDeviceTimeToLive() == TimeToLive.INFINITE ?
                         TimeToLive.INFINITE : now + writeOptions.getDeviceTimeToLive() * 1000L,

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/models/DocumentWrapper.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/models/DocumentWrapper.java
@@ -88,7 +88,7 @@ public class DocumentWrapper<T> extends DocumentMetadata {
      * @return The document in its JSON form.
      */
     public String getJsonValue() {
-        return toString();
+        return Utils.getGson().toJson(mDocument);
     }
 
     /**

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/UtilsTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/UtilsTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -43,16 +44,17 @@ public class UtilsTest {
     public void canParseWhenPassedWrongType() {
         TestDocument testDoc = new TestDocument("test-value");
         DocumentWrapper<TestDocument> doc = new DocumentWrapper<>(testDoc, "partition", "id");
-        DocumentWrapper<String> document = Utils.parseDocument(doc.getJsonValue(), String.class);
+        DocumentWrapper<String> document = Utils.parseDocument(doc.toString(), String.class);
         assertNotNull(document.getError());
     }
 
     @Test
-    public void toStringAndGetJsonValueAreEquivalents() {
+    public void jsonValueIsUserDocument() {
         TestDocument testDoc = new TestDocument("test-value");
         DocumentWrapper<TestDocument> doc = new DocumentWrapper<>(testDoc, "partition", "id");
         assertNotNull(doc.getJsonValue());
-        assertEquals(doc.getJsonValue(), doc.toString());
+        assertEquals(doc.getJsonValue(), Utils.getGson().toJson(testDoc));
+        assertNotEquals(doc.getJsonValue(), doc.toString());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix getJsonValue to return only the customer object and not wrapper.
Fix delete document in sasquatch.

## Related PRs or issues

[AB#60477](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/60477)