### PR TITLE
Fix for [Android] NO_CACHE is not respected for read operation.

### DIFF
--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -328,7 +328,13 @@ class LocalDocumentStorage {
 
             /* Update the expiredAt time only when the readOptions is not null, otherwise keep updating it. */
             if (readOptions != null) {
-                write(table, document, new WriteOptions(readOptions.getDeviceTimeToLive()), values.getAsString(PENDING_OPERATION_COLUMN_NAME));
+                if(readOptions.getDeviceTimeToLive() == TimeToLive.NO_CACHE) {
+                 // delete the document since no cache was requested
+                    mDatabaseManager.delete(table, values.getAsLong(DatabaseManager.PRIMARY_KEY));
+                }
+                else {
+                    write(table, document, new WriteOptions(readOptions.getDeviceTimeToLive()), values.getAsString(PENDING_OPERATION_COLUMN_NAME));
+                }
             }
             return document;
         }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
