### PR TITLE
Sign in always fails on first launch fixed

### DIFF
--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -556,7 +556,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
 
             /* Check if getting the config in process. */
             if (mGetConfigCall != null) {
-                AppCenterLog.debug(LOG_TAG, "Downloading configuration in process. Waiting for it before sign-in.");
+                AppCenterLog.info(LOG_TAG, "Downloading configuration in process. Waiting for it before sign-in.");
             } else {
                 future.complete(new SignInResult(null, new IllegalStateException("signIn is called while it's not configured.")));
             }

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -556,7 +556,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
 
             /* Check if getting the config in process. */
             if (mGetConfigCall != null) {
-                AppCenterLog.debug(LOG_TAG, "Downloading configuration in process. Waiting it before sign-in.");
+                AppCenterLog.debug(LOG_TAG, "Downloading configuration in process. Waiting for it before sign-in.");
             } else {
                 future.complete(new SignInResult(null, new IllegalStateException("signIn is called while it's not configured.")));
             }

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -393,6 +393,11 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     private synchronized void processDownloadNotModified() {
         mGetConfigCall = null;
         AppCenterLog.info(LOG_TAG, "Auth configuration didn't change.");
+
+        /*
+         * We should never be in the case where we don't have a config file and we get 304,
+         * if that ever happens we are stuck and thus signIn fails.
+         */
         if (isPendingSignInWaitingForConfiguration()) {
             mLastSignInFuture.complete(new SignInResult(null, new IllegalStateException("Cannot load auth configuration from the server.")));
         }

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -1786,7 +1786,6 @@ public class AuthTest extends AbstractAuthTest {
 
         /* Simulate download configuration response. */
         mockHttpCallSuccess(mockValidForAppCenterConfig(), serviceCallback);
-
         verify(publicClientApplication).acquireTokenSilentAsync(any(String[].class), notNull(IAccount.class), isNull(String.class), eq(true), signInCallbackCaptor.capture());
 
         /* Simulate Sign-In success. */

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -1801,7 +1801,16 @@ public class AuthTest extends AbstractAuthTest {
     }
 
     @Test
-    public void signInFailedAfterConfigDownloadingFailed() throws Exception {
+    public void signInFailedAfterConfigDownloadingFailedNoNetwork() throws Exception {
+        signInFailedAfterConfigDownloadingFailed(new IOException());
+    }
+
+    @Test
+    public void signInFailedAfterConfigDownloadingHttpFailed() throws Exception {
+        signInFailedAfterConfigDownloadingFailed(new HttpException(304));
+    }
+
+    private void signInFailedAfterConfigDownloadingFailed(Exception e) throws Exception {
 
         /* Mock config call. */
         ServiceCall getConfigCall = mock(ServiceCall.class);
@@ -1828,7 +1837,7 @@ public class AuthTest extends AbstractAuthTest {
         verify(publicClientApplication, never()).acquireTokenSilentAsync(any(String[].class), notNull(IAccount.class), isNull(String.class), eq(true), any(AuthenticationCallback.class));
 
         /* Simulate download configuration response. */
-        serviceCallback.onCallFailed(new IOException());
+        serviceCallback.onCallFailed(e);
 
         /* Verify that sign in failed, cause config downloading failed. */
         assertNotNull(future);
@@ -1836,6 +1845,7 @@ public class AuthTest extends AbstractAuthTest {
         assertNotNull(future.get().getException());
         verify(publicClientApplication, never()).acquireTokenSilentAsync(any(String[].class), notNull(IAccount.class), isNull(String.class), eq(true), any(AuthenticationCallback.class));
     }
+
 
     private void mockReadyToSignIn() throws Exception {
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

The first sign in always fails for a fresh Android app because the config is not downloaded in time and the app thinks that configuration failed.

Steps to reproduce:
1)Create a new Android app and integrate auth
2)Sign in (you will need to close the app and reopen to get sign in to actually happen)

Expected behavior:
1)Auth sign in method waits asynchronously for the HTTP response to get the remote config if the network is up and if there is no cached config.
2)If the HTTP call fails the completion handler of the sign in API is called with SignInResult with an exception.
3)Sign in immediately fails if no network and if the application is in background. (This matches the existing behavior)

## Related PRs or issues

[AB#60930](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/60930)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
