### PR TITLE
Make the postAsyncGetter() call return a proper document error instead of a null

### DIFF
--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -304,7 +304,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
     }
 
     private static IllegalStateException getModuleNotStartedException() {
-        return new IllegalStateException("Data module has not been started. Add `Data.class` to the `AppCenter.start(...)` call.");
+        return new IllegalStateException("Data module is either disabled or has not been started. Add `Data.class` to the `AppCenter.start(...)` call.");
     }
 
     /**
@@ -478,7 +478,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                     doOfflineOperation(cachedDocument, table, cachedToken, result, callTemplate);
                 }
             }
-        }, result, null); // TODO use a document error instead of null.
+        }, result, new DocumentWrapper<T>(getModuleNotStartedException()));
         return result;
     }
 
@@ -647,7 +647,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                             }
                         });
             }
-        }, result, null);
+        }, result, new PaginatedDocuments<T>().setCurrentPage(new Page<T>(getModuleNotStartedException())));
         return result;
     }
 
@@ -794,7 +794,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                     result.complete(createdOrUpdatedDocument);
                 }
             }
-        }, result, null);
+        }, result, new DocumentWrapper<T>(getModuleNotStartedException()));
         return result;
     }
 

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataTest.java
@@ -217,7 +217,10 @@ public class DataTest extends AbstractDataTest {
 
         /* Make the list call again. */
         PaginatedDocuments<TestDocument> docCancel = Data.list(TestDocument.class, USER_DOCUMENTS).get();
-        assertNull(docCancel);
+        assertNotNull(docCancel);
+        assertNull(docCancel.getCurrentPage().getItems());
+        assertNotNull(docCancel.getCurrentPage().getError());
+        assertEquals(IllegalStateException.class, docCancel.getCurrentPage().getError().getCause().getClass());
     }
 
     @Test

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataTest.java
@@ -1521,6 +1521,16 @@ public class DataTest extends AbstractDataTest {
     @Test
     public void moduleHasNotStartedDoesNotThrow() {
         Data.unsetInstance();
+        verifyIllegalStateResult();
+    }
+
+    @Test
+    public void moduleStartedButDisabled() {
+        Data.setEnabled(false);
+        verifyIllegalStateResult();
+    }
+
+    private void verifyIllegalStateResult() {
 
         /* Test `create` before module started */
         DocumentWrapper<TestDocument> createDoc = Data.create("id", new TestDocument("a"), TestDocument.class, DefaultPartitions.APP_DOCUMENTS).get();


### PR DESCRIPTION

Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Make the postAsyncGetter() call return a proper document error instead of a null