### PR TITLE
Add a separate Group State for critical events

### DIFF
--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -14,6 +14,7 @@ import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
 import com.microsoft.appcenter.AppCenter;
+import com.microsoft.appcenter.Constants;
 import com.microsoft.appcenter.Flags;
 import com.microsoft.appcenter.analytics.channel.AnalyticsListener;
 import com.microsoft.appcenter.analytics.channel.AnalyticsValidator;
@@ -27,8 +28,6 @@ import com.microsoft.appcenter.analytics.ingestion.models.json.StartSessionLogFa
 import com.microsoft.appcenter.analytics.ingestion.models.one.CommonSchemaEventLog;
 import com.microsoft.appcenter.analytics.ingestion.models.one.json.CommonSchemaEventLogFactory;
 import com.microsoft.appcenter.channel.Channel;
-import com.microsoft.appcenter.ingestion.Ingestion;
-import com.microsoft.appcenter.ingestion.OneCollectorIngestion;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.ingestion.models.properties.StringTypedProperty;
@@ -663,7 +662,7 @@ public class Analytics extends AbstractAppCenterService {
 
         /* If we enabled the service. */
         if (enabled) {
-            mChannel.addGroup(ANALYTICS_CRITICAL_GROUP, getTriggerCount(), getTriggerInterval(), getTriggerMaxParallelRequests(), null, getChannelListener());
+            mChannel.addGroup(ANALYTICS_CRITICAL_GROUP, getTriggerCount(), Constants.DEFAULT_TRIGGER_INTERVAL, getTriggerMaxParallelRequests(), null, getChannelListener());
 
             /* Check if service started at application level and enable corresponding features. */
             startAppLevelFeatures();

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -50,19 +50,26 @@ import java.util.Map;
  */
 public class Analytics extends AbstractAppCenterService {
 
-    public static final String ANALYTICS_CRITICAL_GROUP = "group_critical";
     /**
      * Constant marking event of the analytics group.
      */
     static final String ANALYTICS_GROUP = "group_analytics";
+
+    /**
+     * Constant marking event of the analytics critical group.
+     */
+    static final String ANALYTICS_CRITICAL_GROUP = ANALYTICS_GROUP + "_critical";
+
     /**
      * Name of the service.
      */
     private static final String SERVICE_NAME = "Analytics";
+
     /**
      * TAG used in logging for Analytics.
      */
     public static final String LOG_TAG = AppCenterLog.LOG_TAG + SERVICE_NAME;
+
     /**
      * Activity suffix to exclude from generated page names.
      */
@@ -656,7 +663,7 @@ public class Analytics extends AbstractAppCenterService {
 
         /* If we enabled the service. */
         if (enabled) {
-            mChannel.addGroup(criticalAnalyticsGroupName("Critical"), getTriggerCount(), getTriggerInterval(), getTriggerMaxParallelRequests(), null, getChannelListener());
+            mChannel.addGroup(ANALYTICS_CRITICAL_GROUP, getTriggerCount(), getTriggerInterval(), getTriggerMaxParallelRequests(), null, getChannelListener());
 
             /* Check if service started at application level and enable corresponding features. */
             startAppLevelFeatures();
@@ -664,7 +671,7 @@ public class Analytics extends AbstractAppCenterService {
 
         /* On disabling service. */
         else {
-            mChannel.removeGroup(criticalAnalyticsGroupName("Critical"));
+            mChannel.removeGroup(ANALYTICS_CRITICAL_GROUP);
 
             /* Cleanup resources. */
             if (mAnalyticsValidator != null) {
@@ -793,11 +800,7 @@ public class Analytics extends AbstractAppCenterService {
     }
 
     private boolean isCritical(int flag) {
-        return flag == Flags.PERSISTENCE_CRITICAL;
-    }
-
-    private String criticalAnalyticsGroupName(String groupName) {
-        return SERVICE_NAME + groupName;
+        return (flag & Flags.PERSISTENCE_CRITICAL) != 0;
     }
 
     /**

--- a/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
+++ b/sdk/appcenter-analytics/src/test/java/com/microsoft/appcenter/analytics/AnalyticsTest.java
@@ -54,6 +54,8 @@ import java.util.concurrent.TimeUnit;
 import static com.microsoft.appcenter.Flags.DEFAULTS;
 import static com.microsoft.appcenter.Flags.PERSISTENCE_CRITICAL;
 import static com.microsoft.appcenter.Flags.PERSISTENCE_NORMAL;
+import static com.microsoft.appcenter.analytics.Analytics.ANALYTICS_CRITICAL_GROUP;
+import static com.microsoft.appcenter.analytics.Analytics.ANALYTICS_GROUP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,16 +81,6 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 public class AnalyticsTest extends AbstractAnalyticsTest {
-
-    /**
-     * Constant marking event of the analytics group.
-     */
-    static final String ANALYTICS_GROUP = "group_analytics";
-
-    /**
-     * Constant marking event of the analytics critical group.
-     */
-    static final String ANALYTICS_CRITICAL_GROUP = ANALYTICS_GROUP + "_critical";
 
     @After
     public void resetUserId() {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/Constants.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/Constants.java
@@ -80,7 +80,7 @@ public class Constants {
     /**
      * Maximum time interval in milliseconds after which a synchronize will be triggered, regardless of queue size.
      */
-    static final int DEFAULT_TRIGGER_INTERVAL = 3 * 1000;
+    public static final int DEFAULT_TRIGGER_INTERVAL = 3 * 1000;
 
     /**
      * Initializes constants from the given context. The context is used to set


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/Microsoft/AppCenter-SDK-Android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Add an instance of GroupState for critical events in Analytics (using addGroup), in the same way as it's done in OneCollector. Name it serviceName + "Critical" (this should be Analytics/Critical).
Implement adding events to a different group depending on the priority.

## Related PRs or issues

[AB#61308](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61308)
