### PR TITLE
Fix NPE in Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### App Center Auth
 
 * **[Fix]** Fix missing proguard rules so that the app does not have to specify them.
+* **[Fix]** Fix crash on silently refreshing token if initialization of MSAL fails.
 
 ### App Center Data
 

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -639,6 +639,8 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     @WorkerThread
     private synchronized void refreshToken(String homeAccountId, boolean networkConnected) {
         if (mAuthenticationClient == null) {
+            AppCenterLog.warn(LOG_TAG, "Failed to refresh token: Auth isn't configured.");
+            AuthTokenContext.getInstance().setAuthToken(null, null, null);
             return;
         }
         if (isFutureInProgress(mLastSignInFuture)) {

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -638,6 +638,9 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
 
     @WorkerThread
     private synchronized void refreshToken(String homeAccountId, boolean networkConnected) {
+        if (mAuthenticationClient == null) {
+            return;
+        }
         if (isFutureInProgress(mLastSignInFuture)) {
             AppCenterLog.debug(LOG_TAG, "Failed to refresh token: sign-in already in progress.");
             return;

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -1385,11 +1385,9 @@ public class AuthTest extends AbstractAuthTest {
     }
 
     @Test
-    public void refreshTokenWithoutConfig() throws Exception {
+    public void refreshTokenWithoutConfig() {
         ArgumentCaptor<AuthTokenContext.Listener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
         doNothing().when(mAuthTokenContext).addListener(authTokenContextListenerCaptor.capture());
-        ArgumentCaptor<NetworkStateHelper.Listener> networkStateListenerCaptor = ArgumentCaptor.forClass(NetworkStateHelper.Listener.class);
-        doNothing().when(mNetworkStateHelper).addListener(networkStateListenerCaptor.capture());
 
         /* Start auth service. */
         Auth auth = Auth.getInstance();
@@ -1400,8 +1398,8 @@ public class AuthTest extends AbstractAuthTest {
 
         /* Connect to online with token to update. */
         authTokenContextListenerCaptor.getValue().onTokenRequiresRefresh("accountId");
-        when(mNetworkStateHelper.isNetworkConnected()).thenReturn(true);
-        networkStateListenerCaptor.getValue().onNetworkStateUpdated(true);
+
+        /* Do not crash. */
     }
 
     @Test

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -1399,7 +1399,8 @@ public class AuthTest extends AbstractAuthTest {
         /* Connect to online with token to update. */
         authTokenContextListenerCaptor.getValue().onTokenRequiresRefresh("accountId");
 
-        /* Do not crash. */
+        /* Verify sign out cleared token. */
+        verify(mAuthTokenContext).setAuthToken(isNull(String.class), isNull(String.class), isNull(Date.class));
     }
 
     @Test


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

```
E/AppCenter: Timeout waiting for looper tasks to complete.
E/AndroidRuntime: FATAL EXCEPTION: AppCenter.Looper
    Process: com.microsoft.appcenter.sasquatch.project, PID: 22199
    java.lang.NullPointerException: Attempt to invoke virtual method 'com.microsoft.identity.client.IAccount com.microsoft.identity.client.PublicClientApplication.getAccount(java.lang.String, java.lang.String)' on a null object reference
        at com.microsoft.appcenter.auth.Auth.retrieveAccount(Auth.java:543)
        at com.microsoft.appcenter.auth.Auth.refreshToken(Auth.java:656)
        at com.microsoft.appcenter.auth.Auth.access$100(Auth.java:76)
        at com.microsoft.appcenter.auth.Auth$2.run(Auth.java:292)
        at com.microsoft.appcenter.AbstractAppCenterService$4.run(AbstractAppCenterService.java:304)
        at com.microsoft.appcenter.AppCenter$7.run(AppCenter.java:718)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:135)
        at android.os.HandlerThread.run(HandlerThread.java:61)
```

Fix crash on silently refreshing token. Unfortunately, I don't have reproduction and full logs, but based on the code it can happen if MSAL initialization fails or we cannot parse new config.
