### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### App Center Push
 
-* **[Fix]** Update Firebase dependency to avoid conflict in applications using latest support libraries (v28) or the latest Firebase messaging version (v18).
+* **[Fix]** Update Firebase dependency and AppCenter push logic to avoid a runtime issue with the latest Firebase messaging version 18.0.0.
 
 ## Version 2.0.0
 


### PR DESCRIPTION
Statement was inaccurrate as Firebase still uses support 26.1.0 and not 28.0.0.

[AB#61836](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61836)
#1159
#1166 