### PR TITLE
Fix store interval when channel paused

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -34,7 +34,6 @@ import com.microsoft.appcenter.utils.context.AuthTokenInfo;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import java.io.IOException;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -767,7 +766,7 @@ public class DefaultChannel implements Channel {
     @VisibleForTesting
     synchronized void checkPendingLogs(@NonNull GroupState groupState) {
         AppCenterLog.debug(LOG_TAG, String.format("checkPendingLogs(%s) pendingLogCount=%s batchTimeInterval=%s",
-                groupState.mName, groupState.mPendingLogCount, DateFormat.getTimeInstance().format(new Date(groupState.mBatchTimeInterval))));
+                groupState.mName, groupState.mPendingLogCount, groupState.mBatchTimeInterval));
         Long batchTimeInterval = resolveTriggerInterval(groupState);
 
         /* Check if there is no need to trigger ingestion. */
@@ -817,7 +816,7 @@ public class DefaultChannel implements Channel {
                 return groupState.mBatchTimeInterval;
             }
 
-            /* We still have to wait for the rest of the interval. */
+            /* Wait for the rest of the interval. */
             return Math.max(groupState.mBatchTimeInterval - (now - startTimer), 0);
         } else {
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
@@ -47,7 +47,8 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
         DeviceInfoHelper.class,
         HandlerUtils.class,
         IdHelper.class,
-        SharedPreferencesManager.class
+        SharedPreferencesManager.class,
+        System.class
 })
 public class AbstractDefaultChannelTest {
 
@@ -141,5 +142,6 @@ public class AbstractDefaultChannelTest {
         when(AuthTokenContext.getInstance()).thenReturn(mAuthTokenContext);
         whenNew(AuthTokenContext.class).withAnyArguments().thenReturn(mAuthTokenContext);
         mockStatic(SharedPreferencesManager.class);
+        mockStatic(System.class);
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelPauseResumeTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelPauseResumeTest.java
@@ -15,6 +15,7 @@ import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.LogContainer;
 import com.microsoft.appcenter.persistence.Persistence;
 import com.microsoft.appcenter.utils.UUIDUtils;
+import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.junit.Test;
 
@@ -22,14 +23,17 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
+import static com.microsoft.appcenter.channel.DefaultChannel.START_TIMER_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -38,6 +42,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
 
@@ -249,5 +254,89 @@ public class DefaultChannelPauseResumeTest extends AbstractDefaultChannelTest {
         /* Verify channel doesn't do anything on pause. */
         verify(channel, never()).checkPendingLogs(any(DefaultChannel.GroupState.class));
         verify(listener, never()).onResumed(eq(TEST_GROUP), anyString());
+    }
+
+    @Test
+    public void pauseWithCustomIntervalAndResumeBeforeIntervalDue() {
+
+        /* Mock current time. */
+        long now = 1000;
+        when(System.currentTimeMillis()).thenReturn(now);
+
+        /* Create channel and group. */
+        Persistence persistence = mock(Persistence.class);
+        when(persistence.countLogs(TEST_GROUP)).thenReturn(0);
+        AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, mockIngestion, mAppCenterHandler);
+        int batchTimeInterval = 10000;
+        channel.addGroup(TEST_GROUP, 10, batchTimeInterval, MAX_PARALLEL_BATCHES, mockIngestion, mock(Channel.GroupListener.class));
+        verifyStatic(never());
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), anyLong());
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
+
+        /* When we enqueue a log while being paused. */
+        channel.pauseGroup(TEST_GROUP, null);
+        when(persistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class), any(Date.class), any(Date.class))).then(getGetLogsAnswer(1));
+        when(persistence.countLogs(TEST_GROUP)).thenReturn(1);
+        channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
+
+        /* Verify that timer does not start but that the current time is saved for future reference. */
+        verifyStatic();
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
+
+        /* When we resume later (before interval is due) */
+        when(SharedPreferencesManager.getLong(eq(START_TIMER_PREFIX + TEST_GROUP))).thenReturn(now);
+        now = 3000;
+        long expectedTimeToWait = 8000;
+        when(System.currentTimeMillis()).thenReturn(now);
+        channel.resumeGroup(TEST_GROUP, null);
+
+        /* Check timer is started with remaining time. */
+        verify(mAppCenterHandler).postDelayed(notNull(Runnable.class), eq(expectedTimeToWait));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+    }
+
+    @Test
+    public void pauseWithCustomIntervalAndResumeAfterIntervalDue() {
+
+        /* Mock current time. */
+        long now = 1000;
+        when(System.currentTimeMillis()).thenReturn(now);
+
+        /* Create channel and group. */
+        Persistence persistence = mock(Persistence.class);
+        when(persistence.countLogs(TEST_GROUP)).thenReturn(0);
+        AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), persistence, mockIngestion, mAppCenterHandler);
+        int batchTimeInterval = 10000;
+        channel.addGroup(TEST_GROUP, 10, batchTimeInterval, MAX_PARALLEL_BATCHES, mockIngestion, mock(Channel.GroupListener.class));
+        verifyStatic(never());
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), anyLong());
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
+
+        /* When we enqueue a log while being paused. */
+        channel.pauseGroup(TEST_GROUP, null);
+        when(persistence.getLogs(any(String.class), anyListOf(String.class), anyInt(), anyListOf(Log.class), any(Date.class), any(Date.class))).then(getGetLogsAnswer(1));
+        when(persistence.countLogs(TEST_GROUP)).thenReturn(1);
+        channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
+
+        /* Verify that timer does not start but that the current time is saved for future reference. */
+        verifyStatic();
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
+
+        /* When we resume later (after interval is due) */
+        when(SharedPreferencesManager.getLong(eq(START_TIMER_PREFIX + TEST_GROUP))).thenReturn(now);
+        when(System.currentTimeMillis()).thenReturn(now + batchTimeInterval + 1);
+        channel.resumeGroup(TEST_GROUP, null);
+
+        /* Check timer is not started and logs send immediately. */
+        verify(mAppCenterHandler, never()).postDelayed(notNull(Runnable.class), anyLong());
+        verify(mockIngestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -24,13 +24,11 @@ import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.context.AuthTokenInfo;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -57,21 +55,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-@PrepareForTest(System.class)
 public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     private static final long CUSTOM_INTERVAL = 10000;
-
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        mockStatic(System.class);
-    }
 
     @Test
     public void invalidGroup() throws Persistence.PersistenceException {
@@ -1032,7 +1021,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         /* Prepare to mock timer. */
         ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
-            when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Create channel. */
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
@@ -1078,34 +1067,6 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verifyStatic();
         SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(CUSTOM_INTERVAL));
-    }
-
-    @Test
-    public void checkPendingLogsStoresStartTimeWhenPaused() {
-
-        /* Mock current time. */
-        long now = 1;
-        when(System.currentTimeMillis()).thenReturn(now);
-
-        /* Create channel and group. */
-        Persistence mockPersistence = mock(Persistence.class);
-        when(mockPersistence.countLogs(TEST_GROUP)).thenReturn(0);
-        AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
-        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
-        channel.addGroup(TEST_GROUP, 10, CUSTOM_INTERVAL, MAX_PARALLEL_BATCHES, mockIngestion, mock(Channel.GroupListener.class));
-        verifyStatic(never());
-        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), anyLong());
-        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
-
-        channel.pauseGroup(TEST_GROUP, null);
-        channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
-
-        /* Verify that timer starts and current time is saved into preferences. */
-        verifyStatic();
-        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
-        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
-        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -7,7 +7,6 @@ package com.microsoft.appcenter.channel;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.support.annotation.NonNull;
 
 import com.microsoft.appcenter.CancellationException;
 import com.microsoft.appcenter.Flags;
@@ -39,13 +38,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static com.microsoft.appcenter.Flags.NORMAL;
 import static com.microsoft.appcenter.channel.DefaultChannel.START_TIMER_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
@@ -140,7 +137,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Schedule only 1 log after that. */
         channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
@@ -151,9 +149,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockListener, times(50)).onSuccess(any(Log.class));
 
         /* Simulate the timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
-        runnable.set(null);
+        delayedRunnable.getValue().run();
 
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mockIngestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
@@ -170,8 +166,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockListener, times(51)).onSuccess(any(Log.class));
 
         /* Simulate the timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
         verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
@@ -200,7 +195,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Enqueuing 49 events. */
         for (int i = 1; i <= 49; i++) {
@@ -214,30 +210,10 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mAppCenterHandler).removeCallbacks(any(Runnable.class));
 
         /* Wait for timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         /* Database returned less logs than we expected (40 vs 50), yet counter must be reset. */
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-    }
-
-    @NonNull
-    private AtomicReference<Runnable> catchPostRunnable() {
-        return catchPostRunnable(BATCH_TIME_INTERVAL);
-    }
-
-    @NonNull
-    private AtomicReference<Runnable> catchPostRunnable(long interval) {
-        final AtomicReference<Runnable> runnable = new AtomicReference<>();
-        when(mAppCenterHandler.postDelayed(any(Runnable.class), eq(interval))).then(new Answer<Boolean>() {
-
-            @Override
-            public Boolean answer(InvocationOnMock invocation) {
-                runnable.set((Runnable) invocation.getArguments()[0]);
-                return true;
-            }
-        });
-        return runnable;
     }
 
     @Test
@@ -269,7 +245,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Enqueue enough logs to be split in N + 1 maximum requests. */
         for (int i = 0; i < 200; i++) {
@@ -297,8 +274,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mockPersistence, times(4)).deleteLogs(any(String.class), any(String.class));
 
         /* Wait for timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         /* The counter should be 0 now as we sent data. */
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
@@ -398,7 +374,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(70, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Enable channel. */
         channel.setEnabled(true);
@@ -407,8 +384,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(20, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Wait for timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         /* The counter should be 0 after the second batch. */
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
@@ -480,7 +456,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mAppCenterHandler).removeCallbacks(any(Runnable.class));
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Enable channel to see if it can work again after that error state. */
         channel.setEnabled(true);
@@ -492,8 +469,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         assertEquals(20, channel.getGroupState(TEST_GROUP).mPendingLogCount);
 
         /* Wait for timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         /* The counter should back to 0 now. */
         assertEquals(0, channel.getGroupState(TEST_GROUP).mPendingLogCount);
@@ -729,11 +705,11 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(listener).onGloballyEnabled(false);
 
         /* Enable and send a new log. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
         channel.setEnabled(true);
         channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
         verify(ingestion).reopen();
         verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(listener).onGloballyEnabled(true);
@@ -764,7 +740,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     @Test
     public void initialLogs() throws IOException {
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
         Ingestion ingestion = mock(Ingestion.class);
         doThrow(new IOException()).when(ingestion).close();
         Persistence persistence = mock(Persistence.class);
@@ -781,8 +758,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
         verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(3, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
         verify(ingestion).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
@@ -790,7 +766,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     @Test
     public void initialLogsMoreThan1Batch() throws IOException {
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
         Ingestion ingestion = mock(Ingestion.class);
         doThrow(new IOException()).when(ingestion).close();
         Persistence persistence = mock(Persistence.class);
@@ -800,8 +777,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
         verify(ingestion, times(2)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(3, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
         verify(ingestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
@@ -809,7 +785,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     @Test
     public void initialLogsThenDisable() throws IOException {
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
         Ingestion ingestion = mock(Ingestion.class);
         doThrow(new IOException()).when(ingestion).close();
         Persistence persistence = mock(Persistence.class);
@@ -823,8 +800,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verify(mAppCenterHandler).removeCallbacks(any(Runnable.class));
         verify(ingestion).close();
         verify(persistence).deleteLogs(TEST_GROUP);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
         verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
     }
 
@@ -851,7 +827,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
     public void somehowDatabaseEmptiedAfterTimer() throws IOException {
 
         /* Cover the if (batchId != null) test though it could happen only if the database content disappear after the timer... */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
         Ingestion ingestion = mock(Ingestion.class);
         doThrow(new IOException()).when(ingestion).close();
         Persistence persistence = mock(Persistence.class);
@@ -860,8 +837,7 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, null);
         verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         assertEquals(2, channel.getGroupState(TEST_GROUP).mPendingLogCount);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
         verify(ingestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(BATCH_TIME_INTERVAL));
         verify(mAppCenterHandler, never()).removeCallbacks(any(Runnable.class));
@@ -1055,15 +1031,15 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         when(mockIngestion.sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class))).then(getSendAsyncAnswer());
 
         /* Prepare to mock timer. */
-        AtomicReference<Runnable> runnable = catchPostRunnable();
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+            when(mAppCenterHandler.postDelayed(delayedRunnable.capture(), anyLong())).thenReturn(true);
 
         /* Create channel. */
         DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
         channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
 
         /* Wait for timer. */
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
     }
 
     @Test
@@ -1102,6 +1078,34 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         verifyStatic();
         SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
         verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(CUSTOM_INTERVAL));
+    }
+
+    @Test
+    public void checkPendingLogsStoresStartTimeWhenPaused() {
+
+        /* Mock current time. */
+        long now = 1;
+        when(System.currentTimeMillis()).thenReturn(now);
+
+        /* Create channel and group. */
+        Persistence mockPersistence = mock(Persistence.class);
+        when(mockPersistence.countLogs(TEST_GROUP)).thenReturn(0);
+        AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion, mAppCenterHandler);
+        channel.addGroup(TEST_GROUP, 10, CUSTOM_INTERVAL, MAX_PARALLEL_BATCHES, mockIngestion, mock(Channel.GroupListener.class));
+        verifyStatic(never());
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), anyLong());
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
+
+        channel.pauseGroup(TEST_GROUP, null);
+        channel.enqueue(mock(Log.class), TEST_GROUP, Flags.DEFAULTS);
+
+        /* Verify that timer starts and current time is saved into preferences. */
+        verifyStatic();
+        SharedPreferencesManager.putLong(eq(START_TIMER_PREFIX + TEST_GROUP), eq(now));
+        verify(mockIngestion, never()).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+        verify(mAppCenterHandler, never()).postDelayed(any(Runnable.class), anyLong());
     }
 
     @Test
@@ -1242,7 +1246,6 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
         /* Prepare to mock timer. */
         long timeDelay = CUSTOM_INTERVAL - (now - startTimer);
-        AtomicReference<Runnable> runnable = catchPostRunnable(timeDelay);
 
         /* Enqueuing 200 events. */
         for (int i = 0; i < 200; i++) {
@@ -1250,13 +1253,13 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
         }
 
         /* Check invoke the timer with custom timestamp. */
-        verify(mAppCenterHandler).postDelayed(any(Runnable.class), eq(timeDelay));
+        ArgumentCaptor<Runnable> delayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        verify(mAppCenterHandler).postDelayed(delayedRunnable.capture(), eq(timeDelay));
 
         /* Wait for timer. */
         now = 12000;
         when(System.currentTimeMillis()).thenReturn(now);
-        assertNotNull(runnable.get());
-        runnable.get().run();
+        delayedRunnable.getValue().run();
 
         /* Check sending the logs batches. */
         verify(mockIngestion, times(3)).sendAsync(anyString(), anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Tracking an event with 1min interval / pause / resume after 30s / event is sent after 30s. Pausing doesn’t reset the timer. It’s probably fine since it's the same behavior if paused for any reasons like going to background on iOS or network down.
The issue is the behavior is different if the `trackEvent` happens while pausing; in this case the timer will wait for the entire latency. For instance: Pause / Tracking an event with 1min interval / resume after 30s / event is sent after 1min 30s.

## Related PRs or issues

[AB#62192](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62192)
