### PR TITLE
Fix etag being overwritten in cache

### DIFF
--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -149,6 +149,24 @@ public class LocalDocumentStorageAndroidTest {
     }
 
     @Test
+    public void offlineDeletePreservesEtagNullDocumentValue() {
+
+        /* Write document to the cache with an etag set. */
+        DocumentWrapper<Void> document = new DocumentWrapper<>(null, DefaultPartitions.USER_DOCUMENTS, ID, "etag", 0);
+        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions());
+        DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(createdDocument.getETag());
+        assertEquals("etag", createdDocument.getETag());
+
+        /* Delete document offline, etag should be replaced. */
+        boolean success = mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
+        assertTrue(success);
+        DocumentWrapper<Void> deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, Void.class, null);
+        assertNotNull(deletedDoc.getETag());
+        assertEquals("etag", deletedDoc.getETag());
+    }
+
+    @Test
     public void readExpiredDocument() {
 
         /* Write a document and mock device ttl to be already expired a few seconds ago. */

--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -110,6 +110,45 @@ public class LocalDocumentStorageAndroidTest {
     }
 
     @Test
+    public void offlineUpdatePreservesEtag() {
+
+        /* Write document to the cache with an etag set. */
+        DocumentWrapper<String> document = new DocumentWrapper<>(TEST_VALUE, DefaultPartitions.USER_DOCUMENTS, ID, "etag", 0);
+        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions());
+        DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(createdDocument.getETag());
+        assertEquals("etag", createdDocument.getETag());
+
+        /* Replace document offline, etag should be replaced. */
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, DefaultPartitions.APP_DOCUMENTS, ID, "value2", String.class, new WriteOptions());
+        DocumentWrapper<String> updatedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(updatedDoc.getETag());
+        assertEquals("etag", updatedDoc.getETag());
+    }
+
+    @Test
+    public void offlineDeletePreservesEtag() {
+
+        /* Delete a non-existant document offline, etag should be null. */
+        mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
+        DocumentWrapper<String> deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, null);
+        assertNull(deletedDoc.getETag());
+
+        /* Write document to the cache with an etag set. */
+        DocumentWrapper<String> document = new DocumentWrapper<>(TEST_VALUE, DefaultPartitions.USER_DOCUMENTS, ID, "etag", 0);
+        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions());
+        DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(createdDocument.getETag());
+        assertEquals("etag", createdDocument.getETag());
+
+        /* Delete document offline, etag should be replaced. */
+        mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
+        deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, null);
+        assertNotNull(deletedDoc.getETag());
+        assertEquals("etag", deletedDoc.getETag());
+    }
+
+    @Test
     public void readExpiredDocument() {
 
         /* Write a document and mock device ttl to be already expired a few seconds ago. */

--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -119,7 +119,7 @@ public class LocalDocumentStorageAndroidTest {
         assertNotNull(createdDocument.getETag());
         assertEquals("etag", createdDocument.getETag());
 
-        /* Replace document offline, etag should be not replaced. */
+        /* Replace document offline, etag should not be replaced. */
         mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, DefaultPartitions.APP_DOCUMENTS, ID, "value2", String.class, new WriteOptions());
         DocumentWrapper<String> updatedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
         assertNotNull(updatedDoc.getETag());
@@ -141,7 +141,7 @@ public class LocalDocumentStorageAndroidTest {
         assertNotNull(createdDocument.getETag());
         assertEquals("etag", createdDocument.getETag());
 
-        /* Delete document offline, etag should be not replaced. */
+        /* Delete document offline, etag should not be replaced. */
         mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
         deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, null);
         assertNotNull(deletedDoc.getETag());

--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -149,24 +149,6 @@ public class LocalDocumentStorageAndroidTest {
     }
 
     @Test
-    public void offlineDeletePreservesEtagNullDocumentValue() {
-
-        /* Write document to the cache with an etag set. */
-        DocumentWrapper<Void> document = new DocumentWrapper<>(null, DefaultPartitions.USER_DOCUMENTS, ID, "etag", 0);
-        mLocalDocumentStorage.writeOnline(USER_TABLE_NAME, document, new WriteOptions());
-        DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
-        assertNotNull(createdDocument.getETag());
-        assertEquals("etag", createdDocument.getETag());
-
-        /* Delete document offline, etag should be not replaced. */
-        boolean success = mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
-        assertTrue(success);
-        DocumentWrapper<Void> deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, Void.class, null);
-        assertNotNull(deletedDoc.getETag());
-        assertEquals("etag", deletedDoc.getETag());
-    }
-
-    @Test
     public void readExpiredDocument() {
 
         /* Write a document and mock device ttl to be already expired a few seconds ago. */

--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -119,7 +119,7 @@ public class LocalDocumentStorageAndroidTest {
         assertNotNull(createdDocument.getETag());
         assertEquals("etag", createdDocument.getETag());
 
-        /* Replace document offline, etag should be replaced. */
+        /* Replace document offline, etag should be not replaced. */
         mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, DefaultPartitions.APP_DOCUMENTS, ID, "value2", String.class, new WriteOptions());
         DocumentWrapper<String> updatedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, new ReadOptions());
         assertNotNull(updatedDoc.getETag());
@@ -141,7 +141,7 @@ public class LocalDocumentStorageAndroidTest {
         assertNotNull(createdDocument.getETag());
         assertEquals("etag", createdDocument.getETag());
 
-        /* Delete document offline, etag should be replaced. */
+        /* Delete document offline, etag should be not replaced. */
         mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
         deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, String.class, null);
         assertNotNull(deletedDoc.getETag());
@@ -158,7 +158,7 @@ public class LocalDocumentStorageAndroidTest {
         assertNotNull(createdDocument.getETag());
         assertEquals("etag", createdDocument.getETag());
 
-        /* Delete document offline, etag should be replaced. */
+        /* Delete document offline, etag should be not replaced. */
         boolean success = mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, new WriteOptions());
         assertTrue(success);
         DocumentWrapper<Void> deletedDoc = mLocalDocumentStorage.read(USER_TABLE_NAME, DefaultPartitions.USER_DOCUMENTS, ID, Void.class, null);

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -163,15 +163,11 @@ class LocalDocumentStorage {
         }
 
         /* The document cache has been expired, or the document did not exists, create it. */
-        DocumentWrapper<T> writeDocument;
-        long rowId;
-        if (cachedDocument.getError() != null) {
-            writeDocument = new DocumentWrapper<>(document, partition, documentId);
-            rowId = createOffline(table, writeDocument, writeOptions);
-        } else {
-            writeDocument = new DocumentWrapper<>(document, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
-            rowId = updateOffline(table, writeDocument, writeOptions);
-        }
+        DocumentWrapper<T> writeDocument = new DocumentWrapper<>(document, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
+        long rowId =
+                cachedDocument.getError() != null ?
+                        createOffline(table, writeDocument, writeOptions) :
+                        updateOffline(table, writeDocument, writeOptions);
         if (rowId < 0) {
             writeDocument = new DocumentWrapper<>(new DataException("Failed to write document into cache."));
         }

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -43,6 +43,11 @@ class LocalDocumentStorage {
     static final String FAILED_TO_READ_FROM_CACHE = "Failed to read from cache.";
 
     /**
+     * Error message when document failed to deserialize.
+     */
+    private static final String FAILED_TO_DESERIALIZE = "Failed to deserialize document.";
+
+    /**
      * Partition column.
      */
     private static final String PARTITION_COLUMN_NAME = "partition";
@@ -163,11 +168,15 @@ class LocalDocumentStorage {
         }
 
         /* The document cache has been expired, or the document did not exists, create it. */
-        DocumentWrapper<T> writeDocument = new DocumentWrapper<>(document, partition, documentId);
-        long rowId =
-                cachedDocument.getError() != null ?
-                        createOffline(table, writeDocument, writeOptions) :
-                        updateOffline(table, writeDocument, writeOptions);
+        DocumentWrapper<T> writeDocument;
+        long rowId;
+        if (cachedDocument.getError() != null) {
+            writeDocument = new DocumentWrapper<>(document, partition, documentId);
+            rowId = createOffline(table, writeDocument, writeOptions);
+        } else {
+            writeDocument = new DocumentWrapper<>(document, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
+            rowId = updateOffline(table, writeDocument, writeOptions);
+        }
         if (rowId < 0) {
             writeDocument = new DocumentWrapper<>(new DataException("Failed to write document into cache."));
         }
@@ -206,7 +215,13 @@ class LocalDocumentStorage {
      * @return true if storage update succeeded, false otherwise.
      */
     boolean deleteOffline(String table, String partition, String documentId, WriteOptions writeOptions) {
-        DocumentWrapper<Void> writeDocument = new DocumentWrapper<>(null, partition, documentId);
+        DocumentWrapper<Void> cachedDocument = read(table, partition, documentId, Void.class, null);
+        DocumentWrapper<Void> writeDocument;
+        if (cachedDocument.getError() != null && !cachedDocument.getError().getMessage().equals(FAILED_TO_DESERIALIZE)) {
+            writeDocument = new DocumentWrapper<>(null, partition, documentId);
+        } else {
+            writeDocument = new DocumentWrapper<>(null, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
+        }
         return write(table, writeDocument, writeOptions, PENDING_OPERATION_DELETE_VALUE) > 0;
     }
 

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -32,7 +32,6 @@ import static com.microsoft.appcenter.data.Constants.PENDING_OPERATION_CREATE_VA
 import static com.microsoft.appcenter.data.Constants.PENDING_OPERATION_DELETE_VALUE;
 import static com.microsoft.appcenter.data.DefaultPartitions.APP_DOCUMENTS;
 import static com.microsoft.appcenter.data.DefaultPartitions.USER_DOCUMENTS;
-import static com.microsoft.appcenter.data.Utils.FAILED_TO_DESERIALIZE_DOCUMENT;
 
 @WorkerThread
 class LocalDocumentStorage {
@@ -212,12 +211,7 @@ class LocalDocumentStorage {
      */
     boolean deleteOffline(String table, String partition, String documentId, WriteOptions writeOptions) {
         DocumentWrapper<Void> cachedDocument = read(table, partition, documentId, Void.class, null);
-        DocumentWrapper<Void> writeDocument;
-        if (cachedDocument.getError() != null && !cachedDocument.getError().getMessage().equals(FAILED_TO_DESERIALIZE_DOCUMENT)) {
-            writeDocument = new DocumentWrapper<>(null, partition, documentId);
-        } else {
-            writeDocument = new DocumentWrapper<>(null, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
-        }
+        DocumentWrapper<Void> writeDocument = new DocumentWrapper<>(null, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());
         return write(table, writeDocument, writeOptions, PENDING_OPERATION_DELETE_VALUE) > 0;
     }
 

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -32,6 +32,7 @@ import static com.microsoft.appcenter.data.Constants.PENDING_OPERATION_CREATE_VA
 import static com.microsoft.appcenter.data.Constants.PENDING_OPERATION_DELETE_VALUE;
 import static com.microsoft.appcenter.data.DefaultPartitions.APP_DOCUMENTS;
 import static com.microsoft.appcenter.data.DefaultPartitions.USER_DOCUMENTS;
+import static com.microsoft.appcenter.data.Utils.FAILED_TO_DESERIALIZE_DOCUMENT;
 
 @WorkerThread
 class LocalDocumentStorage {
@@ -41,11 +42,6 @@ class LocalDocumentStorage {
      */
     @VisibleForTesting
     static final String FAILED_TO_READ_FROM_CACHE = "Failed to read from cache.";
-
-    /**
-     * Error message when document failed to deserialize.
-     */
-    private static final String FAILED_TO_DESERIALIZE = "Failed to deserialize document.";
 
     /**
      * Partition column.
@@ -217,7 +213,7 @@ class LocalDocumentStorage {
     boolean deleteOffline(String table, String partition, String documentId, WriteOptions writeOptions) {
         DocumentWrapper<Void> cachedDocument = read(table, partition, documentId, Void.class, null);
         DocumentWrapper<Void> writeDocument;
-        if (cachedDocument.getError() != null && !cachedDocument.getError().getMessage().equals(FAILED_TO_DESERIALIZE)) {
+        if (cachedDocument.getError() != null && !cachedDocument.getError().getMessage().equals(FAILED_TO_DESERIALIZE_DOCUMENT)) {
             writeDocument = new DocumentWrapper<>(null, partition, documentId);
         } else {
             writeDocument = new DocumentWrapper<>(null, partition, documentId, cachedDocument.getETag(), System.currentTimeMillis());

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
@@ -48,6 +48,11 @@ import static com.microsoft.appcenter.data.DefaultPartitions.USER_DOCUMENTS;
 
 public class Utils {
 
+    /**
+     * Error message when a document cannot be deserialized.
+     */
+    static final String FAILED_TO_DESERIALIZE_DOCUMENT = "Failed to deserialize document.";
+
     private static final Gson sGson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).create();
 
     private static final JsonParser sParser = new JsonParser();
@@ -111,7 +116,7 @@ public class Utils {
         JsonElement eTag = obj.get(ETAG_FIELD_NAME);
         JsonElement timestamp = obj.get(TIMESTAMP_FIELD_NAME);
         if (partition == null || documentId == null || timestamp == null) {
-            return new DocumentWrapper<>(new DataException("Failed to deserialize document."));
+            return new DocumentWrapper<>(new DataException(FAILED_TO_DESERIALIZE_DOCUMENT));
         }
         return parseDocument(
                 document,
@@ -129,7 +134,7 @@ public class Utils {
             try {
                 document = sGson.fromJson(documentObject, documentType);
             } catch (JsonParseException exception) {
-                error = new DataException("Failed to deserialize document.", exception);
+                error = new DataException(FAILED_TO_DESERIALIZE_DOCUMENT, exception);
             }
         }
         return new DocumentWrapper<>(

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
@@ -48,11 +48,6 @@ import static com.microsoft.appcenter.data.DefaultPartitions.USER_DOCUMENTS;
 
 public class Utils {
 
-    /**
-     * Error message when a document cannot be deserialized.
-     */
-    static final String FAILED_TO_DESERIALIZE_DOCUMENT = "Failed to deserialize document.";
-
     private static final Gson sGson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).create();
 
     private static final JsonParser sParser = new JsonParser();
@@ -116,7 +111,7 @@ public class Utils {
         JsonElement eTag = obj.get(ETAG_FIELD_NAME);
         JsonElement timestamp = obj.get(TIMESTAMP_FIELD_NAME);
         if (partition == null || documentId == null || timestamp == null) {
-            return new DocumentWrapper<>(new DataException(FAILED_TO_DESERIALIZE_DOCUMENT));
+            return new DocumentWrapper<>(new DataException("Failed to deserialize document."));
         }
         return parseDocument(
                 document,
@@ -134,7 +129,7 @@ public class Utils {
             try {
                 document = sGson.fromJson(documentObject, documentType);
             } catch (JsonParseException exception) {
-                error = new DataException(FAILED_TO_DESERIALIZE_DOCUMENT, exception);
+                error = new DataException("Failed to deserialize document.", exception);
             }
         }
         return new DocumentWrapper<>(

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
@@ -215,6 +215,7 @@ public class LocalDocumentStorageTest {
     @Test
     public void deleteDocumentOfflineSucceeds() {
         when(mDatabaseManager.replace(anyString(), any(ContentValues.class))).thenReturn(1L);
+        when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenReturn(mCursor);
         DocumentWrapper<Void> wrapper = new DocumentWrapper<>(null, PARTITION, DOCUMENT_ID);
         assertTrue(mLocalDocumentStorage.deleteOffline(mUserTableName, wrapper, new WriteOptions()));
         assertTrue(wrapper.isFromDeviceCache());
@@ -235,6 +236,7 @@ public class LocalDocumentStorageTest {
     @Test
     public void deleteOfflineFails() {
         when(mDatabaseManager.replace(anyString(), any(ContentValues.class))).thenReturn(-1L);
+        when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenReturn(mCursor);
         boolean isSuccess = mLocalDocumentStorage.deleteOffline(mUserTableName, PARTITION, DOCUMENT_ID, new WriteOptions());
         ArgumentCaptor<ContentValues> argumentCaptor = ArgumentCaptor.forClass(ContentValues.class);
         verify(mDatabaseManager).replace(eq(mUserTableName), argumentCaptor.capture());
@@ -245,6 +247,7 @@ public class LocalDocumentStorageTest {
     @Test
     public void deleteOfflineSucceeds() {
         when(mDatabaseManager.replace(anyString(), any(ContentValues.class))).thenReturn(1L);
+        when(mDatabaseManager.getCursor(anyString(), any(SQLiteQueryBuilder.class), any(String[].class), any(String[].class), anyString())).thenReturn(mCursor);
         boolean isSuccess = mLocalDocumentStorage.deleteOffline(mUserTableName, PARTITION, DOCUMENT_ID, new WriteOptions());
         ArgumentCaptor<ContentValues> argumentCaptor = ArgumentCaptor.forClass(ContentValues.class);
         verify(mDatabaseManager).replace(eq(mUserTableName), argumentCaptor.capture());


### PR DESCRIPTION

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Bugfix so that on offline update and delete, any previous cached etag value will not be overwritten.

## Related PRs or issues

[AB#61109](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61109)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
