### PR TITLE
 Fix signin before start auth never ends and blocks every next try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * **[Feature]** Expose the ID Token and Access Token (as raw JWT format) in the `UserInformation` object returned from the sign-in method.
 * **[Fix]** Fix missing proguard rules so that the app does not have to specify them.
 * **[Fix]** Fix crash on silently refreshing token if initialization of MSAL fails.
+* **[Fix]** Fix sign-in before start auth service never ends and blocks every next try.
 * **[Breaking change]** The `UserInformation` class has been moved from the `appcenter` module to the `appcenter-auth` module and must now be imported as `import com.microsoft.appcenter.auth.UserInformation`.
 
 ### App Center Data

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -482,21 +482,13 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             mLastRefreshFuture.complete(new SignInResult(null, new CancellationException()));
         }
         mLastSignInFuture = future;
-        Runnable disabledRunnable = new Runnable() {
-
-            @Override
-            public void run() {
-                future.complete(new SignInResult(null, new IllegalStateException("Auth is disabled.")));
-                mLastSignInFuture = null;
-            }
-        };
-        post(new Runnable() {
+        postAsyncGetter(new Runnable() {
 
             @Override
             public void run() {
                 selectSignInTypeAndSignIn(future);
             }
-        }, disabledRunnable, disabledRunnable);
+        }, future, new SignInResult(null, new IllegalStateException("Auth is disabled.")));
         return future;
     }
 

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -487,6 +487,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             @Override
             public void run() {
                 future.complete(new SignInResult(null, new IllegalStateException("Auth is disabled.")));
+                mLastSignInFuture = null;
             }
         };
         post(new Runnable() {

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -351,7 +351,7 @@ public class AuthTest extends AbstractAuthTest {
     }
 
     @Test
-    public void getLastSessionCrashReportWithMultipleListenersAndResultIsNullBeforeInit() {
+    public void signInIsCalledBeforeStart() {
         Auth auth = Auth.getInstance();
 
         @SuppressWarnings("unchecked")

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -23,6 +23,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.UUIDUtils;
+import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.storage.FileManager;
@@ -42,6 +43,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -346,6 +348,24 @@ public class AuthTest extends AbstractAuthTest {
         verifyStatic(never());
         String configPayload = jsonConfig.toString();
         FileManager.write(notNull(File.class), eq(configPayload));
+    }
+
+    @Test
+    public void getLastSessionCrashReportWithMultipleListenersAndResultIsNullBeforeInit() {
+        Auth auth = Auth.getInstance();
+
+        @SuppressWarnings("unchecked")
+        AppCenterConsumer<SignInResult> callback = (AppCenterConsumer<SignInResult>) Mockito.mock(AppCenterConsumer.class);
+
+        /* Call twice for multiple callbacks before initialize. */
+        Auth.signIn().thenAccept(callback);
+        Auth.signIn().thenAccept(callback);
+        start(auth);
+
+        SignInResult result = Auth.signIn().get();
+        assertNotNull(result.getException());
+        assertTrue(result.getException() instanceof IllegalStateException);
+        verify(callback, times(2)).accept(any(SignInResult.class));
     }
 
     @Test


### PR DESCRIPTION
* [X] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [X] Did you check UI tests on the sample app? They are not executed on CI.

## Description

If you call sign-in before Auth service is started, next time it will fail.

# Misc
[AB#62968](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62968)