### PR TITLE
Upgrade android Data DB schema version

### DIFF
--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -8,6 +8,7 @@ package com.microsoft.appcenter.data;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
@@ -87,7 +88,7 @@ class LocalDocumentStorage {
     /**
      * Current version of the schema.
      */
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
 
     /**
      * `Where` clause to select by partition and document ID.
@@ -103,8 +104,14 @@ class LocalDocumentStorage {
 
     private final DatabaseManager mDatabaseManager;
 
-    LocalDocumentStorage(Context context, String userTable) {
-        mDatabaseManager = new DatabaseManager(context, DATABASE, READONLY_TABLE, VERSION, SCHEMA, new DatabaseManager.DefaultListener());
+    LocalDocumentStorage(Context context, final String userTable) {
+        mDatabaseManager = new DatabaseManager(
+                context,
+                DATABASE,
+                READONLY_TABLE,
+                VERSION,
+                SCHEMA,
+                new LocalDocumentStorageDatabaseListener(userTable));
         if (userTable != null) {
             createTableIfDoesNotExist(userTable);
         }
@@ -416,5 +423,36 @@ class LocalDocumentStorage {
         }
         AppCenterLog.debug(LOG_TAG, "Document was found in the cache, but it was expired. The cached document has been invalidated.");
         return new DocumentWrapper<>(new DataException("Document was not found in the cache."));
+    }
+}
+
+class LocalDocumentStorageDatabaseListener implements DatabaseManager.Listener {
+
+    private String userTable;
+
+    LocalDocumentStorageDatabaseListener(String userTable) {
+        this.userTable = userTable;
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+    }
+
+    @Override
+    public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        /*
+            Between versions 1 and 2 we need to drop both user and readonly tables
+            because we discovered we had been doing inserts instead of upserts into the cache in the original SDK release.
+            Dropping the table will allow to clean up what essentially are duplicate rows
+            (the same partition and document ID, but different `oid`).
+         */
+        if (oldVersion == 1 && newVersion == 2 && userTable != null) {
+            SQLiteUtils.dropTable(db, userTable);
+
+            /* Returning false here so that the default table gets deleted by `DatabaseManager` */
+            return false;
+        }
+
+        return true;
     }
 }

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -104,7 +104,7 @@ class LocalDocumentStorage {
 
     private final DatabaseManager mDatabaseManager;
 
-    LocalDocumentStorage(Context context, final String userTable) {
+    LocalDocumentStorage(Context context, String userTable) {
         mDatabaseManager = new DatabaseManager(
                 context,
                 DATABASE,
@@ -428,10 +428,10 @@ class LocalDocumentStorage {
 
 class LocalDocumentStorageDatabaseListener implements DatabaseManager.Listener {
 
-    private String userTable;
+    private String mUserTable;
 
     LocalDocumentStorageDatabaseListener(String userTable) {
-        this.userTable = userTable;
+        mUserTable = userTable;
     }
 
     @Override
@@ -440,16 +440,17 @@ class LocalDocumentStorageDatabaseListener implements DatabaseManager.Listener {
 
     @Override
     public boolean onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+
         /*
             Between versions 1 and 2 we need to drop both user and readonly tables
             because we discovered we had been doing inserts instead of upserts into the cache in the original SDK release.
             Dropping the table will allow to clean up what essentially are duplicate rows
             (the same partition and document ID, but different `oid`).
          */
-        if (oldVersion == 1 && newVersion == 2 && userTable != null) {
-            SQLiteUtils.dropTable(db, userTable);
+        if (oldVersion == 1 && mUserTable != null) {
+            SQLiteUtils.dropTable(db, mUserTable);
 
-            /* Returning false here so that the default table gets deleted by `DatabaseManager` */
+            /* Returning false here so that the default table gets deleted by `DatabaseManager`. */
             return false;
         }
 

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
@@ -301,14 +301,10 @@ public class LocalDocumentStorageTest {
     @Test
     public void localDocumentStorageDatabaseListenerTests() {
         String userTableName = "UserTable";
-        localDocumentStorageDatabaseListenerTest(0, 1, null, false, true);
-        localDocumentStorageDatabaseListenerTest(0, 1, userTableName, false, true);
-        localDocumentStorageDatabaseListenerTest(1, 1, null, false, true);
-        localDocumentStorageDatabaseListenerTest(1, 1, userTableName, false, true);
         localDocumentStorageDatabaseListenerTest(1, 2, null, false, true);
         localDocumentStorageDatabaseListenerTest(1, 2, userTableName, true, false);
-        localDocumentStorageDatabaseListenerTest(2, 2, null, false, true);
-        localDocumentStorageDatabaseListenerTest(2, 2, userTableName, false, true);
+        localDocumentStorageDatabaseListenerTest(2, 3, null, false, true);
+        localDocumentStorageDatabaseListenerTest(2, 3, userTableName, false, true);
     }
 
     private void localDocumentStorageDatabaseListenerTest(int oldVersion, int newVersion, String userTableName, boolean expectTableDrop, boolean expectedOnUpgradeResult) {
@@ -316,11 +312,11 @@ public class LocalDocumentStorageTest {
         LocalDocumentStorageDatabaseListener listener =
                 new LocalDocumentStorageDatabaseListener(userTableName);
 
-        /* Verify no interactions in `onCreate` */
+        /* Verify no interactions in `onCreate`. */
         listener.onCreate(db);
         verifyZeroInteractions(db);
 
-        /* Verify `onUpgrade` */
+        /* Verify `onUpgrade`. */
         boolean onUpgradeResult = listener.onUpgrade(db, oldVersion, newVersion);
         if (expectTableDrop) {
             verify(db).execSQL(eq(SQLiteUtils.formatDropTableQuery(userTableName)));

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/DatabaseManager.java
@@ -120,7 +120,7 @@ public class DatabaseManager implements Closeable {
 
                 /* Upgrade by destroying the old table unless managed. */
                 if (!mListener.onUpgrade(db, oldVersion, newVersion)) {
-                    dropTable(db, mDefaultTable);
+                    SQLiteUtils.dropTable(db, mDefaultTable);
                     onCreate(db);
                 }
             }
@@ -165,10 +165,6 @@ public class DatabaseManager implements Closeable {
             }
         }
         return values;
-    }
-
-    private void dropTable(@NonNull SQLiteDatabase db, @NonNull String table) {
-        db.execSQL(String.format("DROP TABLE `%s`", table));
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/SQLiteUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/SQLiteUtils.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.appcenter.utils.storage;
 
+import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.support.annotation.NonNull;
 
@@ -13,5 +14,14 @@ public class SQLiteUtils {
     @NonNull
     public static SQLiteQueryBuilder newSQLiteQueryBuilder() {
         return new SQLiteQueryBuilder();
+    }
+
+    public static void dropTable(@NonNull SQLiteDatabase db, @NonNull String table) {
+        db.execSQL(formatDropTableQuery(table));
+    }
+
+    @NonNull
+    public static String formatDropTableQuery(@NonNull String table) {
+        return String.format("DROP TABLE `%s`", table);
     }
 }


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

We need to drop both user and readonly tables because we discovered we had been doing inserts instead of upserts into the cache in the original SDK release. Dropping the table will allow to clean up what essentially are duplicate rows (the same partition and document ID, but different `oid`).
