### PR TITLE
Serialize null values in DocumentWrapper.

### DIFF
--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Utils.java
@@ -50,7 +50,7 @@ import static com.microsoft.appcenter.data.DefaultPartitions.USER_DOCUMENTS;
 
 public class Utils {
 
-    private static final Gson sGson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).create();
+    private static final Gson sGson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).serializeNulls().create();
 
     private static final JsonParser sParser = new JsonParser();
 
@@ -139,14 +139,14 @@ public class Utils {
         JsonElement documentId = obj.get(ID_FIELD_NAME);
         JsonElement eTag = obj.get(ETAG_FIELD_NAME);
         JsonElement timestamp = obj.get(TIMESTAMP_FIELD_NAME);
-        if (partition == null || documentId == null || timestamp == null) {
+        if (isNullOrJsonNull(partition) || isNullOrJsonNull(documentId) || isNullOrJsonNull(timestamp)) {
             return new DocumentWrapper<>(new DataException("Failed to deserialize document."));
         }
         return parseDocument(
                 document,
                 partition.getAsString(),
                 documentId.getAsString(),
-                eTag != null ? eTag.getAsString() : null,
+                !isNullOrJsonNull(eTag) ? eTag.getAsString() : null,
                 timestamp.getAsLong(),
                 documentType);
     }
@@ -167,6 +167,10 @@ public class Utils {
                 documentId,
                 eTag,
                 lastUpdatedTime, error);
+    }
+
+    private static boolean isNullOrJsonNull(JsonElement value) {
+        return value == null || value.isJsonNull();
     }
 
     public static <T> Page<T> parseDocuments(String cosmosDbPayload, Class<T> documentType) {

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/models/DocumentWrapper.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/models/DocumentWrapper.java
@@ -115,18 +115,18 @@ public class DocumentWrapper<T> extends DocumentMetadata {
     }
 
     /**
-     * Get the document in its JSON form.
+     * Get the document value in its JSON form.
      *
-     * @return The document in its JSON form.
+     * @return The document value in its JSON form.
      */
     public String getJsonValue() {
         return mDocument == null ? null : Utils.getGson().toJson(mDocument);
     }
 
     /**
-     * Get the document in string.
+     * Get the document wrapper as a string.
      *
-     * @return Serialized document.
+     * @return Serialized document wrapper.
      */
     @NonNull
     @Override

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/UtilsTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/UtilsTest.java
@@ -14,6 +14,8 @@ import com.microsoft.appcenter.data.models.TokenResult;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,9 +40,38 @@ public class UtilsTest {
     }
 
     @Test
-    public void canParseWhenDocumentNull() {
+    public void canParseWhenWrapperIsNull() {
         DocumentWrapper<TestDocument> document = Utils.parseDocument(null, TestDocument.class);
         assertNotNull(document.getError());
+    }
+
+    @Test
+    public void canParseWhenDocumentIsNull() {
+        DocumentWrapper<String> wrapper = new DocumentWrapper<>(null, "partition", "doc_id");
+        String serializedDocument = wrapper.getJsonValue();
+        String serializedWrapper = wrapper.toString();
+        DocumentWrapper<String> deserializedWrapper = Utils.parseDocument(serializedWrapper, String.class);
+
+        assertNull(serializedDocument);
+        assertTrue(serializedWrapper.contains("\"document\":null"));
+        assertNull(deserializedWrapper.getDeserializedValue());
+    }
+
+    @Test
+    public void canParseWhenDocumentHasNullValues() {
+        Map<String, String> doc = new HashMap<>();
+        //noinspection ConstantConditions
+        doc.put("key", null);
+        DocumentWrapper<Map<String, String>> wrapper = new DocumentWrapper<>(doc, "partition", "doc_id");
+        String serializedDocument = wrapper.getJsonValue();
+        String serializedWrapper = wrapper.toString();
+        DocumentWrapper<Map> deserializedWrapper = Utils.parseDocument(serializedWrapper, Map.class);
+        Map deserializedDoc = deserializedWrapper.getDeserializedValue();
+
+        assertEquals("{\"key\":null}", serializedDocument);
+        assertTrue(serializedWrapper.contains("\"document\":{\"key\":null}"));
+        assertEquals(doc, deserializedDoc);
+
     }
 
     @Test


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

By default, fields with a null value are excluded from serialization. This change serializes those fields as `null`.

## Related PRs or issues

[AB#63856](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63856)
