### PR TITLE
Fix error report and cache being cleared on disabling Crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * **[Fix]** Check for running in App Center Test will now work when using AndroidX instead of the support library.
 * **[Feature]** Add `AppCenter.isRunningInAppCenterTestCloud` to provide method to check if the application is running in Test Cloud.
 
+### App Center Crashes
+
+* **[Fix]** The in memory cache of error reports is now cleared when disabling Crashes.
+
 ### App Center Data
 
 * **[Feature]** Add support for offline list of documents.

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -194,6 +194,16 @@ public class CrashesAndroidTest {
         Throwable lastThrowable = errorReport.getThrowable();
         assertTrue(lastThrowable instanceof IllegalArgumentException);
         assertTrue(Crashes.hasCrashedInLastSession().get());
+
+        /* Disable SDK, that will clear the report. */
+        Crashes.setEnabled(false).get();
+        errorReport = Crashes.getLastSessionCrashReport().get();
+        assertNull(errorReport);
+
+        /* The report must not be restored after re-enabling. */
+        Crashes.setEnabled(true).get();
+        errorReport = Crashes.getLastSessionCrashReport().get();
+        assertNull(errorReport);
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -358,6 +358,8 @@ public class Crashes extends AbstractAppCenterService {
     protected synchronized void applyEnabledState(boolean enabled) {
         initialize();
         if (!enabled) {
+
+            /* Delete all files. */
             for (File file : ErrorLogHelper.getErrorStorageDirectory().listFiles()) {
                 AppCenterLog.debug(LOG_TAG, "Deleting file " + file);
                 if (!file.delete()) {
@@ -365,6 +367,10 @@ public class Crashes extends AbstractAppCenterService {
                 }
             }
             AppCenterLog.info(LOG_TAG, "Deleted crashes local files");
+
+            /* Delete cache and in memory last session report. */
+            mErrorReportCache.clear();
+            mLastSessionErrorReport = null;
         }
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Related PRs or issues

[AB#63924](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63924)