### PR TITLE
Fix gradle dependencies for Data module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * **[Fix]** Fix `isExpired` method in `LocalDocument` for incorrect handling of the `TimeToLive.INFINITE` value. 
 * **[Feature]** Add `ReadOptions` parameter to the `list` API.
 * **[Feature]** Serialize `null` document values.
+* **[Fix]** Fix declaring `gson` as a build time dependency instead of runtime.
 
 ## Version 2.1.0
 

--- a/sdk/appcenter-data/build.gradle
+++ b/sdk/appcenter-data/build.gradle
@@ -9,6 +9,6 @@ evaluationDependsOn(':sdk')
 dependencies {
     api project(':sdk:appcenter')
 
-    implementation 'com.google.code.gson:gson:2.8.5'
+    api 'com.google.code.gson:gson:2.8.5'
 }
 


### PR DESCRIPTION
When used without Auth and if the app does not have gson, it would not
pull gson in the app binary before the change.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix gradle dependencies for Data module