### PR TITLE
Hide redirect uri in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.2.1 (Under development)
 
-### App Center
+### App Center Auth
 
 * **[Fix]** Redirect URIs are now hidden in logs.
 ___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 2.2.1 (Under development)
 
+### App Center
+
+* **[Fix]** Redirect URIs are now hidden in logs.
 ___
 
 ## Version 2.2.0

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClientCallTask.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClientCallTask.java
@@ -96,6 +96,11 @@ class DefaultHttpClientCallTask extends AsyncTask<Void, Void, Object> {
      */
     private static final Pattern TOKEN_REGEX_JSON = Pattern.compile("token\":\"[^\"]+\"");
 
+    /**
+     * Pattern used to replace redirect URI in json responses.
+     */
+    private static final Pattern REDIRECT_URI_REGEX_JSON = Pattern.compile("redirect_uri\":\"[^\"]+\"");
+
     private final String mUrl;
 
     private final String mMethod;
@@ -295,6 +300,7 @@ class DefaultHttpClientCallTask extends AsyncTask<Void, Void, Object> {
                 String logPayload;
                 if (contentType == null || contentType.startsWith("text/") || contentType.startsWith("application/")) {
                     logPayload = TOKEN_REGEX_JSON.matcher(response).replaceAll("token\":\"***\"");
+                    logPayload = REDIRECT_URI_REGEX_JSON.matcher(logPayload).replaceAll("redirect_uri\":\"***\"");
                 } else {
                     logPayload = "<binary>";
                 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?

## Description

Redirect URIs were being shown when making calls to auth tenants.  These contain the App Secret, which is not a security credential, but we hide in other logs containing it.  The redirect URI is now completely hidden in logs

## Misc

[AB#65967](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/65967)
