### PR TITLE
Fix delayed start push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.2.1 (Under development)
 
+### App Center Push
+
+* **[Fix]** Fix sending the push installation log after delayed start.
+
 ___
 
 ## Version 2.2.0

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -271,16 +271,27 @@ public class Push extends AbstractAppCenterService {
      */
     @SuppressWarnings("WeakerAccess") /* protected so that Xamarin can use it. */
     protected synchronized void onTokenRefresh(final String pushToken) {
-        if (pushToken != null && !pushToken.equals(mLatestPushToken)) {
-            AppCenterLog.debug(LOG_TAG, "Push token refreshed: " + pushToken);
-            mLatestPushToken = pushToken;
+        Runnable disabledRunnable = new Runnable() {
+
+            @Override
+            public void run() {
+                AppCenterLog.debug(LOG_TAG, "Push token refreshed before start/enabled, ignoring.");
+            }
+        };
+        if (mContext == null) {
+            disabledRunnable.run();
+        } else {
             post(new Runnable() {
 
                 @Override
                 public void run() {
-                    enqueuePushInstallationLog(pushToken);
+                    if (pushToken != null && !pushToken.equals(mLatestPushToken)) {
+                        AppCenterLog.debug(LOG_TAG, "Push token refreshed: " + pushToken);
+                        mLatestPushToken = pushToken;
+                        enqueuePushInstallationLog(pushToken);
+                    }
                 }
-            });
+            }, disabledRunnable, disabledRunnable);
         }
     }
 

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -271,16 +271,16 @@ public class Push extends AbstractAppCenterService {
      */
     @SuppressWarnings("WeakerAccess") /* protected so that Xamarin can use it. */
     protected synchronized void onTokenRefresh(final String pushToken) {
-        Runnable disabledRunnable = new Runnable() {
-
-            @Override
-            public void run() {
-                AppCenterLog.debug(LOG_TAG, "Push token refreshed before start/enabled, ignoring.");
-            }
-        };
         if (mContext == null) {
-            disabledRunnable.run();
+            AppCenterLog.debug(LOG_TAG, "Token refreshed before Push has been started, ignoring.");
         } else {
+            Runnable disabledRunnable = new Runnable() {
+
+                @Override
+                public void run() {
+                    AppCenterLog.debug(LOG_TAG, "Token refreshed while Push being disabled, ignoring.");
+                }
+            };
             post(new Runnable() {
 
                 @Override

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
@@ -1053,6 +1053,33 @@ public class PushTest {
         verify(channel).enqueue(any(PushInstallationLog.class), eq(push.getGroupName()), anyInt());
     }
 
+    @Test
+    public void tokenReceivedWhileDisabled() {
+
+        /* Start and disable. */
+        Push push = Push.getInstance();
+        Channel channel = mock(Channel.class);
+        start(push, channel);
+        Push.setEnabled(false).get();
+
+        /* Get token via callback. */
+        String testToken = "TEST";
+        push.onTokenRefresh(testToken);
+
+        /* Check the token received while being disabled has been ignored. */
+        verify(channel, never()).enqueue(any(PushInstallationLog.class), eq(push.getGroupName()), anyInt());
+
+        /* Enable. */
+        Push.setEnabled(true);
+
+        /* Get token will be called and we send the token. */
+        verify(mFirebaseInstanceIdResult, times(2)).addOnSuccessListener(mFirebaseInstanceIdSuccessListener.capture());
+        InstanceIdResult result = mock(InstanceIdResult.class);
+        when(result.getToken()).thenReturn(testToken);
+        mFirebaseInstanceIdSuccessListener.getValue().onSuccess(result);
+        verify(channel).enqueue(any(PushInstallationLog.class), eq(push.getGroupName()), anyInt());
+    }
+
     private static Intent createPushIntent(String title, String message, final Map<String, String> customData) {
         mockStatic(PushIntentUtils.class);
         Intent pushIntentMock = mock(Intent.class);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Noticed this while testing something on React Native. Firebase now initialize on its own and can trigger the token update before AppCenter is initialized (which is especially visible with delayed push scenario). And we have an optimization not to send the same token twice but it was used before checking for started/enabled...