### PR TITLE
Fix log url for skip start scenario

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -121,6 +121,7 @@ public class MainActivity extends AppCompatActivity {
         switch (StartType.valueOf(startType)) {
             case TARGET:
             case NO_SECRET:
+            case SKIP_START:
                 return context.getString(R.string.log_url_one_collector);
         }
         return context.getString(R.string.log_url);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Use INT version of the app (projectDependency)
Start with skip start.
Send an event to transmission target 2.
Expected: using one collector.
Actual: Using app center url.

This PR fixes the behavior to be the expected one.
