### PR TITLE
Fix proguard in sasquatch for property reflection

### DIFF
--- a/apps/sasquatch/proguard-rules.pro
+++ b/apps/sasquatch/proguard-rules.pro
@@ -2,3 +2,6 @@
 -keepclasseswithmembers class com.microsoft.appcenter.ingestion.models.Device {
    public ** get*();
 }
+-keepclasseswithmembers class com.microsoft.appcenter.analytics.PropertyConfigurator {
+   private ** get*();
+}


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Found by test team.
Click override common schema on a proguard enabled app build: crash.