### PR TITLE
Fix proguard config for event shared properties

### DIFF
--- a/apps/sasquatch/proguard-rules.pro
+++ b/apps/sasquatch/proguard-rules.pro
@@ -2,6 +2,24 @@
 -keepclasseswithmembers class com.microsoft.appcenter.ingestion.models.Device {
    public ** get*();
 }
+-keepclasseswithmembers class com.microsoft.appcenter.analytics.EventProperties {
+   ** getProperties();
+}
 -keepclasseswithmembers class com.microsoft.appcenter.analytics.PropertyConfigurator {
    private ** get*();
+   private ** mEventProperties;
+}
+-keepclasseswithmembers class * extends com.microsoft.appcenter.ingestion.models.properties.TypedProperty {
+   ** getValue();
+}
+
+# For some reason the previous rule doesn't work with primitive getValue return type
+-keepclasseswithmembers class com.microsoft.appcenter.ingestion.models.properties.BooleanTypedProperty {
+   public boolean getValue();
+}
+-keepclasseswithmembers class com.microsoft.appcenter.ingestion.models.properties.LongTypedProperty {
+   public long getValue();
+}
+-keepclasseswithmembers class com.microsoft.appcenter.ingestion.models.properties.DoubleTypedProperty {
+   public double getValue();
 }

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/EventPropertiesActivity.java
@@ -129,7 +129,7 @@ public class EventPropertiesActivity extends AppCompatActivity {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
     private void updatePropertyList() {
         try {
             Field field = getSelectedTarget().getPropertyConfigurator().getClass().getDeclaredField("mEventProperties");


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

App was crashing when configuring event shared properties in test app UI if proguard was enabled.