### PR TITLE
Revert "setRemoteOperationListener is not documented"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ ___
 ### App Center Data
 
 * **[Fix]** Fix an issue where invalid characters in the document ID are accepted at creation time but causing errors while trying to read or delete the document. The characters are `#`, `\`, `/`, `?`, and all whitespaces.
-* **[Feature]** `setRemoteOperationListener` method allows to be notified of a pending operation being executed when a client device goes from offline to online.
 
 ### App Center Crashes
 


### PR DESCRIPTION
Reverts microsoft/appcenter-sdk-android#1238

Contrary to Apple, this has always been there in Data module in Android.