### PR TITLE
Implement validation for having only 1 token refresh listener

### DIFF
--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -165,7 +165,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     /**
      * The listener to catch if a token needs to be refreshed.
      */
-    private final AuthTokenContext.RefreshListener mAuthTokenContextUpdateListener = new AuthTokenContext.RefreshListener() {
+    private final AuthTokenContext.RefreshListener mAuthTokenContextRefreshListener = new AuthTokenContext.RefreshListener() {
 
         @Override
         public void onTokenRequiresRefresh(String homeAccountId) {
@@ -264,7 +264,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     @Override
     protected synchronized void applyEnabledState(boolean enabled) {
         if (enabled) {
-            AuthTokenContext.getInstance().setRefreshListener(mAuthTokenContextUpdateListener);
+            AuthTokenContext.getInstance().setRefreshListener(mAuthTokenContextRefreshListener);
             NetworkStateHelper.getSharedInstance(mContext).addListener(this);
 
             /* Load cached configuration in case APIs are called early. */
@@ -273,7 +273,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             /* Download the latest configuration in background. */
             downloadConfiguration();
         } else {
-            AuthTokenContext.getInstance().unsetRefreshListener(mAuthTokenContextUpdateListener);
+            AuthTokenContext.getInstance().unsetRefreshListener(mAuthTokenContextRefreshListener);
             NetworkStateHelper.getSharedInstance(mContext).removeListener(this);
             if (mGetConfigCall != null) {
                 mGetConfigCall.cancel();

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -27,7 +27,6 @@ import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.storage.FileManager;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
@@ -166,7 +165,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     /**
      * The listener to catch if a token needs to be refreshed.
      */
-    private final AuthTokenContext.Listener mAuthTokenContextListener = new AbstractTokenContextListener() {
+    private final AuthTokenContext.RefreshListener mAuthTokenContextUpdateListener = new AuthTokenContext.RefreshListener() {
 
         @Override
         public void onTokenRequiresRefresh(String homeAccountId) {
@@ -265,7 +264,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     @Override
     protected synchronized void applyEnabledState(boolean enabled) {
         if (enabled) {
-            AuthTokenContext.getInstance().addListener(mAuthTokenContextListener);
+            AuthTokenContext.getInstance().setRefreshListener(mAuthTokenContextUpdateListener);
             NetworkStateHelper.getSharedInstance(mContext).addListener(this);
 
             /* Load cached configuration in case APIs are called early. */
@@ -274,7 +273,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             /* Download the latest configuration in background. */
             downloadConfiguration();
         } else {
-            AuthTokenContext.getInstance().removeListener(mAuthTokenContextListener);
+            AuthTokenContext.getInstance().unsetRefreshListener(mAuthTokenContextUpdateListener);
             NetworkStateHelper.getSharedInstance(mContext).removeListener(this);
             if (mGetConfigCall != null) {
                 mGetConfigCall.cancel();
@@ -493,6 +492,8 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
     @WorkerThread
     private void saveConfigFile(String payload, String eTag) {
         File file = getConfigFile();
+
+        //noinspection ConstantConditions it's never the root directory so there is always a parent.
         FileManager.mkdir(file.getParent());
         try {
             FileManager.write(file, payload);

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -235,7 +235,7 @@ public class AuthTest extends AbstractAuthTest {
         Channel channel = start(auth);
         verify(channel).removeGroup(eq(auth.getGroupName()));
         verify(channel).addGroup(eq(auth.getGroupName()), anyInt(), anyLong(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mNetworkStateHelper).addListener(any(NetworkStateHelper.Listener.class));
 
         /* Now we can see the service enabled. */
@@ -244,7 +244,7 @@ public class AuthTest extends AbstractAuthTest {
         /* Disable. Testing to wait setEnabled to finish while we are at it. */
         Auth.setEnabled(false).get();
         assertFalse(Auth.isEnabled().get());
-        verify(mAuthTokenContext).removeListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).unsetRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mNetworkStateHelper).removeListener(any(NetworkStateHelper.Listener.class));
         verify(mAuthTokenContext).setAuthToken(isNull(String.class), isNull(String.class), isNull(Date.class));
     }
@@ -1250,9 +1250,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void signOutCancelsCanceledSignIn() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication result. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1287,9 +1287,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void signOutCancelsFailedSignIn() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication result. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1324,9 +1324,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void signOutCancelsSignIn() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication result. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1361,8 +1361,8 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void signOutWithoutNetworkCancelsPendingRefresh() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(authTokenContextListenerCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(authTokenContextListenerCaptor.capture());
         ArgumentCaptor<NetworkStateHelper.Listener> networkStateListenerCaptor = ArgumentCaptor.forClass(NetworkStateHelper.Listener.class);
         doNothing().when(mNetworkStateHelper).addListener(networkStateListenerCaptor.capture());
 
@@ -1375,7 +1375,7 @@ public class AuthTest extends AbstractAuthTest {
         when(publicClientApplication.getAccount(eq("accountId"), anyString())).thenReturn(mock(IAccount.class));
         when(mAuthTokenContext.getAuthToken()).thenReturn(mockAccessToken);
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mNetworkStateHelper).addListener(any(NetworkStateHelper.Listener.class));
 
         /* Simulate offline. */
@@ -1404,14 +1404,14 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshTokenWithoutAccount() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication lib. */
         PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
         whenNew(PublicClientApplication.class).withAnyArguments().thenReturn(publicClientApplication);
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
 
         /* Request token refresh. */
         listenerArgumentCaptor.getValue().onTokenRequiresRefresh("accountId");
@@ -1422,15 +1422,15 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshToken() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication lib. */
         PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
         whenNew(PublicClientApplication.class).withAnyArguments().thenReturn(publicClientApplication);
         when(publicClientApplication.getAccount(eq("accountId"), anyString())).thenReturn(mock(IAccount.class));
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
 
         /* Request token refresh. */
         listenerArgumentCaptor.getValue().onTokenRequiresRefresh("accountId");
@@ -1442,8 +1442,8 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshTokenWithoutNetwork() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(authTokenContextListenerCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(authTokenContextListenerCaptor.capture());
         ArgumentCaptor<NetworkStateHelper.Listener> networkStateListenerCaptor = ArgumentCaptor.forClass(NetworkStateHelper.Listener.class);
         doNothing().when(mNetworkStateHelper).addListener(networkStateListenerCaptor.capture());
 
@@ -1453,7 +1453,7 @@ public class AuthTest extends AbstractAuthTest {
         when(publicClientApplication.getAccount(eq("accountId"), anyString())).thenReturn(mock(IAccount.class));
         when(mNetworkStateHelper.isNetworkConnected()).thenReturn(false);
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mNetworkStateHelper).addListener(any(NetworkStateHelper.Listener.class));
 
         /* Request token refresh. */
@@ -1473,8 +1473,8 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshTokenDoesNotHaveUiFallback() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(authTokenContextListenerCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(authTokenContextListenerCaptor.capture());
 
         /* Mock authentication lib. */
         PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
@@ -1490,7 +1490,7 @@ public class AuthTest extends AbstractAuthTest {
         }).when(publicClientApplication).acquireTokenSilentAsync(
                 notNull(String[].class), any(IAccount.class), any(String.class), eq(true), notNull(AuthenticationCallback.class));
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
 
         /* Request token refresh. */
         authTokenContextListenerCaptor.getValue().onTokenRequiresRefresh("accountId");
@@ -1502,15 +1502,15 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshTokenMultipleTimes() throws Exception {
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication lib. */
         PublicClientApplication publicClientApplication = mock(PublicClientApplication.class);
         whenNew(PublicClientApplication.class).withAnyArguments().thenReturn(publicClientApplication);
         when(publicClientApplication.getAccount(eq("accountId"), anyString())).thenReturn(mock(IAccount.class));
         mockReadyToSignIn();
-        verify(mAuthTokenContext).addListener(any(AuthTokenContext.Listener.class));
+        verify(mAuthTokenContext).setRefreshListener(any(AuthTokenContext.RefreshListener.class));
 
         /* Request token refresh multiple times. */
         listenerArgumentCaptor.getValue().onTokenRequiresRefresh("accountId");
@@ -1524,8 +1524,8 @@ public class AuthTest extends AbstractAuthTest {
 
     @Test
     public void refreshTokenWithoutConfig() {
-        ArgumentCaptor<AuthTokenContext.Listener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(authTokenContextListenerCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> authTokenContextListenerCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(authTokenContextListenerCaptor.capture());
 
         /* Start auth service. */
         Auth auth = Auth.getInstance();
@@ -1544,9 +1544,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void refreshTokenDuringSignIn() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication result. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1591,9 +1591,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void signInDuringRefreshToken() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock authentication result. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1642,9 +1642,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void signOutDuringRefreshToken() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock auth token. */
         String mockAccessToken = UUID.randomUUID().toString();
@@ -1681,9 +1681,9 @@ public class AuthTest extends AbstractAuthTest {
     @Test
     public void disableDuringRefreshToken() throws Exception {
 
-        /* Capture Listener to call onTokenRequiresRefresh later. */
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        /* Capture RefreshListener to call onTokenRequiresRefresh later. */
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        doNothing().when(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
 
         /* Mock auth token. */
         String mockAccessToken = UUID.randomUUID().toString();

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -38,7 +38,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
+import com.microsoft.appcenter.utils.context.AbstractTokenContextUpdateListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 
 import java.util.ArrayList;
@@ -101,7 +101,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
     /**
      * Authorization listener for {@link AuthTokenContext}.
      */
-    private AuthTokenContext.Listener mAuthListener;
+    private AuthTokenContext.UpdateListener mAuthUpdateListener;
 
     private NetworkStateHelper mNetworkStateHelper;
 
@@ -334,7 +334,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
         mTokenManager = TokenManager.getInstance(context);
         mAppSecret = appSecret;
         mLocalDocumentStorage = new LocalDocumentStorage(context, Utils.getUserTableName());
-        mAuthListener = new AbstractTokenContextListener() {
+        mAuthUpdateListener = new AbstractTokenContextUpdateListener() {
 
             @Override
             public void onNewUser(String accountId) {
@@ -400,7 +400,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
     @Override
     protected synchronized void applyEnabledState(boolean enabled) {
         if (enabled) {
-            AuthTokenContext.getInstance().addListener(mAuthListener);
+            AuthTokenContext.getInstance().addUpdateListener(mAuthUpdateListener);
             mNetworkStateHelper.addListener(this);
             if (mNetworkStateHelper.isNetworkConnected()) {
                 processPendingOperations();
@@ -410,7 +410,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                 call.getKey().complete(null);
                 call.getValue().cancel();
             }
-            AuthTokenContext.getInstance().removeListener(mAuthListener);
+            AuthTokenContext.getInstance().removeUpdateListener(mAuthUpdateListener);
             mNetworkStateHelper.removeListener(this);
             mPendingCalls.clear();
             for (Map.Entry<String, ServiceCall> call : mOutgoingPendingOperationCalls.entrySet()) {

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/AuthTokenTests.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/AuthTokenTests.java
@@ -77,10 +77,10 @@ public class AuthTokenTests extends AbstractDataTest {
         when(TokenManager.getInstance(notNull(Context.class))).thenReturn(mTokenManager);
 
         /* Mock context listener. */
-        AuthTokenContext.Listener mockListener = mock(AuthTokenContext.Listener.class);
+        AuthTokenContext.UpdateListener mockUpdateListener = mock(AuthTokenContext.UpdateListener.class);
 
         /* Set new auth token. */
-        AuthTokenContext.getInstance().addListener(mockListener);
+        AuthTokenContext.getInstance().addUpdateListener(mockUpdateListener);
         AuthTokenContext.getInstance().setAuthToken("mock-token", "mock-user", new Date(Long.MAX_VALUE));
 
         /* Verify. */

--- a/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
+++ b/sdk/appcenter-push/src/main/java/com/microsoft/appcenter/push/Push.java
@@ -30,7 +30,7 @@ import com.microsoft.appcenter.push.ingestion.models.PushInstallationLog;
 import com.microsoft.appcenter.push.ingestion.models.json.PushInstallationLogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
+import com.microsoft.appcenter.utils.context.AbstractTokenContextUpdateListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.context.UserIdContext;
 
@@ -119,7 +119,7 @@ public class Push extends AbstractAppCenterService {
     /**
      * Authorization listener for {@link AuthTokenContext}.
      */
-    private AuthTokenContext.Listener mAuthListener;
+    private AuthTokenContext.UpdateListener mAuthListener;
 
     /**
      * User id context listener for {@link UserIdContext}.
@@ -303,11 +303,11 @@ public class Push extends AbstractAppCenterService {
     @Override
     protected synchronized void applyEnabledState(boolean enabled) {
         if (enabled) {
-            AuthTokenContext.getInstance().addListener(mAuthListener);
+            AuthTokenContext.getInstance().addUpdateListener(mAuthListener);
             UserIdContext.getInstance().addListener(mUserListener);
             registerPushToken();
         } else {
-            AuthTokenContext.getInstance().removeListener(mAuthListener);
+            AuthTokenContext.getInstance().removeUpdateListener(mAuthListener);
             UserIdContext.getInstance().removeListener(mUserListener);
         }
     }
@@ -340,7 +340,7 @@ public class Push extends AbstractAppCenterService {
     @Override
     public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
-        mAuthListener = new AbstractTokenContextListener() {
+        mAuthListener = new AbstractTokenContextUpdateListener() {
 
             @Override
             public void onNewUser(String accountId) {

--- a/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
+++ b/sdk/appcenter-push/src/test/java/com/microsoft/appcenter/push/PushTest.java
@@ -989,9 +989,9 @@ public class PushTest {
 
         /* When we start push being enabled. */
         ArgumentCaptor<UserIdContext.Listener> userIdContextArgument = ArgumentCaptor.forClass(UserIdContext.Listener.class);
-        ArgumentCaptor<AuthTokenContext.Listener> authTokenArgument = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
+        ArgumentCaptor<AuthTokenContext.UpdateListener> authTokenArgument = ArgumentCaptor.forClass(AuthTokenContext.UpdateListener.class);
         UserIdContext.Listener currentUserIdContextListener;
-        AuthTokenContext.Listener currentAuthTokenContextListener;
+        AuthTokenContext.UpdateListener currentAuthTokenContextListener;
         UserIdContext userIdContext = mock(UserIdContext.class);
         AuthTokenContext authTokenContext = mock(AuthTokenContext.class);
         mockStatic(UserIdContext.class);
@@ -1006,8 +1006,8 @@ public class PushTest {
         verify(userIdContext).addListener(userIdContextArgument.capture());
         verify(userIdContext, never()).removeListener(any(UserIdContext.Listener.class));
         currentUserIdContextListener = userIdContextArgument.getValue();
-        verify(authTokenContext).addListener(authTokenArgument.capture());
-        verify(authTokenContext, never()).removeListener(any(AuthTokenContext.Listener.class));
+        verify(authTokenContext).addUpdateListener(authTokenArgument.capture());
+        verify(authTokenContext, never()).removeUpdateListener(any(AuthTokenContext.UpdateListener.class));
         currentAuthTokenContextListener = authTokenArgument.getValue();
 
         /* When push is disabled. */
@@ -1016,8 +1016,8 @@ public class PushTest {
         /* Then listeners are removed. (And thus not added more than once in total). */
         verify(userIdContext).addListener(any(UserIdContext.Listener.class));
         verify(userIdContext).removeListener(eq(currentUserIdContextListener));
-        verify(authTokenContext).addListener(any(AuthTokenContext.Listener.class));
-        verify(authTokenContext).removeListener(eq(currentAuthTokenContextListener));
+        verify(authTokenContext).addUpdateListener(any(AuthTokenContext.UpdateListener.class));
+        verify(authTokenContext).removeUpdateListener(eq(currentAuthTokenContextListener));
 
         /* When re-enabling push. */
         push.applyEnabledState(true);
@@ -1025,8 +1025,8 @@ public class PushTest {
         /* Then we re-register listener (thus twice in total). And thus we didn't remove more than once total. */
         verify(userIdContext, times(2)).addListener(any(UserIdContext.Listener.class));
         verify(userIdContext).removeListener(any(UserIdContext.Listener.class));
-        verify(authTokenContext, times(2)).addListener(any(AuthTokenContext.Listener.class));
-        verify(authTokenContext).removeListener(any(AuthTokenContext.Listener.class));
+        verify(authTokenContext, times(2)).addUpdateListener(any(AuthTokenContext.UpdateListener.class));
+        verify(authTokenContext).removeUpdateListener(any(AuthTokenContext.UpdateListener.class));
     }
 
     @Test

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -37,7 +37,6 @@ import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.PrefStorageConstants;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.context.SessionContext;
 import com.microsoft.appcenter.utils.context.UserIdContext;
@@ -220,7 +219,7 @@ public class AppCenter {
     /**
      * Token refresh listener for bring your own identity.
      */
-    private AbstractTokenContextListener mAuthTokenRefreshListener;
+    private AuthTokenContext.RefreshListener mAuthTokenRefreshListener;
 
     /**
      * Get unique instance.
@@ -1179,7 +1178,7 @@ public class AppCenter {
         if (authProvider != null) {
             AppCenterLog.info(LOG_TAG, "Setting up auth token refresh listener.");
             authTokenContext.doNotResetAuthAfterStart();
-            mAuthTokenRefreshListener = new AbstractTokenContextListener() {
+            mAuthTokenRefreshListener = new AuthTokenContext.RefreshListener() {
 
                 @Override
                 public void onTokenRequiresRefresh(String homeAccountId) {
@@ -1198,10 +1197,10 @@ public class AppCenter {
                     });
                 }
             };
-            authTokenContext.addListener(mAuthTokenRefreshListener);
+            authTokenContext.setRefreshListener(mAuthTokenRefreshListener);
         } else if (mAuthTokenRefreshListener != null) {
             AppCenterLog.info(LOG_TAG, "Removing auth token refresh listener.");
-            authTokenContext.removeListener(mAuthTokenRefreshListener);
+            authTokenContext.unsetRefreshListener(mAuthTokenRefreshListener);
             authTokenContext.setAuthToken(null, null, null);
         }
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -28,7 +28,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.IdHelper;
-import com.microsoft.appcenter.utils.context.AbstractTokenContextListener;
+import com.microsoft.appcenter.utils.context.AbstractTokenContextUpdateListener;
 import com.microsoft.appcenter.utils.context.AuthTokenContext;
 import com.microsoft.appcenter.utils.context.AuthTokenInfo;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
@@ -230,7 +230,7 @@ public class DefaultChannel implements Channel {
         groupState.mPendingLogCount = mPersistence.countLogs(groupName);
 
         /* Listen for token refreshed to unblock sending logs after waiting for the token update. */
-        AuthTokenContext.getInstance().addListener(groupState);
+        AuthTokenContext.getInstance().addUpdateListener(groupState);
 
         /*
          * If no app secret, don't resume sending App Center logs from storage.
@@ -255,7 +255,7 @@ public class DefaultChannel implements Channel {
         GroupState groupState = mGroupStates.remove(groupName);
         if (groupState != null) {
             cancelTimer(groupState);
-            AuthTokenContext.getInstance().removeListener(groupState);
+            AuthTokenContext.getInstance().removeUpdateListener(groupState);
         }
 
         /* Call listeners so that they can react on group removed. */
@@ -860,7 +860,7 @@ public class DefaultChannel implements Channel {
      * State for a specific log group.
      */
     @VisibleForTesting
-    class GroupState extends AbstractTokenContextListener {
+    class GroupState extends AbstractTokenContextUpdateListener {
 
         /**
          * Group name.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AbstractTokenContextUpdateListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AbstractTokenContextUpdateListener.java
@@ -8,7 +8,7 @@ package com.microsoft.appcenter.utils.context;
 /**
  * Empty implementation to make callbacks optional.
  */
-public abstract class AbstractTokenContextListener implements AuthTokenContext.Listener {
+public abstract class AbstractTokenContextUpdateListener implements AuthTokenContext.UpdateListener {
 
     @Override
     public void onNewAuthToken(String authToken) {
@@ -16,9 +16,5 @@ public abstract class AbstractTokenContextListener implements AuthTokenContext.L
 
     @Override
     public void onNewUser(String accountId) {
-    }
-
-    @Override
-    public void onTokenRequiresRefresh(String homeAccountId) {
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
@@ -59,9 +60,13 @@ public class AuthTokenContext {
     private static AuthTokenContext sInstance;
 
     /**
-     * Global listeners collection.
+     * Update listeners collection.
      */
-    private final Set<Listener> mListeners = Collections.newSetFromMap(new ConcurrentHashMap<Listener, Boolean>());
+    private final Set<UpdateListener> mUpdateListeners = Collections.newSetFromMap(new ConcurrentHashMap<UpdateListener, Boolean>());
+    /**
+     * Refresh token listener.
+     */
+    private AtomicReference<RefreshListener> mRefreshListener = new AtomicReference<>();
 
     /**
      * {@link Context} instance.
@@ -110,21 +115,37 @@ public class AuthTokenContext {
     }
 
     /**
-     * Adds listener to token context.
-     *
-     * @param listener listener to be notified of changes.
+     * Set or unset the refresh token update listener. There can be only 1 active.
      */
-    public void addListener(@NonNull Listener listener) {
-        mListeners.add(listener);
+    public void setRefreshListener(@NonNull RefreshListener refreshListener) {
+        if (!mRefreshListener.compareAndSet(null, refreshListener)) {
+            AppCenterLog.error(LOG_TAG, "Cannot use 2 authentication modules at the same time.");
+        }
     }
 
     /**
-     * Removes a specific listener.
-     *
-     * @param listener listener to be removed.
+     * Unset the refresh token update listener.
      */
-    public void removeListener(@NonNull Listener listener) {
-        mListeners.remove(listener);
+    public void unsetRefreshListener(@NonNull RefreshListener refreshListener) {
+        mRefreshListener.compareAndSet(refreshListener, null);
+    }
+
+    /**
+     * Register a token update listener.
+     *
+     * @param updateListener updateListener to be notified of changes.
+     */
+    public void addUpdateListener(@NonNull UpdateListener updateListener) {
+        mUpdateListeners.add(updateListener);
+    }
+
+    /**
+     * Unregister a token update listener.
+     *
+     * @param updateListener updateListener to be removed.
+     */
+    public void removeUpdateListener(@NonNull UpdateListener updateListener) {
+        mUpdateListeners.remove(updateListener);
     }
 
     /**
@@ -166,11 +187,11 @@ public class AuthTokenContext {
         }
 
         /* Call listeners so that they can react on new token. */
-        for (Listener listener : mListeners) {
-            listener.onNewAuthToken(authToken);
+        for (UpdateListener updateListener : mUpdateListeners) {
+            updateListener.onNewAuthToken(authToken);
             if (isNewUser) {
                 String accountId = homeAccountId == null ? null : homeAccountId.substring(0, Math.min(ACCOUNT_ID_LENGTH, homeAccountId.length()));
-                listener.onNewUser(accountId);
+                updateListener.onNewUser(accountId);
             }
         }
     }
@@ -330,14 +351,14 @@ public class AuthTokenContext {
      * @param authTokenInfo auth token to check for expiration.
      */
     public void checkIfTokenNeedsToBeRefreshed(@NonNull AuthTokenInfo authTokenInfo) {
-        AuthTokenHistoryEntry lastEntry = getLastHistoryEntry();
-        if (lastEntry == null || authTokenInfo.getAuthToken() == null ||
-                !authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) ||
-                !authTokenInfo.isAboutToExpire()) {
+        if (mRefreshListener.get() == null) {
             return;
         }
-        for (Listener listener : mListeners) {
-            listener.onTokenRequiresRefresh(lastEntry.getHomeAccountId());
+        AuthTokenHistoryEntry lastEntry = getLastHistoryEntry();
+        if (lastEntry != null && authTokenInfo.getAuthToken() != null &&
+                authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) &&
+                authTokenInfo.isAboutToExpire()) {
+            mRefreshListener.get().onTokenRequiresRefresh(lastEntry.getHomeAccountId());
         }
     }
 
@@ -417,9 +438,9 @@ public class AuthTokenContext {
     }
 
     /**
-     * Token context global listener specification.
+     * Listener to get updates on tokens or users.
      */
-    public interface Listener {
+    public interface UpdateListener {
 
         /**
          * Called whenever a new token is set.
@@ -434,6 +455,12 @@ public class AuthTokenContext {
          * @param accountId account id.
          */
         void onNewUser(String accountId);
+    }
+
+    /**
+     * Listener to refresh tokens.
+     */
+    public interface RefreshListener {
 
         /**
          * Called whenever token needs to be refreshed.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -352,14 +352,15 @@ public class AuthTokenContext {
      * @param authTokenInfo auth token to check for expiration.
      */
     public void checkIfTokenNeedsToBeRefreshed(@NonNull AuthTokenInfo authTokenInfo) {
-        if (mRefreshListener.get() == null) {
+        AuthTokenHistoryEntry lastEntry = getLastHistoryEntry();
+        if (lastEntry == null || authTokenInfo.getAuthToken() == null ||
+                !authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) ||
+                !authTokenInfo.isAboutToExpire()) {
             return;
         }
-        AuthTokenHistoryEntry lastEntry = getLastHistoryEntry();
-        if (lastEntry != null && authTokenInfo.getAuthToken() != null &&
-                authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) &&
-                authTokenInfo.isAboutToExpire()) {
-            mRefreshListener.get().onTokenRequiresRefresh(lastEntry.getHomeAccountId());
+        RefreshListener refreshListener = mRefreshListener.get();
+        if (refreshListener != null) {
+            refreshListener.onTokenRequiresRefresh(lastEntry.getHomeAccountId());
         }
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -60,13 +60,14 @@ public class AuthTokenContext {
     private static AuthTokenContext sInstance;
 
     /**
-     * Update listeners collection.
-     */
-    private final Set<UpdateListener> mUpdateListeners = Collections.newSetFromMap(new ConcurrentHashMap<UpdateListener, Boolean>());
-    /**
      * Refresh token listener.
      */
     private AtomicReference<RefreshListener> mRefreshListener = new AtomicReference<>();
+
+    /**
+     * Update listeners collection.
+     */
+    private final Set<UpdateListener> mUpdateListeners = Collections.newSetFromMap(new ConcurrentHashMap<UpdateListener, Boolean>());
 
     /**
      * {@link Context} instance.

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -18,7 +18,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.Date;
 
-import static com.microsoft.appcenter.utils.context.AuthTokenContext.UpdateListener;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -76,14 +75,14 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
     public void setAuthProviderWhenPreviouslySet() {
         AuthTokenContext.RefreshListener refreshListener = testSetAuthProvider();
         AppCenter.setAuthProvider(null);
-        verify(mAuthTokenContext).setRefreshListener(refreshListener);
+        verify(mAuthTokenContext).unsetRefreshListener(refreshListener);
         verify(mAuthTokenContext).setAuthToken(null, null, null);
     }
 
     @Test
     public void setNullAuthProviderWhenNoneExists() {
         AppCenter.setAuthProvider(null);
-        verify(mAuthTokenContext, never()).removeUpdateListener(any(UpdateListener.class));
+        verify(mAuthTokenContext, never()).unsetRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mAuthTokenContext, never()).setAuthToken(anyString(), anyString(), any(Date.class));
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -18,7 +18,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.Date;
 
-import static com.microsoft.appcenter.utils.context.AuthTokenContext.Listener;
+import static com.microsoft.appcenter.utils.context.AuthTokenContext.UpdateListener;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -44,7 +44,7 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
     }
 
     @NonNull
-    private Listener testSetAuthProvider() {
+    private AuthTokenContext.RefreshListener testSetAuthProvider() {
         final String jwt = "jwt";
         JwtClaims claims = mock(JwtClaims.class);
         when(claims.getSubject()).thenReturn("someId");
@@ -57,14 +57,14 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
                 callback.onAuthResult(jwt);
             }
         });
-        ArgumentCaptor<Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(Listener.class);
-        verify(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
-        Listener listener = listenerArgumentCaptor.getValue();
-        assertNotNull(listener);
-        listener.onTokenRequiresRefresh(claims.getSubject());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        verify(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
+        AuthTokenContext.RefreshListener refreshListener = listenerArgumentCaptor.getValue();
+        assertNotNull(refreshListener);
+        refreshListener.onTokenRequiresRefresh(claims.getSubject());
         verify(mAuthTokenContext).doNotResetAuthAfterStart();
         verify(mAuthTokenContext).setAuthToken(jwt, claims.getSubject(), claims.getExpirationDate());
-        return listener;
+        return refreshListener;
     }
 
     @Test
@@ -74,16 +74,16 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
 
     @Test
     public void setAuthProviderWhenPreviouslySet() {
-        Listener listener = testSetAuthProvider();
+        AuthTokenContext.RefreshListener refreshListener = testSetAuthProvider();
         AppCenter.setAuthProvider(null);
-        verify(mAuthTokenContext).removeListener(listener);
+        verify(mAuthTokenContext).setRefreshListener(refreshListener);
         verify(mAuthTokenContext).setAuthToken(null, null, null);
     }
 
     @Test
     public void setNullAuthProviderWhenNoneExists() {
         AppCenter.setAuthProvider(null);
-        verify(mAuthTokenContext, never()).removeListener(any(Listener.class));
+        verify(mAuthTokenContext, never()).removeUpdateListener(any(UpdateListener.class));
         verify(mAuthTokenContext, never()).setAuthToken(anyString(), anyString(), any(Date.class));
     }
 
@@ -99,9 +99,10 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
                 callback.onAuthResult(invalidJwt);
             }
         });
-        ArgumentCaptor<Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(Listener.class);
-        verify(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
-        assertNotNull(listenerArgumentCaptor.getValue());
+        ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
+        verify(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
+        AuthTokenContext.RefreshListener refreshListener = listenerArgumentCaptor.getValue();
+        assertNotNull(refreshListener);
         listenerArgumentCaptor.getValue().onTokenRequiresRefresh("some account id");
         verify(mAuthTokenContext).doNotResetAuthAfterStart();
         verify(mAuthTokenContext).setAuthToken(null, null, null);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1032,8 +1032,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
     @Test
     public void scheduleLogsWithNewToken() {
-        ArgumentCaptor<AuthTokenContext.Listener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.Listener.class);
-        doNothing().when(mAuthTokenContext).addListener(listenerArgumentCaptor.capture());
+        ArgumentCaptor<AuthTokenContext.UpdateListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.UpdateListener.class);
+        doNothing().when(mAuthTokenContext).addUpdateListener(listenerArgumentCaptor.capture());
 
         /* Create channel. Verify scheduling logs. */
         Persistence mockPersistence = mock(Persistence.class);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Implement validation for having only 1 token refresh listener.

## Related PRs or issues

[AB#67952](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/67952)
