### PR TITLE
Add AAD Auth Feature for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Center SDK for Android Change Log
 
-## Version 2.3.1 (Under development)
+## Version 2.4.0 (Under development)
 
 ### App Center Auth
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Version 2.3.1 (Under development)
 
+### App Center Auth
+
+* **[Feature]** Add support for Azure Active Directory (AAD) type authentication. Users with AAD apps on Azure can authenticate using one of three audiences viz. AzureADMyOrg (Single Tenant), AzureADMultipleOrgs (Multi Tenant) and AzureADandPersonalMicrosoftAccount (Multi Tenant and Personal Microsoft accounts).
+
 ### App Center Data
 
 * **[Fix]** Reduced retries on Data-related operations to fail fast and avoid the perception of calls "hanging".
-* **[Feature]** Add support for Azure Active Directory (AAD) type authentication. Users with AAD apps on Azure can authenticate using one of three audiences viz. AzureADMyOrg (Single Tenant), AzureADMultipleOrgs (Multi Tenant) and AzureADandPersonalMicrosoftAccount (Multi Tenant and Personal Microsoft accounts).
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Data
 
 * **[Fix]** Reduced retries on Data-related operations to fail fast and avoid the perception of calls "hanging".
+* **[Feature]** Add support for Azure Active Directory (AAD) type authentication. Users with AAD apps on Azure can authenticate using one of three audiences viz. AzureADMyOrg (Single Tenant), AzureADMultipleOrgs (Multi Tenant) and AzureADandPersonalMicrosoftAccount (Multi Tenant and Personal Microsoft accounts).
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Auth
 
-* **[Feature]** Add support for Azure Active Directory (AAD) type authentication. Users with AAD apps on Azure can authenticate using one of three audiences viz. AzureADMyOrg (Single Tenant), AzureADMultipleOrgs (Multi Tenant) and AzureADandPersonalMicrosoftAccount (Multi Tenant and Personal Microsoft accounts).
+* **[Feature]** Add authentication support for Azure Active Directory (AAD) applications. Users can now connect an [AAD tenant and AAD single tenant (AzureADMyOrg), multi-tenant (AzureADMultipleOrgs) and multi-tenant and personal Microsoft account (AzureADandPersonalMicrosoftAccount)](https://www.microsoft.com) applications.
 
 ### App Center Data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Auth
 
-* **[Feature]** Add authentication support for Azure Active Directory (AAD) applications. Users can now connect an [AAD tenant and AAD single tenant (AzureADMyOrg), multi-tenant (AzureADMultipleOrgs) and multi-tenant and personal Microsoft account (AzureADandPersonalMicrosoftAccount)](https://www.microsoft.com) applications.
+* **[Feature]** Add authentication support for Azure Active Directory (AAD) applications. Users can now connect an [AAD tenant and AAD single tenant (AzureADMyOrg), multi-tenant (AzureADMultipleOrgs) and multi-tenant and personal Microsoft account (AzureADandPersonalMicrosoftAccount)](https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps) applications.
 
 ### App Center Data
 

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -56,6 +56,7 @@ import static android.util.Log.VERBOSE;
 import static com.microsoft.appcenter.auth.Constants.AUTHORITIES;
 import static com.microsoft.appcenter.auth.Constants.AUTHORITY_DEFAULT;
 import static com.microsoft.appcenter.auth.Constants.AUTHORITY_TYPE;
+import static com.microsoft.appcenter.auth.Constants.AUTHORITY_TYPE_AAD;
 import static com.microsoft.appcenter.auth.Constants.AUTHORITY_TYPE_B2C;
 import static com.microsoft.appcenter.auth.Constants.AUTHORITY_URL;
 import static com.microsoft.appcenter.auth.Constants.AUTH_GROUP;
@@ -461,24 +462,26 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             JSONObject configuration = new JSONObject(configurationPayload);
             String identityScope = configuration.getString(IDENTITY_SCOPE);
             String authorityUrl = null;
+            String type = null;
             JSONArray authorities = configuration.getJSONArray(AUTHORITIES);
             for (int i = 0; i < authorities.length(); i++) {
                 JSONObject authority = authorities.getJSONObject(i);
-                if (authority.optBoolean(AUTHORITY_DEFAULT) && AUTHORITY_TYPE_B2C.equals(authority.getString(AUTHORITY_TYPE))) {
-                    authorityUrl = authority.getString(AUTHORITY_URL);
-                    break;
+                if (authority.optBoolean(AUTHORITY_DEFAULT)) {
+                    if (AUTHORITY_TYPE_B2C.equals(authority.getString(AUTHORITY_TYPE))) {
+                        type = AUTHORITY_TYPE_B2C;
+                        authorityUrl = authority.getString(AUTHORITY_URL);
+                    } else if (AUTHORITY_TYPE_AAD.equals(authority.getString(AUTHORITY_TYPE))) {
+                        type = AUTHORITY_TYPE_AAD;
+                    }
                 }
             }
-            if (authorityUrl != null) {
-
-                /* The remaining validation is done by the library. */
-                mAuthenticationClient = new PublicClientApplication(mContext, getConfigFile());
-                mAuthorityUrl = authorityUrl;
-                mIdentityScope = identityScope;
-                AppCenterLog.info(LOG_TAG, "Auth service configured successfully.");
-            } else {
-                throw new IllegalStateException("Cannot find a b2c authority configured to be the default.");
+            if (type == null) {
+                throw new IllegalStateException("Cannot find a default b2c or aad authority configured to be the default.");
             }
+            mAuthenticationClient = new PublicClientApplication(mContext, getConfigFile());
+            mAuthorityUrl = authorityUrl;
+            mIdentityScope = identityScope;
+            AppCenterLog.info(LOG_TAG, "Auth service configured successfully.");
         } catch (JSONException | RuntimeException e) {
             AppCenterLog.error(LOG_TAG, "The configuration is invalid.", e);
             clearCache();

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Constants.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Constants.java
@@ -78,6 +78,11 @@ final class Constants {
     static final String AUTHORITY_TYPE_B2C = "B2C";
 
     /**
+     * JSON configuration value for aad authority within {@link #AUTHORITIES} array.
+     */
+    static final String AUTHORITY_TYPE_AAD = "AAD";
+
+    /**
      * JSON configuration key for authority url within {@link #AUTHORITIES} array.
      */
     static final String AUTHORITY_URL = "authority_url";

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -307,7 +307,7 @@ public class AuthTest extends AbstractAuthTest {
         /* Mock public client application. */
         mockMsalPublicClientApplication();
 
-        /* When we get a payload valid for AppCenter fields but invalid for msal ones. */
+        /* When we get a valid payload for App Center fields but an invalid payload for Microsoft Authentication Library (MSAL) ones. */
         mockSuccessfulHttpCall(jsonConfig, mHttpClient);
 
         /* We saved after we downloaded the file. */
@@ -325,7 +325,7 @@ public class AuthTest extends AbstractAuthTest {
         Auth auth = Auth.getInstance();
         start(auth);
 
-        /* mock public client application for msal*/
+        /* Mock public client application for MSAL*/
         mockMsalPublicClientApplication();
 
         /* When we get a payload valid for AppCenter fields but invalid for msal ones. */

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -325,7 +325,7 @@ public class AuthTest extends AbstractAuthTest {
         Auth auth = Auth.getInstance();
         start(auth);
 
-        /* Mock public client application for MSAL*/
+        /* Mock public client application for MSAL. */
         mockMsalPublicClientApplication();
 
         /* When we get a valid payload for App Center fields but an invalid payload for MSAL ones. */
@@ -335,7 +335,7 @@ public class AuthTest extends AbstractAuthTest {
         verifyStatic();
         FileManager.write(any(File.class), anyString());
 
-        /* We did not delete the file from the cache */
+        /* We did not delete the file from the cache. */
         verifyStatic(never());
         FileManager.delete(any(File.class));
     }

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -125,6 +125,11 @@ public class AuthTest extends AbstractAuthTest {
         mockHttpCallSuccess(jsonConfig, serviceCallback);
     }
 
+    private static void mockMsalPublicClientApplication() throws Exception {
+        PublicClientApplication application = mock(PublicClientApplication.class);
+        whenNew(PublicClientApplication.class).withParameterTypes(Context.class, File.class).withArguments(any(Context.class), any(File.class)).thenReturn(application);
+    }
+
     private static ServiceCallback mockHttpCallStarted(HttpClient httpClient) throws JSONException {
 
         /* Intercept parameters. */
@@ -273,9 +278,13 @@ public class AuthTest extends AbstractAuthTest {
         assertNotNull(serviceCallback);
         serviceCallback.onCallSucceeded("invalid", new HashMap<String, String>());
 
-        /* We didn't attempt to even save. */
+        /* We saved after we downloaded the file. */
         verifyStatic();
         FileManager.write(any(File.class), anyString());
+
+        /* We cleared the cache since the file was invalid. */
+        verifyStatic();
+        FileManager.delete(any(File.class));
     }
 
     private void testInvalidConfig(JSONObject jsonConfig) throws Exception {
@@ -284,17 +293,45 @@ public class AuthTest extends AbstractAuthTest {
         Auth auth = Auth.getInstance();
         start(auth);
 
+        /* Mock public client application. */
+        mockMsalPublicClientApplication();
+
         /* When we get a payload valid for AppCenter fields but invalid for msal ones. */
         mockSuccessfulHttpCall(jsonConfig, mHttpClient);
 
-        /* We didn't attempt to even save. */
+        /* We saved after we downloaded the file. */
         verifyStatic();
         FileManager.write(any(File.class), anyString());
+
+        /* We cleared the cache since the file was invalid. */
+        verifyStatic();
+        FileManager.delete(any(File.class));
+    }
+
+    private void testValidConfig(JSONObject jsonConfig) throws Exception {
+
+        /* Start auth service. */
+        Auth auth = Auth.getInstance();
+        start(auth);
+
+        /* mock public client application for msal*/
+        mockMsalPublicClientApplication();
+
+        /* When we get a payload valid for AppCenter fields but invalid for msal ones. */
+        mockSuccessfulHttpCall(jsonConfig, mHttpClient);
+
+        /* We saved after we downloaded the file. */
+        verifyStatic();
+        FileManager.write(any(File.class), anyString());
+
+        /* We did not delete the file from the cache */
+        verifyStatic(never());
+        FileManager.delete(any(File.class));
     }
 
     @Test
     public void downloadInvalidForMSALConfiguration() throws Exception {
-        testInvalidConfig(mockValidForAppCenterConfig());
+        testValidConfig(mockValidForAppCenterConfig());
     }
 
     @Test
@@ -309,6 +346,7 @@ public class AuthTest extends AbstractAuthTest {
         when(authorities.getJSONObject(0)).thenReturn(authority);
         when(authority.optBoolean("default")).thenReturn(true);
         when(authority.getString("type")).thenReturn("B2C");
+        when(authority.getString("authority_url")).thenThrow(new JSONException("missing"));
         testInvalidConfig(jsonConfig);
     }
 
@@ -337,6 +375,36 @@ public class AuthTest extends AbstractAuthTest {
         JSONObject authority = mock(JSONObject.class);
         when(authorities.getJSONObject(0)).thenReturn(authority);
         when(authority.optBoolean("default")).thenReturn(true);
+        testInvalidConfig(jsonConfig);
+    }
+
+    @Test
+    public void downloadConfigurationWithAAD() throws Exception {
+        JSONObject jsonConfig = mock(JSONObject.class);
+        when(jsonConfig.toString()).thenReturn("mockConfig");
+        whenNew(JSONObject.class).withArguments("mockConfig").thenReturn(jsonConfig);
+        JSONArray authorities = mock(JSONArray.class);
+        when(jsonConfig.getJSONArray("authorities")).thenReturn(authorities);
+        when(authorities.length()).thenReturn(1);
+        JSONObject authority = mock(JSONObject.class);
+        when(authorities.getJSONObject(0)).thenReturn(authority);
+        when(authority.optBoolean("default")).thenReturn(true);
+        when(authority.getString("type")).thenReturn("AAD");
+        testValidConfig(jsonConfig);
+    }
+
+    @Test
+    public void downloadConfigurationWithInvalidAuthenticationType() throws Exception {
+        JSONObject jsonConfig = mock(JSONObject.class);
+        when(jsonConfig.toString()).thenReturn("mockConfig");
+        whenNew(JSONObject.class).withArguments("mockConfig").thenReturn(jsonConfig);
+        JSONArray authorities = mock(JSONArray.class);
+        when(jsonConfig.getJSONArray("authorities")).thenReturn(authorities);
+        when(authorities.length()).thenReturn(1);
+        JSONObject authority = mock(JSONObject.class);
+        when(authorities.getJSONObject(0)).thenReturn(authority);
+        when(authority.optBoolean("default")).thenReturn(true);
+        when(authority.getString("type")).thenReturn("InvalidType");
         testInvalidConfig(jsonConfig);
     }
 

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -328,7 +328,7 @@ public class AuthTest extends AbstractAuthTest {
         /* Mock public client application for MSAL*/
         mockMsalPublicClientApplication();
 
-        /* When we get a payload valid for AppCenter fields but invalid for msal ones. */
+        /* When we get a valid payload for App Center fields but an invalid payload for MSAL ones. */
         mockSuccessfulHttpCall(jsonConfig, mHttpClient);
 
         /* We saved after we downloaded the file. */

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,8 +6,8 @@
 // Version constants
 
 ext {
-    versionCode = 49
-    versionName = '2.3.1'
+    versionCode = 50
+    versionName = '2.4.0'
     minSdkVersion = 16
     targetSdkVersion = 29
     compileSdkVersion = 29

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@
 // Version constants
 
 ext {
-    versionCode = 50
+    versionCode = 49
     versionName = '2.4.0'
     minSdkVersion = 16
     targetSdkVersion = 29


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description


This pull request brings android changes for Azure Active Directory (AAD) Authentication. Users can now be authenticated using AAD for their AAD Auth configured app.

