### PR TITLE
get authority url during init from config

### DIFF
--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -480,6 +480,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
             }
             mAuthenticationClient = new PublicClientApplication(mContext, getConfigFile());
             mAuthorityUrl = (authorityUrl != null) ? authorityUrl : mAuthenticationClient.getConfiguration().getAuthorities().get(0).getAuthorityURL().toString();
+            AppCenterLog.debug(LOG_TAG, "Authority url=" + mAuthorityUrl);
             mIdentityScope = identityScope;
             AppCenterLog.info(LOG_TAG, "Auth service configured successfully.");
         } catch (JSONException | RuntimeException e) {

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -479,7 +479,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
                 throw new IllegalStateException("Cannot find a default b2c or aad authority configured to be the default.");
             }
             mAuthenticationClient = new PublicClientApplication(mContext, getConfigFile());
-            mAuthorityUrl = authorityUrl;
+            mAuthorityUrl = mAuthenticationClient.getConfiguration().getAuthorities().get(0).getAuthorityUri().toString();
             mIdentityScope = identityScope;
             AppCenterLog.info(LOG_TAG, "Auth service configured successfully.");
         } catch (JSONException | RuntimeException e) {

--- a/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
+++ b/sdk/appcenter-auth/src/main/java/com/microsoft/appcenter/auth/Auth.java
@@ -479,7 +479,7 @@ public class Auth extends AbstractAppCenterService implements NetworkStateHelper
                 throw new IllegalStateException("Cannot find a default b2c or aad authority configured to be the default.");
             }
             mAuthenticationClient = new PublicClientApplication(mContext, getConfigFile());
-            mAuthorityUrl = mAuthenticationClient.getConfiguration().getAuthorities().get(0).getAuthorityUri().toString();
+            mAuthorityUrl = (authorityUrl != null) ? authorityUrl : mAuthenticationClient.getConfiguration().getAuthorities().get(0).getAuthorityURL().toString();
             mIdentityScope = identityScope;
             AppCenterLog.info(LOG_TAG, "Auth service configured successfully.");
         } catch (JSONException | RuntimeException e) {

--- a/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
+++ b/sdk/appcenter-auth/src/test/java/com/microsoft/appcenter/auth/AuthTest.java
@@ -33,9 +33,11 @@ import com.microsoft.identity.client.IAccountIdentifier;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.PublicClientApplicationConfiguration;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
+import com.microsoft.identity.common.internal.authorities.Authority;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -52,8 +54,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -128,6 +132,13 @@ public class AuthTest extends AbstractAuthTest {
     private static void mockMsalPublicClientApplication() throws Exception {
         PublicClientApplication application = mock(PublicClientApplication.class);
         whenNew(PublicClientApplication.class).withParameterTypes(Context.class, File.class).withArguments(any(Context.class), any(File.class)).thenReturn(application);
+        PublicClientApplicationConfiguration configuration = mock(PublicClientApplicationConfiguration.class);
+        when(application.getConfiguration()).thenReturn(configuration);
+        Authority authority = mock(Authority.class);
+        List<Authority> authorities = new ArrayList<>();
+        authorities.add(authority);
+        when(configuration.getAuthorities()).thenReturn(authorities);
+        when(authority.getAuthorityURL()).thenReturn(new URL("https://login.microsoft.com/"));
     }
 
     private static ServiceCallback mockHttpCallStarted(HttpClient httpClient) throws JSONException {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Get authority url from config. This will make sure we can use it later and do not run into null exceptions.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-android/pull/1241

## MIsc

Yet to make changes to tests