### PR TITLE
[Android Q] Distribution code deprecation warning

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/CheckDownloadTask.java
@@ -12,6 +12,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -194,18 +195,16 @@ class CheckDownloadTask extends AsyncTask<Void, Void, DownloadProgress> {
         return pendingIntent.getIntentSender();
     }
 
-
     private IntentSender createStatusReceiver() {
-        try {
-            //todo: remove explicit activity declaration
-            Intent intent = new Intent(mContext, Class.forName("com.microsoft.appcenter.sasquatch.activities.MainActivity"));
+        PackageManager pm = mContext.getPackageManager();
+        String packageName = mContext.getPackageName();
+        Intent intent = pm.getLaunchIntentForPackage(packageName);
+        if (intent != null) {
             intent.setAction(PACKAGE_INSTALLED_ACTION);
-            PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, intent, 0);
-            return pendingIntent.getIntentSender();
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
         }
-        return null;
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, intent, 0);
+        return pendingIntent.getIntentSender();
     }
 
     @SuppressLint("NewApi")


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

As part of being up-to-date, we should use the latest APIs for distribute before they are removed in future versions of Android (maybe Android 11 will remove the old one?).

https://developer.android.com/reference/android/content/Intent.html#ACTION_INSTALL_PACKAGE is deprecated.

Starting API level 21 we should have started using https://developer.android.com/reference/android/content/pm/PackageInstaller.html.

Since we are compatible with API level min 16 we need to conditionally use PackageInstaller on API level 21+ (or at least 29+ if issues arise between 21-28 range) and fallback to the old code for older platforms.

## Related PRs or issues

[AB#67823](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/67823)

