### PR TITLE
Fix crash when trying to set auth token before start

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -1186,6 +1186,9 @@ public class AppCenter {
      * Implements {@link #setAuthToken} at instance level.
      */
     private void setInstanceAuthToken(String authToken) {
+        if (!checkPrecondition()) {
+            return;
+        }
         AuthTokenContext authTokenContext = AuthTokenContext.getInstance();
         JwtClaims claims = null;
         if (authToken != null) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -470,8 +470,6 @@ public class AppCenter {
      *
      * @param authTokenListener authentication listener defined by the application or null to remove it.
      */
-    // TODO Remove when used in the app without reflection (after release).
-    @SuppressWarnings("WeakerAccess")
     public static void setAuthTokenListener(AuthTokenListener authTokenListener) {
         getInstance().setInstanceAuthTokenListener(authTokenListener);
     }
@@ -1228,7 +1226,11 @@ public class AppCenter {
         } else if (mAuthTokenRefreshListener != null) {
             AppCenterLog.info(LOG_TAG, "Removing auth token refresh listener.");
             authTokenContext.unsetRefreshListener(mAuthTokenRefreshListener);
-            authTokenContext.setAuthToken(null, null, null);
+
+            /* If removed after start, unset token. */
+            if (mApplication != null) {
+                authTokenContext.setAuthToken(null, null, null);
+            }
         }
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -46,6 +46,9 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
     @Test
     public void setAuthToken() {
 
+        /* Start App Center. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+
         /* Given a valid JWT token. */
         final String jwt = "jwt";
         JwtClaims claims = mock(JwtClaims.class);
@@ -59,6 +62,24 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
         /* Then it's stored. */
         verify(mAuthTokenContext).setAuthToken(jwt, claims.getSubject(), claims.getExpirationDate());
     }
+
+    @Test
+    public void setAuthTokenBeforeStart() {
+
+        /* Given a valid JWT token. */
+        final String jwt = "jwt";
+        JwtClaims claims = mock(JwtClaims.class);
+        when(claims.getSubject()).thenReturn("someId");
+        when(claims.getExpirationDate()).thenReturn(new Date(123L));
+        when(JwtClaims.parse(jwt)).thenReturn(claims);
+
+        /* When we set auth token. */
+        AppCenter.setAuthToken(jwt);
+
+        /* Nothing happens. */
+        verify(mAuthTokenContext, never()).setAuthToken(jwt, claims.getSubject(), claims.getExpirationDate());
+    }
+
 
     @Test
     public void unsetAuthToken() {

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -148,6 +149,20 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
         AppCenter.setAuthTokenListener(null);
         verify(mAuthTokenContext).unsetRefreshListener(refreshListener);
         verify(mAuthTokenContext).setAuthToken(null, null, null);
+    }
+
+    @Test
+    public void setAuthTokenListenerWhenPreviouslySetBeforeStart() {
+        AuthTokenListener listener = new AuthTokenListener() {
+
+            @Override
+            public void acquireAuthToken(AuthTokenCallback callback) {
+            }
+        };
+        AppCenter.setAuthTokenListener(listener);
+        AppCenter.setAuthTokenListener(null);
+        verify(mAuthTokenContext).unsetRefreshListener(notNull(AuthTokenContext.RefreshListener.class));
+        verify(mAuthTokenContext, never()).setAuthToken(null, null, null);
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -84,6 +84,9 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
     @Test
     public void unsetAuthToken() {
 
+        /* Start App Center. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
+
         /* When we unset auth token. */
         AppCenter.setAuthToken(null);
 
@@ -97,6 +100,9 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
 
     @Test
     public void setInvalidAuthToken() {
+
+        /* Start App Center. */
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
 
         /* When we set an invalid auth token. */
         when(JwtClaims.parse("invalidJwt")).thenReturn(null);
@@ -120,6 +126,7 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
                 callback.onAuthTokenResult(jwt);
             }
         });
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
         ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
         verify(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
         AuthTokenContext.RefreshListener refreshListener = listenerArgumentCaptor.getValue();
@@ -161,6 +168,7 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
                 callback.onAuthTokenResult(invalidJwt);
             }
         });
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
         ArgumentCaptor<AuthTokenContext.RefreshListener> listenerArgumentCaptor = ArgumentCaptor.forClass(AuthTokenContext.RefreshListener.class);
         verify(mAuthTokenContext).setRefreshListener(listenerArgumentCaptor.capture());
         AuthTokenContext.RefreshListener refreshListener = listenerArgumentCaptor.getValue();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -81,7 +81,6 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
         verify(mAuthTokenContext, never()).setAuthToken(jwt, claims.getSubject(), claims.getExpirationDate());
     }
 
-
     @Test
     public void unsetAuthToken() {
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterAuthTest.java
@@ -152,6 +152,7 @@ public class AppCenterAuthTest extends AbstractAppCenterTest {
 
     @Test
     public void setNullAuthTokenListenerWhenNoneExists() {
+        AppCenter.start(mApplication, DUMMY_APP_SECRET, DummyService.class);
         AppCenter.setAuthTokenListener(null);
         verify(mAuthTokenContext, never()).unsetRefreshListener(any(AuthTokenContext.RefreshListener.class));
         verify(mAuthTokenContext, never()).setAuthToken(anyString(), anyString(), any(Date.class));


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

As usual, any API that accesses storage cannot be called before AppCenter.start (since that's the one getting the Context).

[AB#69443](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69443)