### PR TITLE
Avoid crashing at start if not using the full google-services.json

### DIFF
--- a/apps/sasquatch/google-services.json
+++ b/apps/sasquatch/google-services.json
@@ -13,7 +13,7 @@
             },
             "api_key": [
                 {
-                    "current_key": ""
+                    "current_key": "null"
                 }
             ]
         },
@@ -26,7 +26,7 @@
             },
             "api_key": [
                 {
-                    "current_key": ""
+                    "current_key": "null"
                 }
             ]
         }


### PR DESCRIPTION
Make it crash at Firebase signIn (instead of being stuck in login UI).

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Make it crash at Firebase signIn (instead of being stuck in login UI).