### PR TITLE
Fix issue where auth tokens were refreshed multiple times

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -360,14 +360,20 @@ public class AuthTokenContext {
     public void checkIfTokenNeedsToBeRefreshed(@NonNull AuthTokenInfo authTokenInfo) {
         RefreshListener refreshListener = mRefreshListener.get();
         if (refreshListener != null) {
-            String accountId = getAccountIdToRefreshAndUpdateCache(authTokenInfo);
+            String accountId = getHomeAccountIdToRefreshToken(authTokenInfo);
             if (accountId != null) {
                 refreshListener.onTokenRequiresRefresh(accountId);
             }
         }
     }
 
-    private synchronized String getAccountIdToRefreshAndUpdateCache(@NonNull AuthTokenInfo authTokenInfo) {
+    /**
+     * Check if the last/current token needs a refresh because expiring soon.
+     *
+     * @param authTokenInfo Auth token to check.
+     * @return Home accountId with last token about to expire or already expired.
+     */
+    private synchronized String getHomeAccountIdToRefreshToken(@NonNull AuthTokenInfo authTokenInfo) {
         AuthTokenHistoryEntry lastEntry = getLastHistoryEntry();
         if (lastEntry == null || authTokenInfo.getAuthToken() == null ||
                 !authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) ||

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -87,7 +87,7 @@ public class AuthTokenContext {
     /**
      * The last token to be refreshed. Saved to ensure that it is not refreshed more than once.
      */
-    private String mLastTokenRefreshed;
+    private String mLastTokenRefreshRequest;
 
     /**
      * Initializes AuthTokenContext class.
@@ -371,10 +371,10 @@ public class AuthTokenContext {
         if (lastEntry == null || authTokenInfo.getAuthToken() == null ||
                 !authTokenInfo.getAuthToken().equals(lastEntry.getAuthToken()) ||
                 !authTokenInfo.isAboutToExpire() ||
-                authTokenInfo.getAuthToken().equals(mLastTokenRefreshed)) {
+                authTokenInfo.getAuthToken().equals(mLastTokenRefreshRequest)) {
             return null;
         }
-        mLastTokenRefreshed = authTokenInfo.getAuthToken();
+        mLastTokenRefreshRequest = authTokenInfo.getAuthToken();
         return lastEntry.getHomeAccountId();
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -357,10 +357,10 @@ public class AuthTokenContext {
      * @param authTokenInfo auth token to check for expiration.
      */
     public void checkIfTokenNeedsToBeRefreshed(@NonNull AuthTokenInfo authTokenInfo) {
-        String accountId = getAccountIdToRefreshAndUpdateCache(authTokenInfo);
-        if (accountId != null) {
-            RefreshListener refreshListener = mRefreshListener.get();
-            if (refreshListener != null) {
+        RefreshListener refreshListener = mRefreshListener.get();
+        if (refreshListener != null) {
+            String accountId = getAccountIdToRefreshAndUpdateCache(authTokenInfo);
+            if (accountId != null) {
                 refreshListener.onTokenRequiresRefresh(accountId);
             }
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/context/AuthTokenContext.java
@@ -211,6 +211,7 @@ public class AuthTokenContext {
      * @return true if it is a new user.
      */
     private synchronized Boolean addTokenHistory(String authToken, String homeAccountId, Date expiresOn) {
+        mLastTokenRefreshRequest = null;
         List<AuthTokenHistoryEntry> history = getHistory();
         if (history == null) {
             history = new ArrayList<>();

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/context/AuthTokenContextTest.java
@@ -392,24 +392,4 @@ public class AuthTokenContextTest {
         mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
         verify(refreshListener, times(1)).onTokenRequiresRefresh(eq("accountId2"));
     }
-
-    @Test
-    public void sameAuthTokenRefreshedAgainIfNoListenerOnFirstTry() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, -60);
-        mAuthTokenContext.setAuthToken("authToken1", "accountId1", calendar.getTime());
-        calendar.add(Calendar.SECOND, 1);
-        mAuthTokenContext.setAuthToken("authToken2", "accountId2", calendar.getTime());
-        List<AuthTokenInfo> tokenInfoList = mAuthTokenContext.getAuthTokenValidityList();
-        AuthTokenInfo authTokenInfo = tokenInfoList.get(tokenInfoList.size() - 1);
-        AuthTokenContext.RefreshListener refreshListener = mock(AuthTokenContext.RefreshListener.class);
-
-        /* Check refresh once before setting the listener. */
-        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
-
-        /* Set a listener and then refresh again to make sure the callback is invoked. */
-        mAuthTokenContext.setRefreshListener(refreshListener);
-        mAuthTokenContext.checkIfTokenNeedsToBeRefreshed(authTokenInfo);
-        verify(refreshListener).onTokenRequiresRefresh(eq("accountId2"));
-    }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

Fixes an issue where a single token can be refreshed multiple times.

Sorry about the messy history- accidentally pushed to feature branch at first, then reverted, and this pr reverts that revert.

[AB#69442](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69442)