### PR TITLE
Android 4 release download task doesn't enforce HTTPS during redirects

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/http/HttpConnectionDownloadFileTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/http/HttpConnectionDownloadFileTask.java
@@ -88,7 +88,7 @@ class HttpConnectionDownloadFileTask extends AsyncTask<Void, Void, Void> {
      * Create connection for downloading.
      *
      * @return instance of {@link URLConnection}.
-     * @throws IOException if connection fails
+     * @throws IOException if connection fails.
      */
     private URLConnection createConnection() throws IOException {
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/http/HttpConnectionDownloadFileTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/http/HttpConnectionDownloadFileTask.java
@@ -73,6 +73,8 @@ class HttpConnectionDownloadFileTask extends AsyncTask<Void, Void, Void> {
             long totalBytesDownloaded = downloadFile(connection);
             if (totalBytesDownloaded > 0) {
                 mDownloader.onDownloadComplete(mTargetFile);
+            } else {
+                throw new IOException("The content of downloaded file is empty");
             }
         } catch (IOException e) {
             mDownloader.onDownloadError(e.getMessage());

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClientCallTask.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/DefaultHttpClientCallTask.java
@@ -7,7 +7,6 @@ package com.microsoft.appcenter.http;
 
 import android.net.TrafficStats;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
 
@@ -22,7 +21,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,11 +36,10 @@ import static com.microsoft.appcenter.http.DefaultHttpClient.CONTENT_ENCODING_VA
 import static com.microsoft.appcenter.http.DefaultHttpClient.CONTENT_TYPE_KEY;
 import static com.microsoft.appcenter.http.DefaultHttpClient.CONTENT_TYPE_VALUE;
 import static com.microsoft.appcenter.http.DefaultHttpClient.METHOD_POST;
-import static com.microsoft.appcenter.http.HttpUtils.CONNECT_TIMEOUT;
 import static com.microsoft.appcenter.http.HttpUtils.READ_BUFFER_SIZE;
-import static com.microsoft.appcenter.http.HttpUtils.READ_TIMEOUT;
 import static com.microsoft.appcenter.http.HttpUtils.THREAD_STATS_TAG;
 import static com.microsoft.appcenter.http.HttpUtils.WRITE_BUFFER_SIZE;
+import static com.microsoft.appcenter.http.HttpUtils.createHttpsConnection;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -160,41 +157,9 @@ class DefaultHttpClientCallTask extends AsyncTask<Void, Void, Object> {
      * Do http call.
      */
     private Pair<String, Map<String, String>> doHttpCall() throws Exception {
-
-        /* HTTP session. */
-        if (!mUrl.startsWith("https")) {
-            throw new IOException("App Center support only HTTPS connection.");
-        }
         URL url = new URL(mUrl);
-        URLConnection urlConnection = url.openConnection();
-        HttpsURLConnection httpsURLConnection;
-        if (urlConnection instanceof HttpsURLConnection) {
-            httpsURLConnection = (HttpsURLConnection) urlConnection;
-        } else {
-            throw new IOException("App Center supports only HTTPS connection.");
-        }
+        HttpsURLConnection httpsURLConnection = createHttpsConnection(url);
         try {
-
-            /*
-             * Make sure we use TLS 1.2 when the device supports it but not enabled by default.
-             * Don't hardcode TLS version when enabled by default to avoid unnecessary wrapping and
-             * to support future versions of TLS such as say 1.3 without having to patch this code.
-             *
-             * TLS 1.2 was enabled by default only on Android 5.0:
-             * https://developer.android.com/about/versions/android-5.0-changes#ssl
-             * https://developer.android.com/reference/javax/net/ssl/SSLSocket#default-configuration-for-different-android-versions
-             *
-             * There is a problem that TLS 1.2 is still disabled by default on some Samsung devices
-             * with API 21, so apply the rule to this API level as well.
-             * See https://github.com/square/okhttp/issues/2372#issuecomment-244807676
-             */
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
-                httpsURLConnection.setSSLSocketFactory(new TLS1_2SocketFactory());
-            }
-
-            /* Configure connection timeouts. */
-            httpsURLConnection.setConnectTimeout(CONNECT_TIMEOUT);
-            httpsURLConnection.setReadTimeout(READ_TIMEOUT);
 
             /* Build payload now if POST. */
             httpsURLConnection.setRequestMethod(mMethod);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpUtils.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpUtils.java
@@ -224,8 +224,8 @@ public class HttpUtils {
      * @throws IOException if connection fails.
      */
     @NonNull
-    public static HttpsURLConnection createHttpsConnection(URL url) throws IOException {
-        if (!url.getProtocol().equals("https")) {
+    public static HttpsURLConnection createHttpsConnection(@NonNull URL url) throws IOException {
+        if (!"https".equals(url.getProtocol())) {
             throw new IOException("App Center support only HTTPS connection.");
         }
         URLConnection urlConnection = url.openConnection();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/TLS1_2SocketFactory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/TLS1_2SocketFactory.java
@@ -20,7 +20,7 @@ import static javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory;
 /**
  * This class forces TLS 1.2 protocol via adapter pattern.
  */
-public class TLS1_2SocketFactory extends SSLSocketFactory {
+class TLS1_2SocketFactory extends SSLSocketFactory {
 
     /**
      * TLS 1.2 protocol name.
@@ -39,7 +39,7 @@ public class TLS1_2SocketFactory extends SSLSocketFactory {
      */
     private final SSLSocketFactory delegate;
 
-    public TLS1_2SocketFactory() {
+    TLS1_2SocketFactory() {
         SSLSocketFactory socketFactory = null;
         try {
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/DefaultHttpClientTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/http/DefaultHttpClientTest.java
@@ -83,6 +83,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
         AppCenterLog.class,
         DefaultHttpClient.class,
         DefaultHttpClientCallTask.class,
+        HttpUtils.class,
         TrafficStats.class
 })
 public class DefaultHttpClientTest {
@@ -153,6 +154,15 @@ public class DefaultHttpClientTest {
         mockCall(null);
     }
 
+    private static HttpsURLConnection mockConnection(String urlString) throws Exception {
+        URL url = mock(URL.class);
+        whenNew(URL.class).withArguments(urlString).thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
+        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
+        when(url.openConnection()).thenReturn(urlConnection);
+        return urlConnection;
+    }
+
     @Test
     public void tls1_2Enforcement() throws Exception {
 
@@ -168,10 +178,7 @@ public class DefaultHttpClientTest {
 
     private void testTls1_2Setting(int apiLevel, int tlsSetExpectedCalls) throws Exception {
         String urlString = "https://mock/logs?api-version=1.0.0";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         DefaultHttpClient httpClient = new DefaultHttpClient();
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", apiLevel);
         httpClient.callAsync(urlString, METHOD_POST, new HashMap<String, String>(), null, mock(ServiceCallback.class));
@@ -200,10 +207,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/logs?api-version=1.0.0";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -232,7 +236,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection).setRequestMethod("POST");
         verify(urlConnection).setDoOutput(true);
         verify(urlConnection).disconnect();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate).buildRequestBody();
         httpClient.close();
 
@@ -256,10 +260,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/logs?api-version=1.0.0";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -298,10 +299,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -331,7 +329,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection, never()).setDoOutput(true);
         verify(urlConnection).disconnect();
         verify(inputStream).close();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate, never()).buildRequestBody();
         httpClient.close();
     }
@@ -341,10 +339,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(outputStream);
         ByteArrayInputStream inputStream = new ByteArrayInputStream("OK".getBytes());
@@ -376,11 +371,8 @@ public class DefaultHttpClientTest {
     public void get100() throws Exception {
 
         /* Configure mock HTTPS. */
-        URL url = mock(URL.class);
         String urlString = "https://mock/get";
-        whenNew(URL.class).withAnyArguments().thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(100);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -404,10 +396,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -445,10 +434,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -471,7 +457,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection, never()).setDoOutput(true);
         verify(urlConnection).disconnect();
         verify(inputStream).close();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate, never()).buildRequestBody();
         httpClient.close();
 
@@ -508,10 +494,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -534,7 +517,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection, never()).setDoOutput(true);
         verify(urlConnection).disconnect();
         verify(inputStream).close();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate, never()).buildRequestBody();
         httpClient.close();
 
@@ -558,10 +541,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -590,7 +570,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection, never()).setDoOutput(true);
         verify(urlConnection).disconnect();
         verify(inputStream).close();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate, never()).buildRequestBody();
         httpClient.close();
 
@@ -615,10 +595,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(304);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -644,10 +621,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withAnyArguments().thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(503);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -717,10 +691,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         mockCall(new Consumer<DefaultHttpClientCallTask>() {
 
             @Override
@@ -744,10 +715,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/post";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
         mockCall(new Consumer<DefaultHttpClientCallTask>() {
@@ -774,10 +742,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         mockCall(new Consumer<DefaultHttpClientCallTask>() {
 
             @Override
@@ -801,10 +766,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -831,10 +793,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock/get";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(503);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -861,6 +820,7 @@ public class DefaultHttpClientTest {
         String urlString = "https://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
         IOException exception = new IOException("mock");
         when(url.openConnection()).thenThrow(exception);
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);
@@ -878,6 +838,7 @@ public class DefaultHttpClientTest {
         String urlString = "https://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
         IOException exception = new IOException("mock");
         HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
         when(url.openConnection()).thenReturn(urlConnection);
@@ -904,6 +865,7 @@ public class DefaultHttpClientTest {
         String urlString = "https://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
         IOException exception = new IOException("mock");
         HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
         when(url.openConnection()).thenReturn(urlConnection);
@@ -932,6 +894,7 @@ public class DefaultHttpClientTest {
         String urlString = "https://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
         when(url.openConnection()).thenThrow(new Error());
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
@@ -953,11 +916,8 @@ public class DefaultHttpClientTest {
     public void failedSerialization() throws Exception {
 
         /* Configure mock HTTPS. */
-        URL url = mock(URL.class);
         String urlString = "https://mock/get";
-        whenNew(URL.class).withAnyArguments().thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
 
         /* Configure API client. */
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);
@@ -1028,10 +988,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -1074,7 +1031,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection).setRequestMethod("POST");
         verify(urlConnection).setDoOutput(true);
         verify(urlConnection).disconnect();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate).buildRequestBody();
         httpClient.close();
 
@@ -1100,10 +1057,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTP. */
         String urlString = "https://mock";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -1139,7 +1093,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection).setRequestMethod("POST");
         verify(urlConnection).setDoOutput(true);
         verify(urlConnection).disconnect();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate).buildRequestBody();
         httpClient.close();
 
@@ -1165,10 +1119,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -1204,7 +1155,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection).setRequestMethod("POST");
         verify(urlConnection).setDoOutput(true);
         verify(urlConnection).disconnect();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate).buildRequestBody();
         httpClient.close();
 
@@ -1230,10 +1181,7 @@ public class DefaultHttpClientTest {
 
         /* Configure mock HTTPS. */
         String urlString = "https://mock";
-        URL url = mock(URL.class);
-        whenNew(URL.class).withArguments(urlString).thenReturn(url);
-        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
-        when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnection urlConnection = mockConnection(urlString);
         when(urlConnection.getResponseCode()).thenReturn(200);
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         when(urlConnection.getOutputStream()).thenReturn(buffer);
@@ -1276,7 +1224,7 @@ public class DefaultHttpClientTest {
         verify(urlConnection).setRequestMethod("POST");
         verify(urlConnection).setDoOutput(true);
         verify(urlConnection).disconnect();
-        verify(callTemplate).onBeforeCalling(eq(url), anyMapOf(String.class, String.class));
+        verify(callTemplate).onBeforeCalling(any(URL.class), anyMapOf(String.class, String.class));
         verify(callTemplate).buildRequestBody();
         httpClient.close();
 
@@ -1298,6 +1246,7 @@ public class DefaultHttpClientTest {
         String urlString = "http://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("http");
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
         DefaultHttpClient httpClient = new DefaultHttpClient();
@@ -1313,6 +1262,7 @@ public class DefaultHttpClientTest {
         String urlString = "bad url";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn(null);
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);
         ServiceCallback serviceCallback = mock(ServiceCallback.class);
         DefaultHttpClient httpClient = new DefaultHttpClient();
@@ -1328,6 +1278,7 @@ public class DefaultHttpClientTest {
         String urlString = "https://mock/get";
         URL url = mock(URL.class);
         whenNew(URL.class).withAnyArguments().thenReturn(url);
+        when(url.getProtocol()).thenReturn("https");
         HttpURLConnection urlConnection = mock(HttpURLConnection.class);
         when(url.openConnection()).thenReturn(urlConnection);
         HttpClient.CallTemplate callTemplate = mock(HttpClient.CallTemplate.class);


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Android 4 release download task doesn't enforce HTTPS during redirects

## Related PRs or issues

[AB#69978](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69978)
