### PR TITLE
Android insecure deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### App Center Crashes
 
-* **[Breaking change]** Remove insecure implementation of `ErrorReport.getThrowable` and `ErrorReport.setThrowable` (now marked as deprecated and always returns `null`). Provide `ErrorReport.getStackTrace` and `ErrorReport.setStackTrace` as an alternative.
+* **[Behavior change]** Deprecate and remove insecure implementation of `ErrorReport.getThrowable()`, which now always returns `null`. Use the new `ErrorReport.getStackTrace()` as an alternative.
 
 ### App Center Data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Accounts in any Azure AD directory.
   - Accounts in any Azure AD directory and personal Microsoft accounts.
 
+### App Center Crashes
+
+* **[Breaking change]** Remove insecure implementation of `ErrorReport.getThrowable` and `ErrorReport.setThrowable` (now marked as deprecated and always returns `null`). Provide `ErrorReport.getStackTrace` and `ErrorReport.setStackTrace` as an alternative.
+
 ### App Center Data
 
 * **[Fix]** Reduced retries on Data-related operations to fail fast and avoid the perception of calls "hanging".

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/appcenter/sasquatch/activities/CrashesTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/appcenter/sasquatch/activities/CrashesTest.java
@@ -48,6 +48,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withChild;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.sasquatch.activities.utils.EspressoUtils.CHECK_DELAY;
 import static com.microsoft.appcenter.sasquatch.activities.utils.EspressoUtils.TOAST_DELAY;
 import static com.microsoft.appcenter.sasquatch.activities.utils.EspressoUtils.onToast;
@@ -57,7 +58,6 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -184,7 +184,7 @@ public class CrashesTest {
                 new Date().getTime() - errorReport.getAppErrorTime().getTime(),
                 lessThan(10000L));
         assertNotNull(errorReport.getDevice());
-        assertNotNull(errorReport.getStackTrace());
+        assertEquals(getStackTraceString(failureHandler.uncaughtException), errorReport.getStackTrace());
 
         /* Send report. */
         waitFor(onView(withText(R.string.crash_confirmation_dialog_send_button))

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/appcenter/sasquatch/activities/CrashesTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/appcenter/sasquatch/activities/CrashesTest.java
@@ -184,9 +184,7 @@ public class CrashesTest {
                 new Date().getTime() - errorReport.getAppErrorTime().getTime(),
                 lessThan(10000L));
         assertNotNull(errorReport.getDevice());
-        assertEquals(failureHandler.uncaughtException.getClass(), errorReport.getThrowable().getClass());
-        assertEquals(failureHandler.uncaughtException.getMessage(), errorReport.getThrowable().getMessage());
-        assertArrayEquals(failureHandler.uncaughtException.getStackTrace(), errorReport.getThrowable().getStackTrace());
+        assertNotNull(errorReport.getStackTrace());
 
         /* Send report. */
         waitFor(onView(withText(R.string.crash_confirmation_dialog_send_button))

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -373,7 +373,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void accept(ErrorReport data) {
                 if (data != null) {
-                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", data.getThrowable());
+                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getStackTrace()=" + data.getStackTrace());
                 }
             }
         });

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -7,10 +7,10 @@ package com.microsoft.appcenter.sasquatch.activities;
 
 import android.annotation.SuppressLint;
 import android.app.Application;
-import android.content.res.Resources;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.StrictMode;
@@ -373,7 +373,13 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void accept(ErrorReport data) {
                 if (data != null) {
-                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getStackTrace()=" + data.getStackTrace());
+
+                    /* TODO remove reflection and catch block after API available to jCenter. */
+                    try {
+                        String stackTrace = (String) ErrorReport.class.getMethod("getStackTrace").invoke(data);
+                        Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getStackTrace()=" + stackTrace);
+                    } catch (Exception ignored) {
+                    }
                 }
             }
         });

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -374,7 +374,8 @@ public class MainActivity extends AppCompatActivity {
             public void accept(ErrorReport data) {
                 if (data != null) {
 
-                    /* TODO remove reflection and catch block after API available to jCenter. */
+                    /* TODO uncomment the next line, remove reflection and catch block after API available to jCenter. */
+                    /* Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getStackTrace()=" + data.getStackTrace()); */
                     try {
                         String stackTrace = (String) ErrorReport.class.getMethod("getStackTrace").invoke(data);
                         Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getStackTrace()=" + stackTrace);

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
@@ -147,7 +147,8 @@ public class SasquatchCrashesListener extends AbstractCrashesListener {
     public void onSendingSucceeded(ErrorReport report) {
         String message = String.format("%s\nCrash ID: %s", mContext.getString(R.string.crash_sent_succeeded), report.getId());
 
-        /* TODO remove reflection and catch block after API available to jCenter. */
+        /* TODO uncomment the next line, remove reflection and catch block after API available to jCenter. */
+        /* message += String.format("\nStackTrace: %s", report.getStackTrace()); */
         try {
             String stackTrace = (String) ErrorReport.class.getMethod("getStackTrace").invoke(report);
             message += String.format("\nStackTrace: %s", stackTrace);

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
@@ -146,8 +146,8 @@ public class SasquatchCrashesListener extends AbstractCrashesListener {
     @Override
     public void onSendingSucceeded(ErrorReport report) {
         String message = String.format("%s\nCrash ID: %s", mContext.getString(R.string.crash_sent_succeeded), report.getId());
-        if (report.getThrowable() != null) {
-            message += String.format("\nThrowable: %s", report.getThrowable().toString());
+        if (report.getStackTrace() != null) {
+            message += String.format("\nStackTrace: %s", report.getStackTrace());
         }
         notifySending(message);
     }

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
@@ -146,8 +146,12 @@ public class SasquatchCrashesListener extends AbstractCrashesListener {
     @Override
     public void onSendingSucceeded(ErrorReport report) {
         String message = String.format("%s\nCrash ID: %s", mContext.getString(R.string.crash_sent_succeeded), report.getId());
-        if (report.getStackTrace() != null) {
-            message += String.format("\nStackTrace: %s", report.getStackTrace());
+
+        /* TODO remove reflection and catch block after API available to jCenter. */
+        try {
+            String stackTrace = (String) ErrorReport.class.getMethod("getStackTrace").invoke(report);
+            message += String.format("\nStackTrace: %s", stackTrace);
+        } catch (Exception ignored) {
         }
         notifySending(message);
     }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -16,7 +16,6 @@ import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog;
 import com.microsoft.appcenter.crashes.ingestion.models.ManagedErrorLog;
 import com.microsoft.appcenter.crashes.model.ErrorReport;
-import com.microsoft.appcenter.crashes.model.NativeException;
 import com.microsoft.appcenter.crashes.utils.ErrorLogHelper;
 import com.microsoft.appcenter.ingestion.Ingestion;
 import com.microsoft.appcenter.ingestion.models.Log;

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -191,8 +191,7 @@ public class CrashesAndroidTest {
         startFresh(null);
         ErrorReport errorReport = Crashes.getLastSessionCrashReport().get();
         assertNotNull(errorReport);
-        Throwable lastThrowable = errorReport.getThrowable();
-        assertTrue(lastThrowable instanceof IllegalArgumentException);
+        assertNotNull(errorReport.getStackTrace());
         assertTrue(Crashes.hasCrashedInLastSession().get());
 
         /* Disable SDK, that will clear the report. */
@@ -236,9 +235,7 @@ public class CrashesAndroidTest {
         startFresh(null);
         ErrorReport errorReport = Crashes.getLastSessionCrashReport().get();
         assertNotNull(errorReport);
-        Throwable lastThrowable = errorReport.getThrowable();
-        assertTrue(lastThrowable instanceof StackOverflowError);
-        assertEquals(ErrorLogHelper.FRAME_LIMIT, lastThrowable.getStackTrace().length);
+        assertNotNull(errorReport.getStackTrace());
         assertTrue(Crashes.hasCrashedInLastSession().get());
     }
 
@@ -264,7 +261,7 @@ public class CrashesAndroidTest {
         ErrorReport errorReport = Crashes.getLastSessionCrashReport().get();
         assertNotNull(errorReport);
         assertTrue(Crashes.hasCrashedInLastSession().get());
-        assertTrue(errorReport.getThrowable() instanceof NativeException);
+        assertNotNull(errorReport.getStackTrace());
 
         /* File has been deleted. */
         assertFalse(minidumpFile.exists());
@@ -360,8 +357,7 @@ public class CrashesAndroidTest {
             @Override
             public void accept(ErrorReport errorReport) {
                 assertNotNull(errorReport);
-                Throwable lastThrowable = errorReport.getThrowable();
-                assertTrue(lastThrowable instanceof RuntimeException);
+                assertNotNull(errorReport.getStackTrace());
             }
         });
         assertTrue(Crashes.hasCrashedInLastSession().get());

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -83,18 +83,18 @@ public class WrapperSdkExceptionManagerAndroidTest {
     public void saveWrapperException() throws java.lang.Exception {
 
         class ErrorData {
-            private byte[] data;
+            private String data;
             private UUID id;
         }
 
         ErrorData errorA = new ErrorData();
-        errorA.data = new byte[]{};
+        errorA.data = "";
 
         ErrorData errorB = new ErrorData();
         errorB.data = null;
 
         ErrorData errorC = new ErrorData();
-        errorC.data = new byte[]{'d', 'a', 't', 'a'};
+        errorC.data = "data";
 
         ErrorData[] errors = new ErrorData[]{errorA, errorB, errorC};
 
@@ -105,7 +105,7 @@ public class WrapperSdkExceptionManagerAndroidTest {
 
             /* Save crash. */
             error.id = WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), error.data);
-            byte[] loadedData = WrapperSdkExceptionManager.loadWrapperExceptionData(error.id);
+            String loadedData = WrapperSdkExceptionManager.loadWrapperExceptionData(error.id);
 
             if (error.data == null) {
                 assertNull(loadedData);
@@ -113,28 +113,22 @@ public class WrapperSdkExceptionManagerAndroidTest {
             }
 
             assertNotNull(loadedData);
-            for (int i = 0; i < error.data.length; ++i) {
-                assertEquals(error.data[i], loadedData[i]);
-            }
+            assertEquals(error.data, loadedData);
         }
 
         /* Even after deleting errorA, it should exist in memory - so, we can still load it. */
         WrapperSdkExceptionManager.deleteWrapperExceptionData(errorA.id);
-        byte[] loadedDataA = WrapperSdkExceptionManager.loadWrapperExceptionData(errorA.id);
+        String loadedDataA = WrapperSdkExceptionManager.loadWrapperExceptionData(errorA.id);
         assertNotNull(loadedDataA);
-        for (int i = 0; i < errorA.data.length; ++i) {
-            assertEquals(errorA.data[i], loadedDataA[i]);
-        }
+        assertEquals(errorA.data, loadedDataA);
 
         /* Try to load data bypassing the cache. */
         WrapperSdkExceptionManager.sWrapperExceptionDataContainer.clear();
-        byte[] loadedDataC = WrapperSdkExceptionManager.loadWrapperExceptionData(errorC.id);
+        String loadedDataC = WrapperSdkExceptionManager.loadWrapperExceptionData(errorC.id);
         assertNotNull(loadedDataC);
-        for (int i = 0; i < errorC.data.length; ++i) {
-            assertEquals(errorC.data[i], loadedDataC[i]);
-        }
+        assertEquals(errorC.data, loadedDataC);
 
         /* Save another crash without reset: will be ignored as only 1 crash per process. */
-        assertNull(WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'e'}));
+        assertNull(WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), "e"));
     }
 }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -49,7 +49,9 @@ public class WrapperSdkExceptionManagerAndroidTest {
     public void setUp() {
         android.util.Log.i(TAG, "Cleanup");
         SharedPreferencesManager.clear();
-        for (File logFile : ErrorLogHelper.getErrorStorageDirectory().listFiles()) {
+        File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles();
+        assertNotNull(files);
+        for (File logFile : files) {
             if (!logFile.isDirectory()) {
                 assertTrue(logFile.delete());
             }
@@ -71,6 +73,16 @@ public class WrapperSdkExceptionManagerAndroidTest {
         method = AppCenter.class.getDeclaredMethod("setChannel", Channel.class);
         method.setAccessible(true);
         method.invoke(appCenter, mock(Channel.class));
+
+
+        /* Since this is a real Android test, it might actually tries to send crash and might delete files on sending completion. Avoid that. */
+        Crashes.setListener(new AbstractCrashesListener() {
+
+            @Override
+            public boolean shouldAwaitUserConfirmation() {
+                return false;
+            }
+        });
 
         /* Start crashes. */
         AppCenter.start(Crashes.class);

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -74,8 +74,10 @@ public class WrapperSdkExceptionManagerAndroidTest {
         method.setAccessible(true);
         method.invoke(appCenter, mock(Channel.class));
 
-
-        /* Since this is a real Android test, it might actually tries to send crash and might delete files on sending completion. Avoid that. */
+        /*
+         * Since this is a real Android test, it might actually try to send crash logs
+         * and will delete files on sending completion. Avoid that by requesting user confirmation.
+         */
         Crashes.setListener(new AbstractCrashesListener() {
 
             @Override

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -96,7 +96,10 @@ public class WrapperSdkExceptionManagerAndroidTest {
         ErrorData errorC = new ErrorData();
         errorC.data = "data";
 
-        ErrorData[] errors = new ErrorData[]{errorA, errorB, errorC};
+        ErrorData errorD = new ErrorData();
+        errorD.data = "otherData";
+
+        ErrorData[] errors = new ErrorData[]{errorA, errorB, errorC, errorD};
 
         for (ErrorData error : errors) {
 
@@ -116,11 +119,15 @@ public class WrapperSdkExceptionManagerAndroidTest {
             assertEquals(error.data, loadedData);
         }
 
-        /* Even after deleting errorA, it should exist in memory - so, we can still load it. */
+        /* Even after deleting errorA and errorD, they should exist in memory - so, we can still load it. */
         WrapperSdkExceptionManager.deleteWrapperExceptionData(errorA.id);
         String loadedDataA = WrapperSdkExceptionManager.loadWrapperExceptionData(errorA.id);
         assertNotNull(loadedDataA);
         assertEquals(errorA.data, loadedDataA);
+        WrapperSdkExceptionManager.deleteWrapperExceptionData(errorD.id);
+        String loadedDataD = WrapperSdkExceptionManager.loadWrapperExceptionData(errorD.id);
+        assertNotNull(loadedDataD);
+        assertEquals(errorD.data, loadedDataD);
 
         /* Try to load data bypassing the cache. */
         WrapperSdkExceptionManager.sWrapperExceptionDataContainer.clear();

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -61,6 +61,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE;
+import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.Constants.WRAPPER_SDK_NAME_NDK;
 
 /**
@@ -1068,11 +1069,11 @@ public class Crashes extends AbstractAppCenterService {
         File throwableFile = new File(errorStorageDirectory, filename + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
         if (throwable != null) {
             try {
-                String stackTrace = android.util.Log.getStackTraceString(throwable);
+                String stackTrace = getStackTraceString(throwable);
                 FileManager.write(throwableFile, stackTrace);
                 AppCenterLog.debug(LOG_TAG, "Saved stackTrace as is for client side inspection in " + throwableFile + " stackTrace:" + stackTrace);
             } catch (StackOverflowError e) {
-                AppCenterLog.error(Crashes.LOG_TAG, "Failed to store throwable", e);
+                AppCenterLog.error(Crashes.LOG_TAG, "Failed to store stacktrace.", e);
                 throwable = null;
 
                 //noinspection ResultOfMethodCallIgnored

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -1070,7 +1070,7 @@ public class Crashes extends AbstractAppCenterService {
             try {
                 String stackTrace = android.util.Log.getStackTraceString(throwable);
                 FileManager.write(throwableFile, stackTrace);
-                AppCenterLog.debug(Crashes.LOG_TAG, "Saved stackTrace as is for client side inspection in " + throwableFile + " stackTrace:" + stackTrace);
+                AppCenterLog.debug(LOG_TAG, "Saved stackTrace as is for client side inspection in " + throwableFile + " stackTrace:" + stackTrace);
             } catch (StackOverflowError e) {
                 AppCenterLog.error(Crashes.LOG_TAG, "Failed to store throwable", e);
                 throwable = null;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -61,6 +61,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE;
+import static com.microsoft.appcenter.Constants.WRAPPER_SDK_NAME_NDK;
 
 /**
  * Crashes service.
@@ -92,7 +93,7 @@ public class Crashes extends AbstractAppCenterService {
      * Preference storage key for memory running level.
      */
     @VisibleForTesting
-    public static final String PREF_KEY_MEMORY_RUNNING_LEVEL = "com.microsoft.appcenter.crashes.memory";
+    static final String PREF_KEY_MEMORY_RUNNING_LEVEL = "com.microsoft.appcenter.crashes.memory";
 
     /**
      * Group for sending logs.
@@ -654,7 +655,7 @@ public class Crashes extends AbstractAppCenterService {
             File dest = new File(ErrorLogHelper.getPendingMinidumpDirectory(), logFile.getName());
             Exception modelException = new Exception();
             modelException.setType("minidump");
-            modelException.setWrapperSdkName(Constants.WRAPPER_SDK_NAME_NDK);
+            modelException.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
             modelException.setMinidumpFilePath(dest.getPath());
             ManagedErrorLog errorLog = new ManagedErrorLog();
             errorLog.setException(modelException);
@@ -694,8 +695,8 @@ public class Crashes extends AbstractAppCenterService {
             errorLog.setUserId(UserIdContext.getInstance().getUserId());
             try {
                 errorLog.setDevice(DeviceInfoHelper.getDeviceInfo(mContext));
-                errorLog.getDevice().setWrapperSdkName(Constants.WRAPPER_SDK_NAME_NDK);
-                saveErrorLogFiles(new NativeException(), errorLog); // TODO
+                errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+                saveErrorLogFiles(new NativeException(), errorLog);
                 if (!logFile.renameTo(dest)) {
                     throw new IOException("Failed to move file");
                 }
@@ -918,7 +919,7 @@ public class Crashes extends AbstractAppCenterService {
                         ErrorAttachmentLog dumpAttachment = null;
                         Map.Entry<UUID, ErrorLogReport> unprocessedEntry = unprocessedIterator.next();
                         ErrorLogReport errorLogReport = unprocessedEntry.getValue();
-                        if (errorLogReport.report.getThrowable() instanceof NativeException) { // TODO
+                        if (errorLogReport.report.getDevice() != null && WRAPPER_SDK_NAME_NDK.equals(errorLogReport.report.getDevice().getWrapperSdkName())) {
 
                             /* Get minidump file path. */
                             Exception exception = errorLogReport.log.getException();

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -1068,7 +1068,7 @@ public class Crashes extends AbstractAppCenterService {
         File throwableFile = new File(errorStorageDirectory, filename + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
         if (throwable != null) {
             try {
-                String stackTrace = throwable.toString();
+                String stackTrace = android.util.Log.getStackTraceString(throwable);
                 FileManager.write(throwableFile, stackTrace);
                 AppCenterLog.debug(Crashes.LOG_TAG, "Saved stackTrace as is for client side inspection in " + throwableFile + " stackTrace:" + stackTrace);
             } catch (StackOverflowError e) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManager.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManager.java
@@ -79,7 +79,7 @@ public class WrapperSdkExceptionManager {
         if (dataFile.exists()) {
             String loadResult = loadWrapperExceptionData(errorId);
             if (loadResult == null) {
-                AppCenterLog.error(Crashes.LOG_TAG, "Failed to delete wrapper exception data: data not found");
+                AppCenterLog.error(Crashes.LOG_TAG, "Failed to load wrapper exception data.");
             }
             FileManager.delete(dataFile);
         }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/model/ErrorReport.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/model/ErrorReport.java
@@ -112,7 +112,7 @@ public class ErrorReport {
     /**
      * Sets the throwable.
      *
-     * @deprecated This method has been deprecated, use {@link #setStackTrace(String)} instead.
+     * @deprecated This method has been deprecated.
      * @param throwable A throwable to set.
      */
     @Deprecated

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/model/ErrorReport.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/model/ErrorReport.java
@@ -25,9 +25,9 @@ public class ErrorReport {
     private String threadName;
 
     /**
-     * The throwable that caused the crash.
+     * The stack trace of the crash.
      */
-    private Throwable throwable;
+    private String stackTrace;
 
     /**
      * The date and time the application started, <code>null</code> if unknown.
@@ -81,21 +81,42 @@ public class ErrorReport {
     }
 
     /**
+     * Gets the stack trace of the crash.
+     *
+     * @return The stack trace.
+     */
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    /**
+     * Sets the stack trace of the crash.
+     *
+     * @param stackTrace The stack trace.
+     */
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    /**
      * Gets the throwable.
      *
+     * @deprecated This method has been deprecated, use {@link #getStackTrace()} instead.
      * @return The throwable.
      */
+    @Deprecated
     public Throwable getThrowable() {
-        return throwable;
+        return null;
     }
 
     /**
      * Sets the throwable.
      *
+     * @deprecated This method has been deprecated, use {@link #setStackTrace(String)} instead.
      * @param throwable A throwable to set.
      */
+    @Deprecated
     public void setThrowable(Throwable throwable) {
-        this.throwable = throwable;
     }
 
     /**

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -291,11 +291,11 @@ public class ErrorLogHelper {
     }
 
     @NonNull
-    public static ErrorReport getErrorReportFromErrorLog(@NonNull ManagedErrorLog log, Throwable throwable) {
+    public static ErrorReport getErrorReportFromErrorLog(@NonNull ManagedErrorLog log, String stackTrace) {
         ErrorReport report = new ErrorReport();
         report.setId(log.getId().toString());
         report.setThreadName(log.getErrorThreadName());
-        report.setThrowable(throwable);
+        report.setStackTrace(stackTrace);
         report.setAppStartTime(log.getAppLaunchTimestamp());
         report.setAppErrorTime(log.getTimestamp());
         report.setDevice(log.getDevice());

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1584,8 +1584,9 @@ public class CrashesTest {
         when(logSerializer.serializeLog(any(Log.class))).thenReturn(jsonCrash);
 
         /* Mock storage to fail on stack overflow when saving a Throwable as binary. */
+        Throwable throwable = new Throwable();
         doThrow(new StackOverflowError()).when(FileManager.class);
-        FileManager.write(any(File.class), anyString());
+        FileManager.write(throwableFile, throwable.toString());
 
         /* Simulate start SDK. */
         Crashes crashes = Crashes.getInstance();
@@ -1594,7 +1595,6 @@ public class CrashesTest {
         crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Simulate crash. */
-        Throwable throwable = new Throwable();
         Crashes.getInstance().saveUncaughtException(Thread.currentThread(), throwable);
 
         /* Verify we gracefully abort saving throwable (no exception) and we created an empty file instead. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -81,6 +81,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN;
+import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.Constants.WRAPPER_SDK_NAME_NDK;
 import static com.microsoft.appcenter.Flags.CRITICAL;
 import static com.microsoft.appcenter.Flags.DEFAULTS;
@@ -347,7 +348,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         CrashesListener mockListener = mock(CrashesListener.class);
@@ -396,7 +397,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException()).thenReturn(new byte[]{});
 
@@ -439,7 +440,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         when(SharedPreferencesManager.getBoolean(eq(Crashes.PREF_KEY_ALWAYS_SEND), anyBoolean())).thenReturn(true);
@@ -851,7 +852,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(new ErrorReport());
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(null);
 
@@ -1193,7 +1194,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(new ErrorReport());
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
 
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(mock(Throwable.class));
@@ -1223,7 +1224,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report1).thenReturn(report2);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1304,7 +1305,7 @@ public class CrashesTest {
         /* Reset instance to test another tine with always send. */
         Crashes.unsetInstance();
         crashes = Crashes.getInstance();
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report1).thenReturn(report2);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         WrapperSdkExceptionManager.setAutomaticProcessing(false);
         crashes.setLogSerializer(logSerializer);
         crashes.onStarting(mAppCenterHandler);
@@ -1331,7 +1332,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report1).thenReturn(report2);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1399,7 +1400,7 @@ public class CrashesTest {
         Whitebox.setInternalState(pendingDir, "path", "");
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingDir);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(report);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.readObject(any(File.class))).thenReturn(new NativeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1476,7 +1477,7 @@ public class CrashesTest {
         Device device = new Device();
         device.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
         errorReport.setDevice(device);
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(errorReport);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(errorReport);
         whenNew(DefaultLogSerializer.class).withAnyArguments().thenReturn(defaultLogSerializer);
         whenNew(com.microsoft.appcenter.crashes.ingestion.models.Exception.class).withAnyArguments().thenReturn(exception);
         when(exception.getMinidumpFilePath()).thenReturn(null);
@@ -1530,7 +1531,7 @@ public class CrashesTest {
         Device device = new Device();
         device.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
         errorReport.setDevice(device);
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(errorReport);
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(errorReport);
         whenNew(DefaultLogSerializer.class).withAnyArguments().thenReturn(defaultLogSerializer);
         whenNew(com.microsoft.appcenter.crashes.ingestion.models.Exception.class).withAnyArguments().thenReturn(exception);
         when(exception.getStackTrace()).thenReturn("some minidump");
@@ -1595,11 +1596,10 @@ public class CrashesTest {
 
         /* Mock storage to fail on stack overflow when saving a Throwable as binary. */
         mockStatic(android.util.Log.class);
-        String stackTrace = "sample stacktrace";
-        when(android.util.Log.getStackTraceString(any(Throwable.class))).thenReturn(stackTrace);
+        when(getStackTraceString(any(Throwable.class))).thenReturn(STACK_TRACE);
         Throwable throwable = new Throwable();
         doThrow(new StackOverflowError()).when(FileManager.class);
-        FileManager.write(throwableFile, stackTrace);
+        FileManager.write(throwableFile, STACK_TRACE);
 
         /* Simulate start SDK. */
         Crashes crashes = Crashes.getInstance();
@@ -1612,7 +1612,7 @@ public class CrashesTest {
 
         /* Verify we gracefully abort saving throwable (no exception) and we created an empty file instead. */
         verifyStatic();
-        FileManager.write(throwableFile, stackTrace);
+        FileManager.write(throwableFile, STACK_TRACE);
         assertNotNull(throwableFile);
         InOrder inOrder = inOrder(throwableFile);
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -23,7 +23,6 @@ import com.microsoft.appcenter.crashes.ingestion.models.json.ErrorAttachmentLogF
 import com.microsoft.appcenter.crashes.ingestion.models.json.HandledErrorLogFactory;
 import com.microsoft.appcenter.crashes.ingestion.models.json.ManagedErrorLogFactory;
 import com.microsoft.appcenter.crashes.model.ErrorReport;
-import com.microsoft.appcenter.crashes.model.NativeException;
 import com.microsoft.appcenter.crashes.model.TestCrashException;
 import com.microsoft.appcenter.crashes.utils.ErrorLogHelper;
 import com.microsoft.appcenter.ingestion.Ingestion;
@@ -338,7 +337,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void queuePendingCrashesShouldProcess() throws IOException, ClassNotFoundException, JSONException {
+    public void queuePendingCrashesShouldProcess() throws JSONException {
 
         /* Setup mock. */
         Context mockContext = mock(Context.class);
@@ -350,7 +349,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
+//        when(FileManager.read(any(File.class))).thenReturn(new RuntimeException());
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(report)).thenReturn(true);
         when(mockListener.shouldAwaitUserConfirmation()).thenReturn(false);
@@ -387,7 +386,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void queuePendingCrashesShouldNotProcess() throws IOException, ClassNotFoundException, JSONException {
+    public void queuePendingCrashesShouldNotProcess() throws JSONException {
         Context mockContext = mock(Context.class);
         Channel mockChannel = mock(Channel.class);
 
@@ -399,7 +398,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException()).thenReturn(new byte[]{});
 
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(report)).thenReturn(false);
@@ -421,7 +419,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void queuePendingCrashesAlwaysSend() throws IOException, ClassNotFoundException, JSONException {
+    public void queuePendingCrashesAlwaysSend() throws JSONException {
         Context mockContext = mock(Context.class);
         Channel mockChannel = mock(Channel.class);
 
@@ -442,7 +440,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         when(SharedPreferencesManager.getBoolean(eq(Crashes.PREF_KEY_ALWAYS_SEND), anyBoolean())).thenReturn(true);
 
         CrashesListener mockListener = mock(CrashesListener.class);
@@ -820,12 +817,12 @@ public class CrashesTest {
     }
 
     @Test
-    public void getChannelListenerErrors() throws IOException, ClassNotFoundException {
+    public void getChannelListenerErrors() {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(FileManager.readObject(any(File.class))).thenReturn(null);
+        when(FileManager.read(any(File.class))).thenReturn(null);
 
         CrashesListener mockListener = mock(CrashesListener.class);
         Crashes crashes = Crashes.getInstance();
@@ -847,14 +844,13 @@ public class CrashesTest {
     }
 
     @Test
-    public void handleUserConfirmationDoNotSend() throws IOException, ClassNotFoundException, JSONException {
+    public void handleUserConfirmationDoNotSend() throws JSONException {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(null);
 
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
@@ -880,7 +876,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void handleUserConfirmationAlwaysSend() throws IOException, ClassNotFoundException, JSONException {
+    public void handleUserConfirmationAlwaysSend() throws JSONException {
 
         /* Simulate the method is called from Worker Thread. */
         mockStatic(Looper.class);
@@ -891,7 +887,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(FileManager.readObject(any(File.class))).thenReturn(null);
+        when(FileManager.read(any(File.class))).thenReturn(null);
 
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
@@ -1169,7 +1165,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void sendMoreThan2ErrorAttachments() throws IOException, ClassNotFoundException, JSONException {
+    public void sendMoreThan2ErrorAttachments() throws JSONException {
         int MAX_ATTACHMENT_PER_CRASH = 2;
         int numOfAttachments = MAX_ATTACHMENT_PER_CRASH + 1;
 
@@ -1197,7 +1193,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
 
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(mock(Throwable.class));
 
         Crashes crashes = Crashes.getInstance();
         crashes.setInstanceListener(listener);
@@ -1226,7 +1221,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
         when(logSerializer.deserializeLog(anyString(), anyString())).thenAnswer(new Answer<ManagedErrorLog>() {
 
@@ -1334,7 +1328,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new RuntimeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
         when(logSerializer.deserializeLog(anyString(), anyString())).thenAnswer(new Answer<ManagedErrorLog>() {
 
@@ -1402,7 +1395,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(new NativeException());
         LogSerializer logSerializer = mock(LogSerializer.class);
         ArgumentCaptor<Log> log = ArgumentCaptor.forClass(Log.class);
         when(logSerializer.serializeLog(log.capture())).thenReturn("{}");

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1073,6 +1073,14 @@ public class CrashesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
+    public void setThrowableDeprecated() {
+        ErrorReport report = new ErrorReport();
+        report.setThrowable(new Throwable());
+        assertNull(report.getThrowable());
+    }
+
+    @Test
     public void noCrashInLastSessionWhenDisabled() {
 
         mockStatic(ErrorLogHelper.class);
@@ -1466,7 +1474,9 @@ public class CrashesTest {
         mockStatic(ErrorLogHelper.class);
         mockStatic(ErrorAttachmentLog.class);
         ErrorReport errorReport = new ErrorReport();
-        errorReport.setThrowable(new NativeException());
+        Device device = new Device();
+        device.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+        errorReport.setDevice(device);
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(String.class))).thenReturn(errorReport);
         whenNew(DefaultLogSerializer.class).withAnyArguments().thenReturn(defaultLogSerializer);
         whenNew(com.microsoft.appcenter.crashes.ingestion.models.Exception.class).withAnyArguments().thenReturn(exception);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -349,7 +349,6 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
-//        when(FileManager.read(any(File.class))).thenReturn(new RuntimeException());
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(report)).thenReturn(true);
         when(mockListener.shouldAwaitUserConfirmation()).thenReturn(false);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -580,7 +580,6 @@ public class CrashesTest {
 
             @Override
             public boolean matches(Object item) {
-
                 return item instanceof HandledErrorLog && EXCEPTION.getMessage() != null
                         && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage());
             }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -65,7 +65,6 @@ import org.powermock.reflect.Whitebox;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -757,7 +756,7 @@ public class CrashesTest {
     }
 
     @Test
-    public void getChannelListener() throws IOException, ClassNotFoundException, JSONException {
+    public void getChannelListener() throws JSONException {
         ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE);
 
         mockStatic(ErrorLogHelper.class);
@@ -771,7 +770,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
         when(ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE)).thenReturn(errorReport);
         when(FileManager.read(any(File.class))).thenReturn("");
-        when(FileManager.readObject(any(File.class))).thenReturn(EXCEPTION);
+        when(FileManager.read(any(File.class))).thenReturn(STACK_TRACE);
 
         LogSerializer logSerializer = mock(LogSerializer.class);
         when(logSerializer.deserializeLog(anyString(), anyString())).thenReturn(mErrorLog);
@@ -1455,6 +1454,7 @@ public class CrashesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void minidumpFilePathNull() throws Exception {
 
         /* Set up mock for the crash. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -145,12 +145,10 @@ public class CrashesTest {
     @Mock
     private AppCenterHandler mAppCenterHandler;
 
-    @SuppressWarnings("deprecation")
     private static void assertErrorEquals(ManagedErrorLog errorLog, ErrorReport report) {
         assertNotNull(report);
         assertEquals(errorLog.getId().toString(), report.getId());
         assertEquals(errorLog.getErrorThreadName(), report.getThreadName());
-        assertNull(report.getThrowable());
         assertEquals(STACK_TRACE, report.getStackTrace());
         assertEquals(errorLog.getAppLaunchTimestamp(), report.getAppStartTime());
         assertEquals(errorLog.getTimestamp(), report.getAppErrorTime());
@@ -582,7 +580,9 @@ public class CrashesTest {
 
             @Override
             public boolean matches(Object item) {
-                return item instanceof HandledErrorLog && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage());
+
+                return item instanceof HandledErrorLog && EXCEPTION.getMessage() != null
+                        && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage());
             }
         }), eq(crashes.getGroupName()), eq(DEFAULTS));
         reset(mockChannel);
@@ -596,7 +596,8 @@ public class CrashesTest {
 
             @Override
             public boolean matches(Object item) {
-                return item instanceof HandledErrorLog && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage())
+                return item instanceof HandledErrorLog && EXCEPTION.getMessage() != null
+                        && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage())
                         && ((HandledErrorLog) item).getProperties().size() == 0;
             }
         }), eq(crashes.getGroupName()), eq(DEFAULTS));
@@ -610,7 +611,8 @@ public class CrashesTest {
 
             @Override
             public boolean matches(Object item) {
-                return item instanceof HandledErrorLog && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage())
+                return item instanceof HandledErrorLog && EXCEPTION.getMessage() != null
+                        && EXCEPTION.getMessage().equals(((HandledErrorLog) item).getException().getMessage())
                         && ((HandledErrorLog) item).getProperties().size() == 20;
             }
         }), eq(crashes.getGroupName()), eq(DEFAULTS));
@@ -625,7 +627,7 @@ public class CrashesTest {
             public boolean matches(Object item) {
                 if (item instanceof HandledErrorLog) {
                     HandledErrorLog errorLog = (HandledErrorLog) item;
-                    if (EXCEPTION.getMessage().equals((errorLog.getException().getMessage()))) {
+                    if (EXCEPTION.getMessage() != null && EXCEPTION.getMessage().equals((errorLog.getException().getMessage()))) {
                         if (errorLog.getProperties().size() == 1) {
                             Map.Entry<String, String> entry = errorLog.getProperties().entrySet().iterator().next();
                             String truncatedMapItem = generateString(ErrorLogHelper.MAX_PROPERTY_ITEM_LENGTH, '*');
@@ -1001,7 +1003,6 @@ public class CrashesTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void crashInLastSession() throws JSONException, IOException {
 
         final ManagedErrorLog errorLog = new ManagedErrorLog();
@@ -1069,13 +1070,13 @@ public class CrashesTest {
         assertEquals(logTimestamp, result.getAppErrorTime());
         assertNotNull(result.getDevice());
         assertEquals(STACK_TRACE, result.getStackTrace());
-        assertNull(result.getThrowable());
     }
 
     @Test
     @SuppressWarnings("deprecation")
-    public void setThrowableDeprecated() {
+    public void getAndSetThrowableDeprecated() {
         ErrorReport report = new ErrorReport();
+        assertNull(report.getThrowable());
         report.setThrowable(new Throwable());
         assertNull(report.getThrowable());
     }
@@ -1462,7 +1463,6 @@ public class CrashesTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void minidumpFilePathNull() throws Exception {
 
         /* Set up mock for the crash. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -119,7 +119,6 @@ public class WrapperSdkExceptionManagerTest {
         File file = mock(File.class);
         whenNew(File.class).withAnyArguments().thenReturn(file);
         when(file.exists()).thenReturn(true);
-        FileManager.read(any(File.class));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(UUID.randomUUID()));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(null));
     }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -119,11 +119,7 @@ public class WrapperSdkExceptionManagerTest {
         File file = mock(File.class);
         whenNew(File.class).withAnyArguments().thenReturn(file);
         when(file.exists()).thenReturn(true);
-        doThrow(new IOException()).when(FileManager.class);
-        FileManager.readObject(any(File.class));
-        assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(UUID.randomUUID()));
-        doThrow(new ClassNotFoundException()).when(FileManager.class);
-        FileManager.readObject(any(File.class));
+        FileManager.read(any(File.class));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(UUID.randomUUID()));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(null));
     }
@@ -169,16 +165,16 @@ public class WrapperSdkExceptionManagerTest {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
-        byte[] data = new byte[]{'d'};
+        String data = "d";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(data));
+        FileManager.write(any(File.class), eq(data));
 
         /* We can't do it twice in the same process. */
-        data = new byte[]{'e'};
+        data = "e";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verifyStatic(never());
-        FileManager.writeObject(any(File.class), eq(data));
+        FileManager.write(any(File.class), eq(data));
     }
 
     @Test
@@ -187,21 +183,21 @@ public class WrapperSdkExceptionManagerTest {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
-        byte[] data = new byte[]{'d'};
+        String data = "d";
         Throwable throwable = new Throwable();
         mockStatic(android.util.Log.class);
         Mockito.when(getStackTraceString(any(Throwable.class))).thenReturn(STACK_TRACE);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), data);
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(data));
+        FileManager.write(any(File.class), eq(data));
         verifyStatic();
         FileManager.write(any(File.class), eq(STACK_TRACE));
 
         /* We can't do it twice in the same process. */
-        data = new byte[]{'e'};
+        data = "e";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), data);
         verifyStatic(never());
-        FileManager.writeObject(any(File.class), eq(data));
+        FileManager.write(any(File.class), eq(data));
         verifyStatic();
         FileManager.write(any(File.class), eq(STACK_TRACE));
     }
@@ -217,7 +213,7 @@ public class WrapperSdkExceptionManagerTest {
         Mockito.when(getStackTraceString(any(Throwable.class))).thenReturn(STACK_TRACE);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic(never());
-        FileManager.writeObject(any(File.class), isNull(byte[].class));
+        FileManager.write(any(File.class), isNull(String.class));
         verifyStatic();
         FileManager.write(any(File.class), eq(STACK_TRACE));
 
@@ -241,7 +237,7 @@ public class WrapperSdkExceptionManagerTest {
             }
         })).thenReturn(throwableFile);
         when(throwableFile.createNewFile()).thenReturn(false);
-        byte[] data = new byte[]{'d'};
+        String data = "d";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verifyStatic();
         AppCenterLog.error(anyString(), anyString(), argThat(new ArgumentMatcher<Throwable>() {
@@ -253,7 +249,7 @@ public class WrapperSdkExceptionManagerTest {
         }));
 
         /* Second call is ignored. */
-        data = new byte[]{'e'};
+        data = "e";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
 
         /* No more error. */
@@ -272,7 +268,8 @@ public class WrapperSdkExceptionManagerTest {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenThrow(new JSONException("mock"));
         Crashes.getInstance().setLogSerializer(logSerializer);
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'d'});
+        String data = "d";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verifyStatic();
         AppCenterLog.error(anyString(), anyString(), argThat(new ArgumentMatcher<Throwable>() {
 
@@ -283,7 +280,8 @@ public class WrapperSdkExceptionManagerTest {
         }));
 
         /* Second call is ignored. */
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'e'});
+        data = "e";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
 
         /* No more error. */
         verifyStatic();
@@ -303,7 +301,8 @@ public class WrapperSdkExceptionManagerTest {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'d'});
+        String data = "d";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verifyStatic();
         AppCenterLog.error(anyString(), anyString(), argThat(new ArgumentMatcher<Throwable>() {
 
@@ -314,7 +313,8 @@ public class WrapperSdkExceptionManagerTest {
         }));
 
         /* Second call is ignored. */
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'e'});
+        data = "e";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
 
         /* No more error. */
         verifyStatic();
@@ -329,9 +329,9 @@ public class WrapperSdkExceptionManagerTest {
 
     @Test
     public void saveWrapperSdkCrashFailsWithIOExceptionAfterLog() throws IOException, JSONException {
-        byte[] data = {'d'};
+        String data = "d";
         doThrow(new IOException()).when(FileManager.class);
-        FileManager.writeObject(any(File.class), eq(data));
+        FileManager.write(any(File.class), eq(data));
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
@@ -346,7 +346,8 @@ public class WrapperSdkExceptionManagerTest {
         }));
 
         /* Second call is ignored. */
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'e'});
+        data = "e";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
 
         /* No more error. */
         verifyStatic();
@@ -364,7 +365,8 @@ public class WrapperSdkExceptionManagerTest {
         when(SharedPreferencesManager.getBoolean(CRASHES_ENABLED_KEY, true)).thenReturn(false);
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         Crashes.getInstance().setLogSerializer(logSerializer);
-        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), new byte[]{'d'});
+        String data = "d";
+        WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
         verify(logSerializer, never()).serializeLog(any(Log.class));
         verifyNoMoreInteractions(ErrorLogHelper.class);
     }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -179,17 +179,21 @@ public class WrapperSdkExceptionManagerTest {
     }
 
     @Test
+    @PrepareForTest({android.util.Log.class})
     public void saveWrapperSdkCrashWithJavaThrowable() throws JSONException, IOException {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
         byte[] data = new byte[]{'d'};
         Throwable throwable = new Throwable();
+        mockStatic(android.util.Log.class);
+        String stackTrace = "sample stacktrace";
+        Mockito.when(android.util.Log.getStackTraceString(any(Throwable.class))).thenReturn(stackTrace);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), data);
         verifyStatic();
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(throwable.toString()));
+        FileManager.write(any(File.class), eq(stackTrace));
 
         /* We can't do it twice in the same process. */
         data = new byte[]{'e'};
@@ -197,25 +201,29 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(throwable.toString()));
+        FileManager.write(any(File.class), eq(stackTrace));
     }
 
     @Test
+    @PrepareForTest({android.util.Log.class})
     public void saveWrapperSdkCrashWithOnlyJavaThrowable() throws JSONException, IOException {
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
         when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
         Crashes.getInstance().setLogSerializer(logSerializer);
         Throwable throwable = new Throwable();
+        mockStatic(android.util.Log.class);
+        String stackTrace = "sample stacktrace";
+        Mockito.when(android.util.Log.getStackTraceString(any(Throwable.class))).thenReturn(stackTrace);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic(never());
         FileManager.writeObject(any(File.class), isNull(byte[].class));
         verifyStatic();
-        FileManager.write(any(File.class), eq(throwable.toString()));
+        FileManager.write(any(File.class), eq(stackTrace));
 
         /* We can't do it twice in the same process. */
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic();
-        FileManager.write(any(File.class), eq(throwable.toString()));
+        FileManager.write(any(File.class), eq(stackTrace));
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
+import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.utils.PrefStorageConstants.KEY_ENABLED;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
@@ -62,6 +63,8 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 public class WrapperSdkExceptionManagerTest {
 
     private static final String CRASHES_ENABLED_KEY = KEY_ENABLED + "_" + Crashes.getInstance().getServiceName();
+
+    private static final String STACK_TRACE = "Sample stacktrace";
 
     @Rule
     public final PowerMockRule rule = new PowerMockRule();
@@ -187,13 +190,12 @@ public class WrapperSdkExceptionManagerTest {
         byte[] data = new byte[]{'d'};
         Throwable throwable = new Throwable();
         mockStatic(android.util.Log.class);
-        String stackTrace = "sample stacktrace";
-        Mockito.when(android.util.Log.getStackTraceString(any(Throwable.class))).thenReturn(stackTrace);
+        Mockito.when(getStackTraceString(any(Throwable.class))).thenReturn(STACK_TRACE);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), data);
         verifyStatic();
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(stackTrace));
+        FileManager.write(any(File.class), eq(STACK_TRACE));
 
         /* We can't do it twice in the same process. */
         data = new byte[]{'e'};
@@ -201,7 +203,7 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(stackTrace));
+        FileManager.write(any(File.class), eq(STACK_TRACE));
     }
 
     @Test
@@ -212,18 +214,17 @@ public class WrapperSdkExceptionManagerTest {
         Crashes.getInstance().setLogSerializer(logSerializer);
         Throwable throwable = new Throwable();
         mockStatic(android.util.Log.class);
-        String stackTrace = "sample stacktrace";
-        Mockito.when(android.util.Log.getStackTraceString(any(Throwable.class))).thenReturn(stackTrace);
+        Mockito.when(getStackTraceString(any(Throwable.class))).thenReturn(STACK_TRACE);
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic(never());
         FileManager.writeObject(any(File.class), isNull(byte[].class));
         verifyStatic();
-        FileManager.write(any(File.class), eq(stackTrace));
+        FileManager.write(any(File.class), eq(STACK_TRACE));
 
         /* We can't do it twice in the same process. */
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic();
-        FileManager.write(any(File.class), eq(stackTrace));
+        FileManager.write(any(File.class), eq(STACK_TRACE));
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -189,7 +189,7 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic();
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(throwable));
+        FileManager.write(any(File.class), eq(throwable.toString()));
 
         /* We can't do it twice in the same process. */
         data = new byte[]{'e'};
@@ -197,7 +197,7 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.writeObject(any(File.class), eq(data));
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(throwable));
+        FileManager.write(any(File.class), eq(throwable.toString()));
     }
 
     @Test
@@ -210,12 +210,12 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.writeObject(any(File.class), isNull(byte[].class));
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(throwable));
+        FileManager.write(any(File.class), eq(throwable.toString()));
 
         /* We can't do it twice in the same process. */
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic();
-        FileManager.writeObject(any(File.class), eq(throwable));
+        FileManager.write(any(File.class), eq(throwable.toString()));
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -263,6 +263,7 @@ public class ErrorLogHelperTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void getErrorReportFromErrorLog() throws java.lang.Exception {
 
         /* Mock base. */
@@ -290,12 +291,13 @@ public class ErrorLogHelperTest {
         assertNotNull(errorLog);
 
         /* Test. */
-        Throwable throwable = new RuntimeException();
-        ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(errorLog, throwable);
+        String stackTrace = "Sample stacktrace";
+        ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(errorLog, stackTrace);
         assertNotNull(report);
         assertEquals(errorLog.getId().toString(), report.getId());
         assertEquals(errorLog.getErrorThreadName(), report.getThreadName());
-        assertEquals(throwable, report.getThrowable());
+        assertEquals(stackTrace, report.getStackTrace());
+        assertNull(report.getThrowable());
         assertEquals(errorLog.getAppLaunchTimestamp(), report.getAppStartTime());
         assertEquals(errorLog.getTimestamp(), report.getAppErrorTime());
         assertEquals(errorLog.getDevice(), report.getDevice());

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -263,7 +263,6 @@ public class ErrorLogHelperTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void getErrorReportFromErrorLog() throws java.lang.Exception {
 
         /* Mock base. */
@@ -297,7 +296,6 @@ public class ErrorLogHelperTest {
         assertEquals(errorLog.getId().toString(), report.getId());
         assertEquals(errorLog.getErrorThreadName(), report.getThreadName());
         assertEquals(stackTrace, report.getStackTrace());
-        assertNull(report.getThrowable());
         assertEquals(errorLog.getAppLaunchTimestamp(), report.getAppStartTime());
         assertEquals(errorLog.getTimestamp(), report.getAppErrorTime());
         assertEquals(errorLog.getDevice(), report.getDevice());

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/FileManagerAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/utils/storage/FileManagerAndroidTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -133,7 +132,7 @@ public class FileManagerAndroidTest {
 
         /* Verify the contents of the most recent file. */
         assertNotNull(actual);
-        assertEquals(contents2, actual.trim());
+        assertEquals(contents2, actual);
 
         /* Delete the files to clean up. */
         for (String filename : filenames) {
@@ -147,40 +146,6 @@ public class FileManagerAndroidTest {
         assertNull(FileManager.read("not-exist-filename"));
         assertArrayEquals(new String[0], FileManager.getFilenames("not-exist-path", null));
         assertNull(FileManager.lastModifiedFile("not-exist-path", null));
-    }
-
-    @Test
-    public void fileManagerForObject() throws IOException, ClassNotFoundException {
-        File file = new File(sAndroidFilesPath + UUID.randomUUID().toString() + FILE_STORAGE_TEST_FILE_EXTENSION);
-
-        /* Create a mock object. */
-        DataModel model = new DataModel(10, "Model", true);
-
-        /* Write the object to a file. */
-        FileManager.writeObject(file, model);
-
-        /* Read the file. */
-        DataModel actual = FileManager.readObject(file);
-
-        /* Read with class cast exception. */
-        Exception readCastException = null;
-        try {
-
-            @SuppressWarnings("unused")
-            String wrongType = FileManager.readObject(file);
-        } catch (Exception e) {
-            readCastException = e;
-        }
-        assertTrue(readCastException instanceof ClassCastException);
-
-        /* Verify the deserialized instance and original instance are same. */
-        assertNotNull(actual);
-        assertEquals(model.number, actual.number);
-        assertEquals(model.object.text, actual.object.text);
-        assertEquals(model.object.enabled, actual.object.enabled);
-
-        /* Delete the files to clean up. */
-        FileManager.delete(file);
     }
 
     @Test
@@ -203,29 +168,5 @@ public class FileManagerAndroidTest {
 
         /* Check file not found. */
         assertNull(FileManager.readBytes(file));
-    }
-
-    /**
-     * Temporary class for testing object serialization.
-     */
-    private static class DataModel implements Serializable {
-        final int number;
-        final InnerModel object;
-
-        @SuppressWarnings("SameParameterValue")
-        DataModel(int number, String text, boolean enabled) {
-            this.number = number;
-            this.object = new InnerModel(text, enabled);
-        }
-
-        static class InnerModel implements Serializable {
-            final String text;
-            final boolean enabled;
-
-            InnerModel(String text, boolean enabled) {
-                this.text = text;
-                this.enabled = enabled;
-            }
-        }
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -19,14 +19,10 @@ import java.io.BufferedWriter;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
 
 /**
  * File manager for internal/external storage access
@@ -77,8 +73,12 @@ public class FileManager {
                 String line;
                 String lineSeparator = System.getProperty("line.separator");
                 contents = new StringBuilder();
-                while ((line = reader.readLine()) != null) {
-                    contents.append(line).append(lineSeparator);
+                line = reader.readLine();
+                if (line != null) {
+                    contents.append(line);
+                    while ((line = reader.readLine()) != null) {
+                        contents.append(lineSeparator).append(line);
+                    }
                 }
             } finally {
                 reader.close();
@@ -143,47 +143,6 @@ public class FileManager {
             writer.write(contents);
         } finally {
             writer.close();
-        }
-    }
-
-    /**
-     * Read an object from a file (deserialization).
-     *
-     * @param file The file to read from.
-     * @param <T>  A type for the deserialized instance.
-     * @return The deserialized instance.
-     * @throws IOException            If an I/O error occurs
-     * @throws ClassNotFoundException If no class definition found for serialized instance.
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends Serializable> T readObject(@NonNull File file)
-            throws IOException, ClassNotFoundException {
-        ObjectInputStream inputStream = new ObjectInputStream(new FileInputStream(file));
-        //noinspection TryFinallyCanBeTryWithResources
-        try {
-            return (T) inputStream.readObject();
-        } finally {
-            inputStream.close();
-        }
-    }
-
-    /**
-     * Write an object to a file (serialization).
-     *
-     * @param file   The file to write to.
-     * @param object The object to be written to the file.
-     * @param <T>    A type for the object.
-     * @throws IOException If an I/O error occurs
-     */
-    public static <T extends Serializable> void writeObject(@NonNull File file, @NonNull T object) throws IOException {
-        ObjectOutputStream outputStream = new ObjectOutputStream(new FileOutputStream(file));
-
-        //noinspection TryFinallyCanBeTryWithResources
-        try {
-            outputStream.writeObject(object);
-        } finally {
-
-            outputStream.close();
         }
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -82,6 +82,17 @@ public class FileManagerTest {
         AppCenterLog.error(anyString(), anyString(), any(IOException.class));
     }
 
+    @Test
+    public void readEmptyFile() throws Exception {
+        mockStatic(AppCenterLog.class);
+        BufferedReader reader = mock(BufferedReader.class);
+        whenNew(BufferedReader.class).withAnyArguments().thenReturn(reader);
+        whenNew(FileReader.class).withAnyArguments().thenReturn(mock(FileReader.class));
+        when(reader.readLine()).thenReturn(null);
+        assertEquals("", FileManager.read(new File("")));
+        verify(reader).close();
+    }
+
     @Test(expected = IOException.class)
     public void writeError() throws Exception {
         mockStatic(TextUtils.class);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -22,13 +22,10 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -95,26 +92,6 @@ public class FileManagerTest {
         whenNew(FileWriter.class).withAnyArguments().thenReturn(mock(FileWriter.class));
         doThrow(new IOException("mock")).when(writer).write(anyString());
         FileManager.write(mock(File.class), "test");
-        verify(writer).close();
-    }
-
-    @Test(expected = IOException.class)
-    public void readObjectError() throws Exception {
-        ObjectInputStream reader = mock(ObjectInputStream.class);
-        whenNew(ObjectInputStream.class).withAnyArguments().thenReturn(reader);
-        whenNew(FileInputStream.class).withAnyArguments().thenReturn(mock(FileInputStream.class));
-        doThrow(new IOException("mock")).when(reader).readObject();
-        FileManager.readObject(mock(File.class));
-        verify(reader).close();
-    }
-
-    @Test(expected = IOException.class)
-    public void writeObjectError() throws Exception {
-        ObjectOutputStream writer = mock(ObjectOutputStream.class);
-        whenNew(ObjectOutputStream.class).withAnyArguments().thenReturn(writer);
-        whenNew(FileOutputStream.class).withAnyArguments().thenReturn(mock(FileOutputStream.class));
-        doThrow(new IOException("mock")).when(writer).writeObject(any());
-        FileManager.writeObject(mock(File.class), "test");
         verify(writer).close();
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

On Java we serialize the exception that caused the crash for client side inspection. Serialization was used to preserve custom fields of the original exception to be available after the app restart.

The problem is that ObjectInputStream.readObject suffers from similar vulnerability as BinaryFormatter on .NET.

This PR removes the insecure implementation of `ErrorReport.getThrowable` and `ErrorReport.setThrowable` (now marked as deprecated and always returns `null`). Provide `ErrorReport.getStackTrace` and `ErrorReport.setStackTrace` as an alternative.

## Related PRs or issues

[AB#69643](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/69643)

