### PR TITLE
Mbaas data refator/cache before send

### DIFF
--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -319,7 +319,7 @@ public class LocalDocumentStorageAndroidTest {
     }
 
     @Test
-    public void ReadFailForTransitOperation() {
+    public void readFailForTransitOperation() {
         mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, APP_DOCUMENTS, ID, "test", String.class, new WriteOptions(TimeToLive.NO_CACHE));
         DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, APP_DOCUMENTS, ID, String.class, new ReadOptions());
         assertNotNull(createdDocument);

--- a/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
+++ b/sdk/appcenter-data/src/androidTest/java/com/microsoft/appcenter/data/LocalDocumentStorageAndroidTest.java
@@ -319,6 +319,21 @@ public class LocalDocumentStorageAndroidTest {
     }
 
     @Test
+    public void ReadFailForTransitOperation() {
+        mLocalDocumentStorage.createOrUpdateOffline(USER_TABLE_NAME, APP_DOCUMENTS, ID, "test", String.class, new WriteOptions(TimeToLive.NO_CACHE));
+        DocumentWrapper<String> createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, APP_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(createdDocument);
+        assertNotNull(createdDocument.getError());
+        assertNotNull(createdDocument.getError().getMessage());
+        assertTrue(createdDocument.getError().getMessage().contains("Document remote state is unknown"));
+        createdDocument = mLocalDocumentStorage.read(USER_TABLE_NAME, APP_DOCUMENTS, ID, String.class, new ReadOptions());
+        assertNotNull(createdDocument);
+        assertNotNull(createdDocument.getError());
+        assertNotNull(createdDocument.getError().getMessage());
+        assertTrue(createdDocument.getError().getMessage().contains("Document was not found"));
+    }
+
+    @Test
     public void deleteOfflineAddsNoPendingOperation() {
         mLocalDocumentStorage.deleteOffline(USER_TABLE_NAME, USER_DOCUMENTS, ID, new WriteOptions());
         List<LocalDocument> operations = mLocalDocumentStorage.getPendingOperations(USER_TABLE_NAME);

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Constants.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Constants.java
@@ -43,7 +43,7 @@ public final class Constants {
      */
     static final String PENDING_OPERATION_DELETE_VALUE = "DELETE";
 
-    /***
+    /**
      * Generic pending operation when writeOptions is no cache.
      */
     static final String PENDING_OPERATION_PROCESS_VALUE = "PROCESSING";

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Constants.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Constants.java
@@ -43,6 +43,11 @@ public final class Constants {
      */
     static final String PENDING_OPERATION_DELETE_VALUE = "DELETE";
 
+    /***
+     * Generic pending operation when writeOptions is no cache.
+     */
+    static final String PENDING_OPERATION_PROCESS_VALUE = "PROCESSING";
+
     /**
      * Base URL to call token exchange service.
      */

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -390,7 +390,6 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                 mLocalDocumentStorage.deleteOnline(table, localDocument.getPartition(), localDocument.getDocumentId());
                 continue;
             }
-            System.out.println();
             String outgoingId = Utils.getOutgoingId(localDocument.getPartition(), localDocument.getDocumentId());
 
             /* If the operation is already being processed, skip it. */

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -575,9 +575,15 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
             }
 
             @Override
-            public void callCosmosDb(TokenResult tokenResult, DefaultAppCenterFuture<DocumentWrapper<Void>> result) {
-                mLocalDocumentStorage.deleteOffline(Utils.getTableName(tokenResult.getPartition()), tokenResult.getPartition(), documentId, writeOptions);
-                callCosmosDbDeleteApi(tokenResult, partition, documentId, result);
+            public void callCosmosDb(final TokenResult tokenResult, final DefaultAppCenterFuture<DocumentWrapper<Void>> result) {
+                postAsyncGetter(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        mLocalDocumentStorage.deleteOffline(Utils.getTableName(tokenResult.getPartition()), tokenResult.getPartition(), documentId, writeOptions);
+                        callCosmosDbDeleteApi(tokenResult, partition, documentId, result);
+                    }
+                }, result, new DocumentWrapper<Void>(getModuleNotStartedException()));
             }
         });
     }
@@ -867,6 +873,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
             @Override
             public void run() {
                 if (mNetworkStateHelper.isNetworkConnected()) {
+
                     getTokenAndCallCosmosDbApi(
                             partition,
                             mHttpClientNoRetryer,
@@ -874,9 +881,16 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                             new TokenExchangeServiceCallback(mTokenManager) {
 
                                 @Override
-                                public void callCosmosDb(TokenResult tokenResult) {
-                                    mLocalDocumentStorage.createOrUpdateOffline(Utils.getTableName(tokenResult), tokenResult.getPartition(), documentId, document, documentType, writeOptions);
-                                    callCosmosDbCreateOrUpdateApi(tokenResult, document, documentType, tokenResult.getPartition(), documentId, writeOptions, additionalHeaders, result);
+                                public void callCosmosDb(final TokenResult tokenResult) {
+
+                                    postAsyncGetter(new Runnable() {
+
+                                        @Override
+                                        public void run() {
+                                            mLocalDocumentStorage.createOrUpdateOffline(Utils.getTableName(tokenResult), tokenResult.getPartition(), documentId, document, documentType, writeOptions);
+                                            callCosmosDbCreateOrUpdateApi(tokenResult, document, documentType, tokenResult.getPartition(), documentId, writeOptions, additionalHeaders, result);
+                                        }
+                                    }, result, new DocumentWrapper<T>(getModuleNotStartedException()));
                                 }
 
                                 @Override

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -380,7 +380,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
         for (LocalDocument localDocument : mLocalDocumentStorage.getPendingOperations(table)) {
             if (localDocument.getOperation().equals(Constants.PENDING_OPERATION_PROCESS_VALUE)) {
                 notifyListenerAndUpdateOperationOnFailure(
-                        new DataException(String.format("Remote state is unknown for document %s, and no local cache for this document.", localDocument.getDocumentId())),
+                        new DataException(String.format("Remote state is unknown for document id %s, and no local cache exists for this document.", localDocument.getDocumentId())),
                         localDocument);
                 mLocalDocumentStorage.deleteOnline(table, localDocument.getPartition(), localDocument.getDocumentId());
                 continue;

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -374,6 +374,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
         }
     }
 
+    @WorkerThread
     private synchronized void processPendingOperations() {
         String table = Utils.getUserTableName();
         for (LocalDocument localDocument : mLocalDocumentStorage.getPendingOperations(table)) {

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -390,6 +390,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                 mLocalDocumentStorage.deleteOnline(table, localDocument.getPartition(), localDocument.getDocumentId());
                 continue;
             }
+            System.out.println();
             String outgoingId = Utils.getOutgoingId(localDocument.getPartition(), localDocument.getDocumentId());
 
             /* If the operation is already being processed, skip it. */
@@ -1094,9 +1095,9 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                             null,
                             e);
                 }
-                if (deleteLocalCopy || pendingOperation.isExpired()) {
+                if (deleteLocalCopy) {
 
-                    /* Remove the document if document was removed on the server, or expiration_time has elapsed. */
+                    /* Remove the document if document was removed on the server. */
                     mLocalDocumentStorage.deleteOnline(pendingOperation.getTable(), pendingOperation.getPartition(), pendingOperation.getDocumentId());
                 }
                 mOutgoingPendingOperationCalls.remove(Utils.getOutgoingId(pendingOperation.getPartition(), pendingOperation.getDocumentId()));

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/Data.java
@@ -1054,7 +1054,7 @@ public class Data extends AbstractAppCenterService implements NetworkStateHelper
                                     eTag),
                             null);
                 }
-                if (pendingOperation.isExpired() || PENDING_OPERATION_DELETE_VALUE.equals(pendingOperation.getOperation())) {
+                if (PENDING_OPERATION_DELETE_VALUE.equals(pendingOperation.getOperation())) {
 
                     /* Remove the document if expiration_time has elapsed or it is a delete operation. */
                     mLocalDocumentStorage.deleteOnline(pendingOperation.getTable(), pendingOperation.getPartition(), pendingOperation.getDocumentId());

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -447,9 +447,10 @@ class LocalDocumentStorage {
         cursor.close();
         if (values != null) {
             long documentExpirationTime = values.getAsLong(EXPIRATION_TIME_COLUMN_NAME);
+            String pendingOperation = values.getAsString(PENDING_OPERATION_COLUMN_NAME);
 
             /*  This happens when doing operation cosmosdb create/update when writeOptions in flight and did not resolve a result yet. **/
-            if (values.getAsString(PENDING_OPERATION_COLUMN_NAME).equals(Constants.PENDING_OPERATION_PROCESS_VALUE)) {
+            if (pendingOperation != null && pendingOperation.equals(Constants.PENDING_OPERATION_PROCESS_VALUE)) {
                 String errorMessage = "Document remote state is unknown, and local storage is set to no cache.";
                 AppCenterLog.debug(LOG_TAG, errorMessage);
                 mDatabaseManager.delete(table, values.getAsLong(DatabaseManager.PRIMARY_KEY));

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -453,11 +453,11 @@ class LocalDocumentStorage {
             if (pendingOperation != null && pendingOperation.equals(Constants.PENDING_OPERATION_PROCESS_VALUE)) {
                 String errorMessage = "Document remote state is unknown, and local storage is set to no cache.";
                 AppCenterLog.debug(LOG_TAG, errorMessage);
-                mDatabaseManager.delete(table, values.getAsLong(DatabaseManager.PRIMARY_KEY));
+                mDatabaseManager.delete(table, DatabaseManager.PRIMARY_KEY, values.getAsLong(DatabaseManager.PRIMARY_KEY));
                 return new DocumentWrapper<>(new DataException(errorMessage));
             }
             if (ReadOptions.isExpired(documentExpirationTime)) {
-                mDatabaseManager.delete(table, values.getAsLong(DatabaseManager.PRIMARY_KEY));
+                mDatabaseManager.delete(table, DatabaseManager.PRIMARY_KEY, values.getAsLong(DatabaseManager.PRIMARY_KEY));
                 String errorMessage = "Document was found in the cache, but it was expired. The cached document has been invalidated.";
                 AppCenterLog.debug(LOG_TAG, errorMessage);
                 return new DocumentWrapper<>(new DataException(errorMessage));
@@ -475,7 +475,7 @@ class LocalDocumentStorage {
                 if (readOptions.getDeviceTimeToLive() == TimeToLive.NO_CACHE) {
 
                     /* Delete the document since no cache was requested. */
-                    mDatabaseManager.delete(table, values.getAsLong(DatabaseManager.PRIMARY_KEY));
+                    mDatabaseManager.delete(table, DatabaseManager.PRIMARY_KEY, values.getAsLong(DatabaseManager.PRIMARY_KEY));
                 } else if (!documentWrapper.hasFailed()) {
 
                     /* We update cache timestamp only if no serialization issue, otherwise that would corrupt cache in payload. */

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -393,7 +393,7 @@ class LocalDocumentStorage {
             if (pendingOperationValue == null) {
                 AppCenterLog.debug(LOG_TAG, String.format("Trying to remove %s:%s document trace from cache", document.getPartition(), document.getId()));
 
-                /* Successfully create or update documents online, remove the pending operation from  localstorage. **/
+                /* Successfully create or update documents online, remove the pending operation from the local storage. */
                 return mDatabaseManager.delete(table, document.getId());
             } else {
 

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -399,9 +399,10 @@ class LocalDocumentStorage {
 
                 /*
                   The pending operation is delete/create/update with writeOptions no cache. It will be execute:
-                  1. Before every delete/create/update call to cosmosdb.
+                  Before every delete/create/update call to cosmosdb.
                  */
                 values = getContentValues(document.getPartition(), document.getId(), new HashMap<String, String>() {{
+                    put(DOCUMENT_COLUMN_NAME, null);
                     put(EXPIRATION_TIME_COLUMN_NAME, TimeToLive.NO_CACHE + "");
                     put(PENDING_OPERATION_COLUMN_NAME, Constants.PENDING_OPERATION_PROCESS_VALUE);
                 }});

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -453,7 +453,7 @@ class LocalDocumentStorage {
             long documentExpirationTime = values.getAsLong(EXPIRATION_TIME_COLUMN_NAME);
             String pendingOperation = values.getAsString(PENDING_OPERATION_COLUMN_NAME);
 
-            /*  This happens when doing operation cosmosdb create/update when writeOptions in flight and did not resolve a result yet. **/
+            /* This happens when doing operation cosmosdb create/update when writeOptions in flight and did not resolve a result yet. */
             if (pendingOperation != null && pendingOperation.equals(Constants.PENDING_OPERATION_PROCESS_VALUE)) {
                 String errorMessage = "Document remote state is unknown, and local storage is set to no cache.";
                 AppCenterLog.debug(LOG_TAG, errorMessage);

--- a/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
+++ b/sdk/appcenter-data/src/main/java/com/microsoft/appcenter/data/LocalDocumentStorage.java
@@ -99,11 +99,14 @@ class LocalDocumentStorage {
             String.format("%s = ? AND %s = ?", PARTITION_COLUMN_NAME, DOCUMENT_ID_COLUMN_NAME);
 
     /**
-     * String columns can be updated.
+     * String type columns can be updated.
      */
     private static final String[] MUTABLE_STRING_COLUMNS = new String[]
             {DOCUMENT_COLUMN_NAME, ETAG_COLUMN_NAME, PENDING_OPERATION_COLUMN_NAME};
 
+    /**
+     * Long type columns can be updated.
+     */
     private static final String[] MUTABLE_LONG_COLUMNS = new String[]
             {EXPIRATION_TIME_COLUMN_NAME, DOWNLOAD_TIME_COLUMN_NAME, OPERATION_TIME_COLUMN_NAME};
 

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataCreateUpdateDeleteTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/DataCreateUpdateDeleteTest.java
@@ -103,7 +103,6 @@ public class DataCreateUpdateDeleteTest extends AbstractDataTest {
 
         /* Verify document error. Confirm the cache was not touched. */
         assertNotNull(doc);
-        verifyNoMoreInteractions(mLocalDocumentStorage);
         DocumentWrapper<TestDocument> testCosmosDocument = doc.get();
         assertNotNull(testCosmosDocument);
         assertTrue(testCosmosDocument.hasFailed());
@@ -119,7 +118,6 @@ public class DataCreateUpdateDeleteTest extends AbstractDataTest {
         DocumentWrapper<TestDocument> testCosmosDocument = doc.get();
         assertNotNull(testCosmosDocument);
         verify(mLocalDocumentStorage, times(1)).writeOnline(eq(USER_TABLE_NAME), refEq(testCosmosDocument), refEq(writeOptions));
-        verifyNoMoreInteractions(mLocalDocumentStorage);
         assertEquals(RESOLVED_USER_PARTITION, testCosmosDocument.getPartition());
         assertEquals(DOCUMENT_ID, testCosmosDocument.getId());
         assertNull(testCosmosDocument.getError());
@@ -390,7 +388,6 @@ public class DataCreateUpdateDeleteTest extends AbstractDataTest {
         AppCenterFuture<DocumentWrapper<Void>> doc = Data.delete(DOCUMENT_ID, USER_DOCUMENTS);
         verifyTokenExchangeToCosmosDbFlow(false, DOCUMENT_ID, TOKEN_EXCHANGE_USER_PAYLOAD, METHOD_DELETE, "", null);
         verify(mLocalDocumentStorage).deleteOnline(eq(USER_TABLE_NAME), eq(RESOLVED_USER_PARTITION), eq(DOCUMENT_ID));
-        verifyNoMoreInteractions(mLocalDocumentStorage);
         DocumentWrapper<Void> wrapper = doc.get();
         assertNotNull(wrapper);
         assertEquals(USER_DOCUMENTS, wrapper.getPartition());

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/LocalDocumentStorageTest.java
@@ -155,7 +155,7 @@ public class LocalDocumentStorageTest {
         DocumentWrapper<String> doc = mLocalDocumentStorage.read(mUserTableName, PARTITION, DOCUMENT_ID, String.class, ReadOptions.createNoCacheOptions());
 
         /* Verify that we delete the written document because readOptions are set to NoCache. */
-        verify(mDatabaseManager).delete(anyString(), any(ContentValues.class));
+        verify(mDatabaseManager).delete(anyString(), anyString(), any(ContentValues.class));
         assertNotNull(doc);
         assertNotNull(doc.getDeserializedValue());
         assertFalse(doc.hasFailed());

--- a/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/NetworkStateChangeDataTest.java
+++ b/sdk/appcenter-data/src/test/java/com/microsoft/appcenter/data/NetworkStateChangeDataTest.java
@@ -81,7 +81,6 @@ public class NetworkStateChangeDataTest extends AbstractDataTest {
                 }});
         Data.setRemoteOperationListener(mRemoteOperationListener);
         mData.onNetworkStateUpdated(true);
-        ArgumentCaptor<DocumentMetadata> documentMetadataArgumentCaptor = ArgumentCaptor.forClass(DocumentMetadata.class);
 
         /* Verify operation is deleted from the cache when operation expired. */
         ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description
[AB#70996](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/70996)
Refactor to perform local storage write before doing remote operation.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
