### PR TITLE
We never released trackException in Java, it's trackError in .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Crashes
 
-* **[Feature]** Add the `Crash.trackException` method to send handled errors.
+* **[Feature]** Add the `Crash.trackError` method to send handled errors (with optional properties and attachments).
 
 ___
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ManagedErrorActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ManagedErrorActivity.java
@@ -71,17 +71,14 @@ public class ManagedErrorActivity extends PropertyActivity {
         } catch (Throwable t) {
             try {
                 Map<String, String> properties = readStringProperties();
-
-                @SuppressWarnings("JavaReflectionMemberAccess")
-                Method method = Crashes.class.getDeclaredMethod("trackException", Throwable.class, Map.class, Iterable.class);
-                method.setAccessible(true);
+                Method method = Crashes.class.getMethod("trackError", Throwable.class, Map.class, Iterable.class);
                 Iterable<ErrorAttachmentLog> attachmentLogs = AttachmentsUtil.getInstance().getErrorAttachments(getApplicationContext());
                 method.invoke(null, t, properties, attachmentLogs);
 
                 /* TODO uncomment the next line, remove reflection and catch block after API available to jCenter. */
-                /* Crashes.trackException(throwable, properties, attachments); */
+                /* Crashes.trackError(throwable, properties, attachments); */
             } catch (Exception e) {
-                Log.d(LOG_TAG, "Could not call Crashes.trackException", e);
+                Log.d(LOG_TAG, "Could not call Crashes.trackError", e);
             }
         }
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -251,27 +251,28 @@ public class Crashes extends AbstractAppCenterService {
     }
 
     /**
-     * Track an exception.
+     * Track a handled error.
      *
-     * @param throwable An exception.
+     * @param throwable The throwable describing the handled error.
      */
     @SuppressWarnings({"SameParameterValue", "WeakerAccess"})
-    public static void trackException(Throwable throwable) {
-        trackException(throwable, null, null);
+    public static void trackError(Throwable throwable) {
+        trackError(throwable, null, null);
     }
 
     /**
-     * Track a custom exception with name and optional properties.
+     * Track a handled error with name and optional properties and attachments.
      * The name parameter can not be null or empty. Maximum allowed length = 256.
      * The properties parameter maximum item count = 5.
      * The properties keys can not be null or empty, maximum allowed key length = 64.
      * The properties values can not be null, maximum allowed value length = 64.
      * Any length of name/keys/values that are longer than each limit will be truncated.
      *
-     * @param throwable  An exception.
-     * @param properties Optional properties.
+     * @param throwable   The throwable describing the handled error.
+     * @param properties  Optional properties.
+     * @param attachments Optional attachments.
      */
-    public static void trackException(Throwable throwable, Map<String, String> properties, Iterable<ErrorAttachmentLog> attachments) {
+    public static void trackError(Throwable throwable, Map<String, String> properties, Iterable<ErrorAttachmentLog> attachments) {
         getInstance().queueException(throwable, properties, attachments);
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -221,7 +221,7 @@ public class CrashesTest extends AbstractCrashesTest {
         assertFalse(Thread.getDefaultUncaughtExceptionHandler() instanceof UncaughtExceptionHandler);
         assertFalse(verify(file1).delete());
         assertFalse(verify(file2).delete());
-        Crashes.trackException(EXCEPTION);
+        Crashes.trackError(EXCEPTION);
         verifyNoMoreInteractions(mockChannel);
 
         /* Enable back, testing double calls. */
@@ -232,7 +232,7 @@ public class CrashesTest extends AbstractCrashesTest {
         Crashes.setEnabled(true);
         assertTrue(Crashes.isEnabled().get());
         verify(mockChannel, times(2)).addGroup(eq(crashes.getGroupName()), anyInt(), anyInt(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
-        Crashes.trackException(EXCEPTION);
+        Crashes.trackError(EXCEPTION);
         verify(mockChannel, times(1)).enqueue(isA(HandledErrorLog.class), eq(crashes.getGroupName()), eq(DEFAULTS));
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/HandledErrorTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/HandledErrorTest.java
@@ -64,15 +64,15 @@ public class HandledErrorTest extends AbstractCrashesTest {
 
     @Test
     public void notInit() {
-        Crashes.trackException(EXCEPTION, null, null);
+        Crashes.trackError(EXCEPTION, null, null);
         verifyStatic();
         AppCenterLog.error(eq(AppCenter.LOG_TAG), anyString());
     }
 
     @Test
-    public void trackException() {
+    public void trackError() {
         startCrashes();
-        Crashes.trackException(EXCEPTION);
+        Crashes.trackError(EXCEPTION);
         verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
 
             @Override
@@ -82,7 +82,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
             }
         }), eq(mCrashes.getGroupName()), eq(DEFAULTS));
         reset(mChannel);
-        Crashes.trackException(EXCEPTION, new HashMap<String, String>() {{
+        Crashes.trackError(EXCEPTION, new HashMap<String, String>() {{
             put(null, null);
             put("", null);
             put(generateString(ErrorLogHelper.MAX_PROPERTY_ITEM_LENGTH + 1, '*'), null);
@@ -98,7 +98,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
             }
         }), eq(mCrashes.getGroupName()), eq(DEFAULTS));
         reset(mChannel);
-        Crashes.trackException(EXCEPTION, new HashMap<String, String>() {{
+        Crashes.trackError(EXCEPTION, new HashMap<String, String>() {{
             for (int i = 0; i < 30; i++) {
                 put("valid" + i, "valid");
             }
@@ -114,7 +114,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
         }), eq(mCrashes.getGroupName()), eq(DEFAULTS));
         reset(mChannel);
         final String longerMapItem = generateString(ErrorLogHelper.MAX_PROPERTY_ITEM_LENGTH + 1, '*');
-        Crashes.trackException(EXCEPTION, new HashMap<String, String>() {{
+        Crashes.trackError(EXCEPTION, new HashMap<String, String>() {{
             put(longerMapItem, longerMapItem);
         }}, null);
         verify(mChannel).enqueue(argThat(new ArgumentMatcher<Log>() {
@@ -138,7 +138,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
         CrashesListener mockListener = mock(CrashesListener.class);
         mCrashes.setInstanceListener(mockListener);
 
-        /* mCrashes callback test for trackException. */
+        /* mCrashes callback test for trackError. */
         mCrashes.getChannelListener().onBeforeSending(mockLog);
         verify(mockListener, never()).onBeforeSending(any(ErrorReport.class));
         mCrashes.getChannelListener().onSuccess(mockLog);
@@ -235,10 +235,10 @@ public class HandledErrorTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void trackExceptionWithUserId() {
+    public void trackErrorWithUserId() {
         startCrashes();
         UserIdContext.getInstance().setUserId("charlie");
-        Crashes.trackException(EXCEPTION);
+        Crashes.trackError(EXCEPTION);
         ArgumentCaptor<HandledErrorLog> log = ArgumentCaptor.forClass(HandledErrorLog.class);
         verify(mChannel).enqueue(log.capture(), eq(mCrashes.getGroupName()), eq(DEFAULTS));
         assertNotNull(log.getValue());
@@ -247,14 +247,14 @@ public class HandledErrorTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void trackExceptionWithOneAttachment() {
+    public void trackErrorWithOneAttachment() {
 
         /* If we start crashes. */
         startCrashes();
 
         /* When we track error with an attachment. */
         ErrorAttachmentLog textAttachment = ErrorAttachmentLog.attachmentWithText("text", null);
-        Crashes.trackException(EXCEPTION, null, Collections.singleton(textAttachment));
+        Crashes.trackError(EXCEPTION, null, Collections.singleton(textAttachment));
 
         /* Then we send the handled error. */
         ArgumentCaptor<Log> log = ArgumentCaptor.forClass(Log.class);
@@ -296,7 +296,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void trackExceptionWithEverything() {
+    public void trackErrorWithEverything() {
 
         /* If we start crashes. */
         startCrashes();
@@ -312,7 +312,7 @@ public class HandledErrorTest extends AbstractCrashesTest {
                 put("a", "b");
             }
         };
-        Crashes.trackException(EXCEPTION, properties, Arrays.asList(textAttachment, binaryAttachment));
+        Crashes.trackError(EXCEPTION, properties, Arrays.asList(textAttachment, binaryAttachment));
 
         /* Then we send the handled error. */
         ArgumentCaptor<Log> logs = ArgumentCaptor.forClass(Log.class);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

When we did trackException work for Xamarin, PMs wanted to name it trackError.
To this day this is the name of the concept: "Error" in the Portal.
Java work has always been hidden before.
