### PR TITLE
Fix in-app update cache issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 2.4.2
+
+### App Center Distribute
+
+* **[Fix]** Fix an in-app update caching issue, where the same version was installed constantly after the 1st successful update.
+
+___
+
 ## Version 2.4.1
 
 ### App Center Distribute

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -679,7 +679,7 @@ public class Distribute extends AbstractAppCenterService {
 
             /* Load cached release details if process restarted and we have such a cache. */
             int downloadState = getStoredDownloadState();
-            if (mReleaseDetails == null) {
+            if (mReleaseDetails == null && downloadState != DOWNLOAD_STATE_COMPLETED) {
                 updateReleaseDetails(DistributeUtils.loadCachedReleaseDetails());
 
                 /* If cached release is optional and we have network, we should not reuse it. */
@@ -1129,8 +1129,15 @@ public class Distribute extends AbstractAppCenterService {
                         return;
                     }
 
-                    /* Show update dialog. */
+                    /* Load last known release to see if we need to prepare a cleanup. */
+                    if (mReleaseDetails == null) {
+                        updateReleaseDetails(DistributeUtils.loadCachedReleaseDetails());
+                    }
+
+                    /* Prepare download and cleanup older files if needed. */
                     updateReleaseDetails(releaseDetails);
+
+                    /* Show update dialog. */
                     AppCenterLog.debug(LOG_TAG, "Latest release is more recent.");
                     SharedPreferencesManager.putInt(PREFERENCE_KEY_DOWNLOAD_STATE, DOWNLOAD_STATE_AVAILABLE);
                     if (mForegroundActivity != null) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -896,7 +896,6 @@ public class Distribute extends AbstractAppCenterService {
      */
     synchronized void completeWorkflow() {
         cancelNotification();
-        SharedPreferencesManager.remove(PREFERENCE_KEY_RELEASE_DETAILS);
         SharedPreferencesManager.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
         mCheckReleaseApiCall = null;
         mCheckReleaseCallId = null;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -679,7 +679,7 @@ public class Distribute extends AbstractAppCenterService {
 
             /* Load cached release details if process restarted and we have such a cache. */
             int downloadState = getStoredDownloadState();
-            if (mReleaseDetails == null && downloadState != DOWNLOAD_STATE_COMPLETED) {
+            if (mReleaseDetails == null) {
                 updateReleaseDetails(DistributeUtils.loadCachedReleaseDetails());
 
                 /* If cached release is optional and we have network, we should not reuse it. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1115,6 +1115,11 @@ public class Distribute extends AbstractAppCenterService {
                 AppCenterLog.debug(LOG_TAG, "Check if latest release is more recent.");
                 if (isMoreRecent(releaseDetails) && canUpdateNow(releaseDetails)) {
 
+                    /* Load last known release to see if we need to prepare a cleanup. */
+                    if (mReleaseDetails == null) {
+                        updateReleaseDetails(DistributeUtils.loadCachedReleaseDetails());
+                    }
+
                     /* Update cache. */
                     SharedPreferencesManager.putString(PREFERENCE_KEY_RELEASE_DETAILS, rawReleaseDetails);
 
@@ -1127,11 +1132,6 @@ public class Distribute extends AbstractAppCenterService {
                             AppCenterLog.debug(LOG_TAG, "The latest release is mandatory and already being processed.");
                         }
                         return;
-                    }
-
-                    /* Load last known release to see if we need to prepare a cleanup. */
-                    if (mReleaseDetails == null) {
-                        updateReleaseDetails(DistributeUtils.loadCachedReleaseDetails());
                     }
 
                     /* Prepare download and cleanup older files if needed. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1161,6 +1161,10 @@ public class Distribute extends AbstractAppCenterService {
                 mReleaseDownloader.cancel();
             }
             mReleaseDownloader = null;
+        } else if (releaseDetails == null) {
+
+            /* When we disable the SDK or cancel every state, we need to clean download cache. */
+            ReleaseDownloaderFactory.create(mContext, null, null).cancel();
         }
         if (mReleaseDownloaderListener != null) {
             mReleaseDownloaderListener.hideProgressDialog();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -344,7 +344,7 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         /* Verify. */
         verifyStatic();
         SharedPreferencesManager.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
-        verifyStatic();
+        verifyStatic(never());
         SharedPreferencesManager.remove(PREFERENCE_KEY_RELEASE_DETAILS);
         verifyStatic();
         SharedPreferencesManager.putLong(eq(PREFERENCE_KEY_POSTPONE_TIME), eq(now));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -984,6 +984,67 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         verify(cachedReleaseDownloader).cancel();
     }
 
+    @Test
+    public void disableThenEnableBeforeUpdatingSecondTime() throws Exception {
+
+        /* Mock first update completed but we disable in this test so mock we don't have release details. */
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_COMPLETED);
+
+        /* Mock next release. */
+        final ReleaseDetails nextReleaseDetails = mock(ReleaseDetails.class);
+        when(nextReleaseDetails.getId()).thenReturn(2);
+        when(nextReleaseDetails.getVersion()).thenReturn(7);
+        when(ReleaseDetails.parse(anyString())).thenReturn(nextReleaseDetails);
+        ReleaseDownloader nextReleaseDownloader = mock(ReleaseDownloader.class);
+        when(ReleaseDownloaderFactory.create(any(Context.class), same(nextReleaseDetails), any(ReleaseDownloadListener.class))).thenReturn(nextReleaseDownloader);
+        when(nextReleaseDownloader.getReleaseDetails()).thenReturn(nextReleaseDetails);
+
+        /* Simulate cache update. */
+        doAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(nextReleaseDetails);
+                return null;
+            }
+        }).when(SharedPreferencesManager.class);
+        SharedPreferencesManager.putString(eq(PREFERENCE_KEY_RELEASE_DETAILS), anyString());
+
+        /* Mock we receive a second update. */
+        when(SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("some group");
+        when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
+        when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class))).thenAnswer(new Answer<ServiceCall>() {
+
+            @Override
+            public ServiceCall answer(InvocationOnMock invocation) {
+                ((ServiceCallback) invocation.getArguments()[4]).onCallSucceeded("mock", null);
+                return mock(ServiceCall.class);
+            }
+        });
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(DistributeConstants.HEADER_API_TOKEN, "some token");
+
+        /* Start SDK. */
+        start();
+
+        /* Disable SDK. */
+        ReleaseDownloader cleanupReleaseDownloader = mock(ReleaseDownloader.class);
+        when(ReleaseDownloaderFactory.create(any(Context.class), isNull(ReleaseDetails.class), any(ReleaseDownloadListener.class))).thenReturn(cleanupReleaseDownloader);
+        Distribute.setEnabled(false).get();
+        Distribute.setEnabled(true).get();
+
+        /* Verify previous download canceled. */
+        verify(cleanupReleaseDownloader).cancel();
+
+        /* Resume workflow. */
+        Distribute.getInstance().onActivityResumed(mock(Activity.class));
+        verify(mHttpClient).callAsync(anyString(), anyString(), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+
+        /* Verify prompt is shown. */
+        verify(mDialog).show();
+    }
+
     @After
     public void tearDown() throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 0);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 
 import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.distribute.download.ReleaseDownloader;
 import com.microsoft.appcenter.distribute.download.ReleaseDownloaderFactory;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.ServiceCall;
@@ -35,6 +36,7 @@ import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -133,6 +135,8 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         AppCenterLog.error(anyString(), anyString());
 
         /* Enable the service. */
+        ReleaseDownloader cleanupReleaseDownloader = mock(ReleaseDownloader.class);
+        Mockito.when(ReleaseDownloaderFactory.create(any(Context.class), isNull(ReleaseDetails.class), any(ReleaseDownloadListener.class))).thenReturn(cleanupReleaseDownloader);
         distribute.setInstanceEnabled(true);
 
         /* Verify the method is called by resumeDistributeWorkflow. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -579,6 +579,27 @@ public class DistributeTest extends AbstractDistributeTest {
     }
 
     @Test
+    public void loadCacheReleaseDetailsIfProcessRestarted() {
+
+        /* Mock mReleaseDownloader is downloading. */
+        when(mReleaseDownloader.isDownloading()).thenReturn(true);
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_COMPLETED);
+
+        /* Mock that download time is bigger than packageInfo.lastUpdateTime. */
+        when(SharedPreferencesManager.getLong(eq(PREFERENCE_KEY_DOWNLOAD_TIME))).thenReturn(3L);
+
+        /* mReleaseDetails is not null and it's a mandatory update. */
+        when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(null);
+        when(mReleaseDetails.isMandatoryUpdate()).thenReturn(true);
+        resumeWorkflow(mock(Activity.class));
+
+        /* Verify that load cache release details was called. */
+        verifyStatic(times(1));
+        DistributeUtils.loadCachedReleaseDetails();
+    }
+
+    @Test
     public void showMandatoryDownloadReadyDialogTest() {
         mockStatic(DistributeUtils.class);
         when(DistributeUtils.getStoredDownloadState()).thenReturn(-1).thenReturn(DOWNLOAD_STATE_INSTALLING);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -579,27 +579,6 @@ public class DistributeTest extends AbstractDistributeTest {
     }
 
     @Test
-    public void loadCacheReleaseDetailsIfProcessRestarted() {
-
-        /* Mock mReleaseDownloader is downloading. */
-        when(mReleaseDownloader.isDownloading()).thenReturn(true);
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_COMPLETED);
-
-        /* Mock that download time is bigger than packageInfo.lastUpdateTime. */
-        when(SharedPreferencesManager.getLong(eq(PREFERENCE_KEY_DOWNLOAD_TIME))).thenReturn(3L);
-
-        /* mReleaseDetails is not null and it's a mandatory update. */
-        when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(null);
-        when(mReleaseDetails.isMandatoryUpdate()).thenReturn(true);
-        resumeWorkflow(mock(Activity.class));
-
-        /* Verify that load cache release details was called. */
-        verifyStatic();
-        DistributeUtils.loadCachedReleaseDetails();
-    }
-
-    @Test
     public void showMandatoryDownloadReadyDialogTest() {
         mockStatic(DistributeUtils.class);
         when(DistributeUtils.getStoredDownloadState()).thenReturn(-1).thenReturn(DOWNLOAD_STATE_INSTALLING);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -595,7 +595,7 @@ public class DistributeTest extends AbstractDistributeTest {
         resumeWorkflow(mock(Activity.class));
 
         /* Verify that load cache release details was called. */
-        verifyStatic(times(1));
+        verifyStatic();
         DistributeUtils.loadCachedReleaseDetails();
     }
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -247,7 +247,7 @@ public class DistributeTest extends AbstractDistributeTest {
         Distribute.getInstance().setInstalling(mReleaseDetails);
 
         /* Verify. */
-        verifyStatic();
+        verifyStatic(never());
         SharedPreferencesManager.remove(eq(PREFERENCE_KEY_RELEASE_DETAILS));
         verifyStatic();
         SharedPreferencesManager.remove(eq(PREFERENCE_KEY_DOWNLOAD_STATE));

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,8 +6,8 @@
 // Version constants
 
 ext {
-    versionCode = 50
-    versionName = '2.4.1'
+    versionCode = 51
+    versionName = '2.4.2'
     minSdkVersion = 16
     targetSdkVersion = 29
     compileSdkVersion = 29


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

The way we cancel previous downloads since version 2.4.0 is by using the release cache.
If the download was completed successfully, we were not loading the release cache after installing the update (from version A to B), that step was skipped because before version 2.4.0 there was no reason to load release details in that case and the code was not updated.
Thus when receiving the update from B to C, release cache was not pruned because not loaded so the comparison/cancel was skipped in `updateReleaseDetails()`.

## Related PRs or issues

#1301 
[AB#71993](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/71993)