### PR TITLE
Clear release details on complete workflow

### DIFF
--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -896,6 +896,7 @@ public class Distribute extends AbstractAppCenterService {
      */
     synchronized void completeWorkflow() {
         cancelNotification();
+        SharedPreferencesManager.remove(PREFERENCE_KEY_RELEASE_DETAILS);
         SharedPreferencesManager.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
         mCheckReleaseApiCall = null;
         mCheckReleaseCallId = null;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -344,7 +344,7 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         /* Verify. */
         verifyStatic();
         SharedPreferencesManager.remove(PREFERENCE_KEY_DOWNLOAD_STATE);
-        verifyStatic(never());
+        verifyStatic();
         SharedPreferencesManager.remove(PREFERENCE_KEY_RELEASE_DETAILS);
         verifyStatic();
         SharedPreferencesManager.putLong(eq(PREFERENCE_KEY_POSTPONE_TIME), eq(now));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -247,7 +247,7 @@ public class DistributeTest extends AbstractDistributeTest {
         Distribute.getInstance().setInstalling(mReleaseDetails);
 
         /* Verify. */
-        verifyStatic(never());
+        verifyStatic();
         SharedPreferencesManager.remove(eq(PREFERENCE_KEY_RELEASE_DETAILS));
         verifyStatic();
         SharedPreferencesManager.remove(eq(PREFERENCE_KEY_DOWNLOAD_STATE));


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Restore logic that clears release details in the "completeWorflow" method. This fixes a bug that would cause a download fail loop after a single failed download for an in app update.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
