### PR TITLE
Fix validating attachment size to avoid server error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.5.1 (Under development)
 
+### App Center Crashes
+
+* **[Fix]** Validate error attachment size to avoid server error or out of memory issues (using the documented limit which is 7MB).
+
 ___
 
 ## Version 2.5.0

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchCrashesListener.java
@@ -22,7 +22,6 @@ import com.microsoft.appcenter.sasquatch.R;
 import com.microsoft.appcenter.sasquatch.util.AttachmentsUtil;
 import com.microsoft.appcenter.utils.HandlerUtils;
 
-@SuppressWarnings("TryFinallyCanBeTryWithResources")
 public class SasquatchCrashesListener extends AbstractCrashesListener {
 
     @VisibleForTesting

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -120,6 +120,11 @@ public class Crashes extends AbstractAppCenterService {
     private static final int MAX_ATTACHMENT_PER_CRASH = 2;
 
     /**
+     * Maximum size for attachment data in bytes.
+     */
+    private static final int MAX_ATTACHMENT_SIZE = 7 * 1024 * 1024;
+
+    /**
      * Default crashes listener.
      */
     private static final CrashesListener DEFAULT_ERROR_REPORTING_LISTENER = new DefaultCrashesListener();
@@ -1019,10 +1024,10 @@ public class Crashes extends AbstractAppCenterService {
                     attachment.setErrorId(errorId);
                     if (!attachment.isValid()) {
                         AppCenterLog.error(LOG_TAG, "Not all required fields are present in ErrorAttachmentLog.");
-                    } else if (attachment.getData().length > ErrorAttachmentLog.MAX_SIZE) {
+                    } else if (attachment.getData().length > MAX_ATTACHMENT_SIZE) {
                         AppCenterLog.error(LOG_TAG, String.format(Locale.ENGLISH,
                                 "Discarding attachment with size above %d bytes: size=%d, fileName=%s.",
-                                ErrorAttachmentLog.MAX_SIZE, attachment.getData().length, attachment.getFileName()));
+                                MAX_ATTACHMENT_SIZE, attachment.getData().length, attachment.getFileName()));
                     } else {
                         ++totalErrorAttachments;
                         mChannel.enqueue(attachment, ERROR_GROUP, Flags.DEFAULTS);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -55,6 +55,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -1019,7 +1020,9 @@ public class Crashes extends AbstractAppCenterService {
                     if (!attachment.isValid()) {
                         AppCenterLog.error(LOG_TAG, "Not all required fields are present in ErrorAttachmentLog.");
                     } else if (attachment.getData().length > ErrorAttachmentLog.MAX_SIZE) {
-                        AppCenterLog.error(LOG_TAG, "Discarding attachment with size above " + ErrorAttachmentLog.MAX_SIZE + " bytes.");
+                        AppCenterLog.error(LOG_TAG, String.format(Locale.ENGLISH,
+                                "Discarding attachment with size above %d bytes: size=%d, fileName=%s.",
+                                ErrorAttachmentLog.MAX_SIZE, attachment.getData().length, attachment.getFileName()));
                     } else {
                         ++totalErrorAttachments;
                         mChannel.enqueue(attachment, ERROR_GROUP, Flags.DEFAULTS);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -1016,11 +1016,13 @@ public class Crashes extends AbstractAppCenterService {
                 if (attachment != null) {
                     attachment.setId(UUID.randomUUID());
                     attachment.setErrorId(errorId);
-                    if (attachment.isValid()) {
+                    if (!attachment.isValid()) {
+                        AppCenterLog.error(LOG_TAG, "Not all required fields are present in ErrorAttachmentLog.");
+                    } else if (attachment.getData().length > ErrorAttachmentLog.MAX_SIZE) {
+                        AppCenterLog.error(LOG_TAG, "Discarding attachment with size above " + ErrorAttachmentLog.MAX_SIZE + " bytes.");
+                    } else {
                         ++totalErrorAttachments;
                         mChannel.enqueue(attachment, ERROR_GROUP, Flags.DEFAULTS);
-                    } else {
-                        AppCenterLog.error(LOG_TAG, "Not all required fields are present in ErrorAttachmentLog.");
                     }
                 } else {
                     AppCenterLog.warn(LOG_TAG, "Skipping null ErrorAttachmentLog.");

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
@@ -32,6 +32,11 @@ public class ErrorAttachmentLog extends AbstractLog {
     @SuppressWarnings("WeakerAccess")
     public static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
 
+    /**
+     * Maximum size for attachment data in bytes.
+     */
+    public static final int MAX_SIZE = 7 * 1024 * 1024;
+
     public static final String TYPE = "errorAttachment";
 
     private static final String ERROR_ID = "errorId";
@@ -204,6 +209,7 @@ public class ErrorAttachmentLog extends AbstractLog {
         return getId() != null && getErrorId() != null && getContentType() != null && getData() != null;
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void read(JSONObject object) throws JSONException {
         super.read(object);
@@ -228,7 +234,7 @@ public class ErrorAttachmentLog extends AbstractLog {
         JSONUtils.write(writer, DATA, Base64.encodeToString(getData(), Base64.NO_WRAP));
     }
 
-    @SuppressWarnings("SimplifiableIfStatement")
+    @SuppressWarnings({"SimplifiableIfStatement", "EqualsReplaceableByObjectsCall"})
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
@@ -32,11 +32,6 @@ public class ErrorAttachmentLog extends AbstractLog {
     @SuppressWarnings("WeakerAccess")
     public static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
 
-    /**
-     * Maximum size for attachment data in bytes.
-     */
-    public static final int MAX_SIZE = 7 * 1024 * 1024;
-
     public static final String TYPE = "errorAttachment";
 
     private static final String ERROR_ID = "errorId";

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -925,6 +925,7 @@ public class CrashesTest extends AbstractCrashesTest {
         for (int i = 0; i < numOfAttachments; ++i) {
             ErrorAttachmentLog log = mock(ErrorAttachmentLog.class);
             when(log.isValid()).thenReturn(true);
+            when(log.getData()).thenReturn(new byte[1]);
             errorAttachmentLogs.add(log);
         }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -73,6 +73,7 @@ import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.Constants.WRAPPER_SDK_NAME_NDK;
 import static com.microsoft.appcenter.Flags.CRITICAL;
 import static com.microsoft.appcenter.Flags.DEFAULTS;
+import static com.microsoft.appcenter.Flags.NORMAL;
 import static com.microsoft.appcenter.crashes.Crashes.PREF_KEY_MEMORY_RUNNING_LEVEL;
 import static com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog.attachmentWithBinary;
 import static org.junit.Assert.assertEquals;
@@ -955,6 +956,46 @@ public class CrashesTest extends AbstractCrashesTest {
         String expectedMessage = "A limit of " + MAX_ATTACHMENT_PER_CRASH + " attachments per error report might be enforced by server.";
         PowerMockito.verifyStatic();
         AppCenterLog.warn(Crashes.LOG_TAG, expectedMessage);
+    }
+
+    @Test
+    public void discardHugeErrorAttachments() throws JSONException {
+
+        /* Prepare a big (too big) attachment and a small one. */
+        ArrayList<ErrorAttachmentLog> errorAttachmentLogs = new ArrayList<>(2);
+        ErrorAttachmentLog binaryAttachment = attachmentWithBinary(new byte[7 * 1024 * 1024 + 1], "earth.png", "image/png");
+        errorAttachmentLogs.add(binaryAttachment);
+        ErrorAttachmentLog textAttachment = ErrorAttachmentLog.attachmentWithText("hello", "log.txt");
+        errorAttachmentLogs.add(textAttachment);
+
+        /* Set up callbacks. */
+        CrashesListener listener = mock(CrashesListener.class);
+        when(listener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
+        when(listener.getErrorAttachments(any(ErrorReport.class))).thenReturn(errorAttachmentLogs);
+
+        /* Mock a crash log to process. */
+        ManagedErrorLog log = mock(ManagedErrorLog.class);
+        when(log.getId()).thenReturn(UUID.randomUUID());
+        LogSerializer logSerializer = mock(LogSerializer.class);
+        when(logSerializer.deserializeLog(anyString(), anyString())).thenReturn(log);
+        mockStatic(ErrorLogHelper.class);
+        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
+        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
+        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
+        when(FileManager.read(any(File.class))).thenReturn("");
+
+        /* Mock starting crashes so that attachments are processed. */
+        Crashes crashes = Crashes.getInstance();
+        crashes.setInstanceListener(listener);
+        crashes.setLogSerializer(logSerializer);
+        crashes.onStarting(mAppCenterHandler);
+        Channel channel = mock(Channel.class);
+        crashes.onStarted(mock(Context.class), channel, "", null, true);
+
+        /* Check we send only the text attachment as the binary is too big. */
+        verify(channel).enqueue(textAttachment, crashes.getGroupName(), NORMAL);
+        verify(channel, never()).enqueue(eq(binaryAttachment), anyString(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix validating attachment size to avoid server error
    
* 4xx error disables channel and cause all logs to be deleted.
* It can also cause out of memory crashes if we don't limit.

## Related PRs or issues

[AB#70760](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/70760)