### PR TITLE
Breakpad Crash uploaded as incorrect version when sent after updating the app

### DIFF
--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -673,8 +673,8 @@ public class Crashes extends AbstractAppCenterService {
                 mUncaughtExceptionHandler = null;
             }
         } else {
+            DeviceInfoHelper.loadHistoryDevices(mContext);
 
-            DeviceInfoHelper.loadHistoryDevices();
             /* Register Java crash handler. */
             mUncaughtExceptionHandler = new UncaughtExceptionHandler();
             mUncaughtExceptionHandler.register();

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -56,12 +56,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.UUID;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
@@ -673,7 +669,6 @@ public class Crashes extends AbstractAppCenterService {
                 mUncaughtExceptionHandler = null;
             }
         } else {
-            DeviceInfoHelper.loadHistoryDevices(mContext);
 
             /* Register Java crash handler. */
             mUncaughtExceptionHandler = new UncaughtExceptionHandler();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -13,6 +13,7 @@ import android.support.annotation.NonNull;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
+import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
@@ -203,6 +204,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
             }
         }
         mChannel = channel;
+        DeviceInfoHelper.loadHistoryDevices(context);
         applyEnabledState(enabled);
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -685,15 +685,9 @@ public class DefaultChannel implements Channel {
 
         /* Attach device properties to every log if its not already attached by a service. */
         if (log.getDevice() == null) {
-
             /* Generate device properties only once per process life time. */
             if (mDevice == null) {
-                try {
-                    mDevice = DeviceInfoHelper.getDeviceInfo(mContext);
-                } catch (DeviceInfoHelper.DeviceInfoException e) {
-                    AppCenterLog.error(LOG_TAG, "Device log cannot be generated", e);
-                    return;
-                }
+                mDevice = DeviceInfoHelper.getDeviceInfoByTimestamp(log.getTimestamp().getTime());
             }
 
             /* Attach device properties. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
@@ -45,14 +45,8 @@ public class DefaultLogSerializer implements LogSerializer {
     }
 
     @NonNull
-    private JSONStringer writeDevice(JSONStringer writer, DeviceHistory deviceHistory) throws JSONException {
-        writer.object();
-        writer.key(DeviceHistory.KEY_TIMESTAMP).value(deviceHistory.getTimestamp());
-        Device device = deviceHistory.getGetDevice();
-        device.write(writer);
-        writer.key(DeviceHistory.KEY_DEVICE).value(device);
-        writer.endObject();
-        return writer;
+    private JSONStringer writeDevices(JSONStringer writer, DeviceHistory deviceHistory) throws JSONException {
+        return DeviceHistory.writeDevicesHistory(writer, deviceHistory);
     }
 
     @NonNull
@@ -70,16 +64,8 @@ public class DefaultLogSerializer implements LogSerializer {
     }
 
     @NonNull
-    private SortedSet<DeviceHistory> readDevice(JSONArray arrayObject) throws JSONException {
-        SortedSet<DeviceHistory> devicesHistory = new TreeSet<>();
-        for (int i = 0; i < arrayObject.length(); i++) {
-            JSONObject deviceHelperObj = new JSONObject(arrayObject.get(i).toString());
-            long timestamp = deviceHelperObj.getLong(DeviceHistory.KEY_TIMESTAMP);
-            Device device = new Device();
-            device.read(deviceHelperObj.getJSONObject(DeviceHistory.KEY_DEVICE));
-            devicesHistory.add(new DeviceHistory(timestamp, device));
-        }
-        return devicesHistory;
+    private SortedSet<DeviceHistory> readDevices(JSONArray arrayObject) throws JSONException {
+        return DeviceHistory.readDevicesHistory(arrayObject);
     }
 
     @NonNull
@@ -96,18 +82,18 @@ public class DefaultLogSerializer implements LogSerializer {
 
     @NonNull
     @Override
-    public Set<String> serializeDevice(@NonNull SortedSet<DeviceHistory> device) throws JSONException {
+    public Set<String> serializeDevices(@NonNull SortedSet<DeviceHistory> device) throws JSONException {
         Set<String> deviceHistories = new HashSet<>();
         for (DeviceHistory deviceHistory : device) {
-            deviceHistories.add(writeDevice(new JSONStringer(), deviceHistory).toString());
+            deviceHistories.add(writeDevices(new JSONStringer(), deviceHistory).toString());
         }
         return deviceHistories;
     }
 
     @NonNull
     @Override
-    public SortedSet<DeviceHistory> deserializeDevice(@NonNull Set<String> json) throws JSONException {
-        return readDevice(new JSONArray(json));
+    public SortedSet<DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException {
+        return readDevices(new JSONArray(json));
     }
 
     @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
@@ -23,9 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static com.microsoft.appcenter.ingestion.models.CommonProperties.TYPE;
 
@@ -63,7 +62,7 @@ public class DefaultLogSerializer implements LogSerializer {
     }
 
     @NonNull
-    private SortedSet<DeviceHistory> readDevices(JSONArray arrayObject) throws JSONException {
+    private NavigableMap<Long, DeviceHistory> readDevices(JSONArray arrayObject) throws JSONException {
         return DeviceHistory.readDevicesHistory(arrayObject);
     }
 
@@ -81,9 +80,9 @@ public class DefaultLogSerializer implements LogSerializer {
 
     @NonNull
     @Override
-    public Set<String> serializeDevices(@NonNull SortedSet<DeviceHistory> device) throws JSONException {
+    public Set<String> serializeDevices(@NonNull NavigableMap<Long, DeviceHistory> devices) throws JSONException {
         Set<String> deviceHistories = new HashSet<>();
-        for (DeviceHistory deviceHistory : device) {
+        for (DeviceHistory deviceHistory : devices.values()) {
             deviceHistories.add(writeDevices(new JSONStringer(), deviceHistory).toString());
         }
         return deviceHistories;
@@ -91,7 +90,7 @@ public class DefaultLogSerializer implements LogSerializer {
 
     @NonNull
     @Override
-    public SortedSet<DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException {
+    public NavigableMap<Long, DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException {
         return readDevices(new JSONArray(json));
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/DefaultLogSerializer.java
@@ -7,6 +7,7 @@ package com.microsoft.appcenter.ingestion.models.json;
 
 import android.support.annotation.NonNull;
 
+import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.LogContainer;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
@@ -39,6 +40,14 @@ public class DefaultLogSerializer implements LogSerializer {
     }
 
     @NonNull
+    private JSONStringer writeDevice(JSONStringer writer, Device device) throws JSONException {
+        writer.object();
+        device.write(writer);
+        writer.endObject();
+        return writer;
+    }
+
+    @NonNull
     private Log readLog(JSONObject object, String type) throws JSONException {
         if (type == null) {
             type = object.getString(TYPE);
@@ -53,6 +62,13 @@ public class DefaultLogSerializer implements LogSerializer {
     }
 
     @NonNull
+    private Device readDevice(JSONObject object) throws JSONException {
+        Device log = new Device();
+        log.read(object);
+        return log;
+    }
+
+    @NonNull
     @Override
     public String serializeLog(@NonNull Log log) throws JSONException {
         return writeLog(new JSONStringer(), log).toString();
@@ -62,6 +78,18 @@ public class DefaultLogSerializer implements LogSerializer {
     @Override
     public Log deserializeLog(@NonNull String json, String type) throws JSONException {
         return readLog(new JSONObject(json), type);
+    }
+
+    @NonNull
+    @Override
+    public String serializeDevice(@NonNull Device device) throws JSONException {
+        return writeDevice(new JSONStringer(), device).toString();
+    }
+
+    @NonNull
+    @Override
+    public Device deserializeDevice(@NonNull String json) throws JSONException {
+        return readDevice(new JSONObject(json));
     }
 
     @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
@@ -7,14 +7,16 @@ package com.microsoft.appcenter.ingestion.models.json;
 
 import android.support.annotation.NonNull;
 
-import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.LogContainer;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
+import com.microsoft.appcenter.utils.DeviceHistory;
 
 import org.json.JSONException;
 
 import java.util.Collection;
+import java.util.Set;
+import java.util.SortedSet;
 
 public interface LogSerializer {
 
@@ -25,10 +27,10 @@ public interface LogSerializer {
     Log deserializeLog(@NonNull String json, String type) throws JSONException;
 
     @NonNull
-    String serializeDevice(@NonNull Device device) throws JSONException;
+    Set<String> serializeDevice(@NonNull SortedSet<DeviceHistory> device) throws JSONException;
 
     @NonNull
-    Device deserializeDevice(@NonNull String json) throws JSONException;
+    SortedSet<DeviceHistory> deserializeDevice(@NonNull Set<String> json) throws JSONException;
 
     Collection<CommonSchemaLog> toCommonSchemaLog(@NonNull Log log);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
@@ -7,6 +7,7 @@ package com.microsoft.appcenter.ingestion.models.json;
 
 import android.support.annotation.NonNull;
 
+import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.ingestion.models.LogContainer;
 import com.microsoft.appcenter.ingestion.models.one.CommonSchemaLog;
@@ -22,6 +23,12 @@ public interface LogSerializer {
 
     @NonNull
     Log deserializeLog(@NonNull String json, String type) throws JSONException;
+
+    @NonNull
+    String serializeDevice(@NonNull Device device) throws JSONException;
+
+    @NonNull
+    Device deserializeDevice(@NonNull String json) throws JSONException;
 
     Collection<CommonSchemaLog> toCommonSchemaLog(@NonNull Log log);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
@@ -27,10 +27,10 @@ public interface LogSerializer {
     Log deserializeLog(@NonNull String json, String type) throws JSONException;
 
     @NonNull
-    Set<String> serializeDevice(@NonNull SortedSet<DeviceHistory> device) throws JSONException;
+    Set<String> serializeDevices(@NonNull SortedSet<DeviceHistory> device) throws JSONException;
 
     @NonNull
-    SortedSet<DeviceHistory> deserializeDevice(@NonNull Set<String> json) throws JSONException;
+    SortedSet<DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException;
 
     Collection<CommonSchemaLog> toCommonSchemaLog(@NonNull Log log);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/json/LogSerializer.java
@@ -15,6 +15,7 @@ import com.microsoft.appcenter.utils.DeviceHistory;
 import org.json.JSONException;
 
 import java.util.Collection;
+import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -27,10 +28,10 @@ public interface LogSerializer {
     Log deserializeLog(@NonNull String json, String type) throws JSONException;
 
     @NonNull
-    Set<String> serializeDevices(@NonNull SortedSet<DeviceHistory> device) throws JSONException;
+    Set<String> serializeDevices(@NonNull NavigableMap<Long, DeviceHistory> device) throws JSONException;
 
     @NonNull
-    SortedSet<DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException;
+    NavigableMap<Long, DeviceHistory> deserializeDevices(@NonNull Set<String> json) throws JSONException;
 
     Collection<CommonSchemaLog> toCommonSchemaLog(@NonNull Log log);
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -20,7 +20,7 @@ import java.util.TreeSet;
 /**
  * Model class that correlates Device to a crash at app relaunch.
  */
-public class DeviceHistory implements Comparable<Long> {
+public class DeviceHistory implements Comparable<DeviceHistory> {
 
     public static String KEY_TIMESTAMP = "mTimestamp";
     public static String KEY_DEVICE = "mDevice";
@@ -42,8 +42,8 @@ public class DeviceHistory implements Comparable<Long> {
     }
 
     @Override
-    public int compareTo(@NonNull Long timestamp) {
-        return mTimestamp > timestamp ? 1 : 0;
+    public int compareTo(@NonNull DeviceHistory deviceHistory) {
+        return mTimestamp > deviceHistory.mTimestamp ? 1 : 0;
     }
 
     /**
@@ -58,7 +58,7 @@ public class DeviceHistory implements Comparable<Long> {
             JSONObject deviceHelperObj = new JSONObject(arrayObject.get(i).toString());
             long timestamp = deviceHelperObj.getLong(DeviceHistory.KEY_TIMESTAMP);
             Device device = new Device();
-            device.read(deviceHelperObj.getJSONObject(DeviceHistory.KEY_DEVICE));
+            device.read(new JSONObject(deviceHelperObj.get(DeviceHistory.KEY_DEVICE).toString()));
             devicesHistory.add(new DeviceHistory(timestamp, device));
         }
         return  devicesHistory;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -74,10 +74,12 @@ public class DeviceHistory implements Comparable<Long> {
     public static JSONStringer writeDevicesHistory(JSONStringer writer, DeviceHistory deviceHistory) throws JSONException {
         writer.object();
         writer.key(DeviceHistory.KEY_TIMESTAMP).value(deviceHistory.getTimestamp());
-        // todo
+        JSONStringer deviceWriter = new JSONStringer();
         Device device = deviceHistory.getGetDevice();
-        device.write(writer);
-        writer.key(DeviceHistory.KEY_DEVICE).value(device);
+        deviceWriter.object();
+        device.write(deviceWriter);
+        deviceWriter.endObject();
+        writer.key(DeviceHistory.KEY_DEVICE).value(deviceWriter);
         writer.endObject();
         return writer;
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -22,22 +22,21 @@ import java.util.TreeSet;
  */
 public class DeviceHistory implements Comparable<DeviceHistory> {
 
-    private static String KEY_TIMESTAMP = "mTimestamp";
-    private static String KEY_DEVICE = "mDevice";
-
+    private static String KEY_TIMESTAMP = "timestamp";
+    private static String KEY_DEVICE = "device";
     private long mTimestamp;
     private Device mDevice;
 
-    DeviceHistory(long getTimestamp, Device getDevice) {
-        mTimestamp = getTimestamp;
-        mDevice = getDevice;
+    DeviceHistory(long timestamp, Device device) {
+        mTimestamp = timestamp;
+        mDevice = device;
     }
 
     public long getTimestamp() {
         return mTimestamp;
     }
 
-    public Device getGetDevice() {
+    public Device getDevice() {
         return mDevice;
     }
 
@@ -57,7 +56,7 @@ public class DeviceHistory implements Comparable<DeviceHistory> {
         writer.object();
         writer.key(DeviceHistory.KEY_TIMESTAMP).value(deviceHistory.getTimestamp());
         JSONStringer deviceWriter = new JSONStringer();
-        Device device = deviceHistory.getGetDevice();
+        Device device = deviceHistory.getDevice();
         deviceWriter.object();
         device.write(deviceWriter);
         deviceWriter.endObject();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.appcenter.utils;
 
-import android.support.annotation.NonNull;
-
 import com.microsoft.appcenter.ingestion.models.Device;
 
 import org.json.JSONArray;
@@ -14,13 +12,13 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONStringer;
 
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 
 /**
  * Model class that correlates Device to a crash at app relaunch.
  */
-public class DeviceHistory implements Comparable<DeviceHistory> {
+public class DeviceHistory {
 
     private static String KEY_TIMESTAMP = "timestamp";
     private static String KEY_DEVICE = "device";
@@ -40,14 +38,14 @@ public class DeviceHistory implements Comparable<DeviceHistory> {
         return mDevice;
     }
 
-    public static SortedSet<DeviceHistory> readDevicesHistory(JSONArray arrayObject) throws JSONException {
-        SortedSet<DeviceHistory> devicesHistory = new TreeSet<>();
+    public static NavigableMap<Long, DeviceHistory> readDevicesHistory(JSONArray arrayObject) throws JSONException {
+        NavigableMap<Long, DeviceHistory> devicesHistory = new TreeMap<>();
         for (int i = 0; i < arrayObject.length(); i++) {
             JSONObject deviceHelperObj = new JSONObject(arrayObject.get(i).toString());
             long timestamp = deviceHelperObj.getLong(DeviceHistory.KEY_TIMESTAMP);
             Device device = new Device();
             device.read(new JSONObject(deviceHelperObj.get(DeviceHistory.KEY_DEVICE).toString()));
-            devicesHistory.add(new DeviceHistory(timestamp, device));
+            devicesHistory.put(timestamp, new DeviceHistory(timestamp, device));
         }
         return  devicesHistory;
     }
@@ -63,15 +61,5 @@ public class DeviceHistory implements Comparable<DeviceHistory> {
         writer.key(DeviceHistory.KEY_DEVICE).value(deviceWriter);
         writer.endObject();
         return writer;
-    }
-
-    @Override
-    public int compareTo(@NonNull DeviceHistory deviceHistory) {
-        if (mTimestamp > deviceHistory.mTimestamp){
-            return 1;
-        } else if (mTimestamp == deviceHistory.mTimestamp) {
-            return 0;
-        }
-        return -1;
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+package com.microsoft.appcenter.utils;
+
+import android.support.annotation.NonNull;
+
+import com.microsoft.appcenter.ingestion.models.Device;
+
+/**
+ * Model class that correlates Device to a crash at app relaunch.
+ */
+public class DeviceHistory implements Comparable<Long> {
+
+    public static String KEY_TIMESTAMP = "mTimestamp";
+    public static String KEY_DEVICE = "mDevice";
+
+    private long mTimestamp;
+    private Device mDevice;
+
+    public DeviceHistory(long getTimestamp, Device getDevice) {
+        mTimestamp = getTimestamp;
+        mDevice = getDevice;
+    }
+
+    public long getTimestamp() {
+        return mTimestamp;
+    }
+
+    public Device getGetDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public int compareTo(@NonNull Long timestamp) {
+        return mTimestamp > timestamp ? 1 : 0;
+    }
+}

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceHistory.java
@@ -9,6 +9,14 @@ import android.support.annotation.NonNull;
 
 import com.microsoft.appcenter.ingestion.models.Device;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONStringer;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 /**
  * Model class that correlates Device to a crash at app relaunch.
  */
@@ -36,5 +44,41 @@ public class DeviceHistory implements Comparable<Long> {
     @Override
     public int compareTo(@NonNull Long timestamp) {
         return mTimestamp > timestamp ? 1 : 0;
+    }
+
+    /**
+     * todo
+     * @param arrayObject
+     * @return
+     * @throws JSONException
+     */
+    public static SortedSet<DeviceHistory> readDevicesHistory(JSONArray arrayObject) throws JSONException {
+        SortedSet<DeviceHistory> devicesHistory = new TreeSet<>();
+        for (int i = 0; i < arrayObject.length(); i++) {
+            JSONObject deviceHelperObj = new JSONObject(arrayObject.get(i).toString());
+            long timestamp = deviceHelperObj.getLong(DeviceHistory.KEY_TIMESTAMP);
+            Device device = new Device();
+            device.read(deviceHelperObj.getJSONObject(DeviceHistory.KEY_DEVICE));
+            devicesHistory.add(new DeviceHistory(timestamp, device));
+        }
+        return  devicesHistory;
+    }
+
+    /**
+     * todo
+     * @param writer
+     * @param deviceHistory
+     * @return
+     * @throws JSONException
+     */
+    public static JSONStringer writeDevicesHistory(JSONStringer writer, DeviceHistory deviceHistory) throws JSONException {
+        writer.object();
+        writer.key(DeviceHistory.KEY_TIMESTAMP).value(deviceHistory.getTimestamp());
+        // todo
+        Device device = deviceHistory.getGetDevice();
+        device.write(writer);
+        writer.key(DeviceHistory.KEY_DEVICE).value(device);
+        writer.endObject();
+        return writer;
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
@@ -34,6 +34,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TimeZone;
+import java.util.TreeSet;
 
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
@@ -45,7 +46,7 @@ public class DeviceInfoHelper {
     /**
      * todo
      */
-    private static SortedSet<DeviceHistory> mSetDevices;
+    private static SortedSet<DeviceHistory> mSetDevices = new TreeSet<>();
 
     /**
      * OS name.
@@ -230,10 +231,10 @@ public class DeviceInfoHelper {
     /**
      * todo
      */
-    public static synchronized void clearHistoryDevices(LogSerializer logSerializer) {
-        DeviceHistory firstDevice = mSetDevices.first();
-        mSetDevices.clear();
-        mSetDevices.add(firstDevice);
+    public static synchronized void clearHistoryDevices() {
+//        DeviceHistory firstDevice = mSetDevices.first();
+//        mSetDevices.clear();
+//        mSetDevices.add(firstDevice);
         saveDevices();
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
@@ -248,8 +248,8 @@ public class DeviceInfoHelper {
 
         /* If search return negative number we should select value the smaller target number and convert to the positive value. */
         if (index < 0) {
-            index -= 1;
             index *= -1;
+            index -= 1;
         }
         if (index == 0) {
             return devices.get(0).getGetDevice();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
@@ -11,25 +11,20 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Point;
 import android.os.Build;
-import android.support.annotation.VisibleForTesting;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
 
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.ingestion.models.WrapperSdk;
 import com.microsoft.appcenter.ingestion.models.json.DefaultLogSerializer;
 import com.microsoft.appcenter.ingestion.models.json.LogSerializer;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
-import org.json.JSONException;
-
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -62,7 +57,7 @@ public class DeviceInfoHelper {
     /**
      * Flag to remember whether we already refresh devices' history or not.
      */
-    private static boolean needRefresh = true;
+    private static boolean mNeedRefresh = true;
 
     /**
      * Preference storage key for last device info.
@@ -228,12 +223,12 @@ public class DeviceInfoHelper {
     private static synchronized void refreshHistoryDevice(Context context) throws DeviceInfoException {
 
         /* If current device is not already stored in storage. */
-        if (needRefresh) {
+        if (mNeedRefresh) {
             DeviceHistory currentDeviceHistory = new DeviceHistory(System.currentTimeMillis(), getDeviceInfo(context));
             mSetDevices.add(currentDeviceHistory);
             saveDevices();
             mSetDevices.remove(currentDeviceHistory);
-            needRefresh = false;
+            mNeedRefresh = false;
         }
     }
 
@@ -252,11 +247,11 @@ public class DeviceInfoHelper {
             index -= 1;
         }
         if (index == 0) {
-            return devices.get(0).getGetDevice();
+            return devices.get(0).getDevice();
         } else if (index == devices.size()) {
-            return devices.get(devices.size() - 1).getGetDevice();
+            return devices.get(devices.size() - 1).getDevice();
         } else {
-            return devices.get(index - 1).getGetDevice();
+            return devices.get(index - 1).getDevice();
         }
     }
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DeviceHistoryTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/DeviceHistoryTest.java
@@ -1,0 +1,4 @@
+package com.microsoft.appcenter.utils.storage;
+
+public class DeviceHistoryTest {
+}


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Reproduce steps:

1. Run app
2. Crash app with NDK exception (crash saved but is not uploaded yet)
3. Update `versionName` and `versionCode`
4. Run the app and see current `versionName` and `versionCode` instead last.

## Related PRs or issues

[AB#70052](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/70052)