### PR TITLE
Keep distribute state on SSL error as it could just be invalid WIFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 2.5.2 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
+* **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
+
 ___
 
 ## Version 2.5.1

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1079,7 +1079,7 @@ public class Distribute extends AbstractAppCenterService {
                     if (ErrorDetails.NO_RELEASES_FOR_USER_CODE.equals(code)) {
                         AppCenterLog.info(LOG_TAG, "No release available to the current user.");
                     } else {
-                        AppCenterLog.error(LOG_TAG, "Failed to check latest release:", e);
+                        AppCenterLog.error(LOG_TAG, "Failed to check latest release (delete setup state)", e);
                         SharedPreferencesManager.remove(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
                         SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_TOKEN);
                         SharedPreferencesManager.remove(PREFERENCE_KEY_POSTPONE_TIME);
@@ -1092,7 +1092,7 @@ public class Distribute extends AbstractAppCenterService {
                  * it could be SSL error due to WIFI sign-in for example.
                  */
                 else {
-                    AppCenterLog.error(LOG_TAG, "Failed to check latest release:", e);
+                    AppCenterLog.error(LOG_TAG, "Failed to check latest release", e);
                 }
             }
         }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -66,6 +66,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOADED_RELEASE_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_POSTPONE_TIME;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_REQUEST_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY;
@@ -1213,6 +1214,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         verifyStatic(deleteTokenVerificationMode);
         SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_TOKEN);
 
+        /* Check postpone time kept or not depending on the test. */
+        verifyStatic(deleteTokenVerificationMode);
+        SharedPreferencesManager.remove(PREFERENCE_KEY_POSTPONE_TIME);
+
         /* After that if we resume app nothing happens. */
         Distribute.getInstance().onActivityPaused(mock(Activity.class));
         Distribute.getInstance().onActivityResumed(mock(Activity.class));
@@ -1231,7 +1236,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
     @Test
     public void checkReleaseFailsWithSomeSSL() {
-        checkReleaseFailure(new SSLPeerUnverifiedException("unsecured connection"), times(1));
+        checkReleaseFailure(new SSLPeerUnverifiedException("unsecured connection"), never());
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Keep distribute state on SSL error as it could just be invalid WIFI.
Also remove postpone time if removing token like on iOS.

## Related PRs or issues

[AB#73030](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/73030)
