### PR TITLE
Fix Breakpad Crash uploaded as incorrect version when sent after updating the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
 * **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
+* **[Fix]** Fix incorrect app version when an NDK crash is sent after updating the app.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
 * **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
 * **[Fix]** Fix incorrect app version when an NDK crash is sent after updating the app.
-
+* **[Behavior change]** Change the path to the minidump directory to use a subfolder in which the current contextual data (device information, etc.) is saved along with the .dmp file.
 ___
 
 ## Version 2.5.1

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -109,25 +109,14 @@ public class CrashesAndroidTest {
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles();
         assertNotNull(files);
         for (File logFile : files) {
-            if (logFile.isDirectory()) {
-                File[] childFiles = logFile.listFiles();
-                assertNotNull(childFiles);
-                for (File dumpDir : childFiles) {
-                    File[] dumpFiles = dumpDir.listFiles();
-                    assertNotNull(dumpFiles);
-                    for (File dumpFile : dumpFiles) {
-                        assertTrue(dumpFile.delete());
-                    }
-                }
-            } else {
-                assertTrue(logFile.delete());
-            }
+            assertTrue(FileManager.deleteDir(logFile));
         }
         mChannel = mock(Channel.class);
     }
 
     @After
     public void tearDown() {
+        ErrorLogHelper.clearInstance();
         Thread.setDefaultUncaughtExceptionHandler(sDefaultCrashHandler);
     }
 
@@ -165,6 +154,9 @@ public class CrashesAndroidTest {
 
         /* Wait for start. */
         assertTrue(Crashes.isEnabled().get());
+
+        /* Clear sub-folders from previous runs. */
+        ErrorLogHelper.removeStaleMinidumpSubfolders();
     }
 
     @Test
@@ -570,5 +562,11 @@ public class CrashesAndroidTest {
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
         assertEquals(2, files.length);
+    }
+
+    @Test
+    public void getMinidumpSubfolder() {
+        File newMinidumpSubfolder = ErrorLogHelper.getNewMinidumpSubfolder();
+        assertTrue(newMinidumpSubfolder.exists());
     }
 }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -436,6 +436,9 @@ public class CrashesAndroidTest {
     @Test
     public void processingWithMinidump() throws Exception {
 
+        /* Save device info on disk. */
+        ErrorLogHelper.getNewMinidumpSubfolderWithDeviceInfo(sApplication);
+
         /* Simulate we have a minidump. */
         File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();
         File minidumpFile = new File(newMinidumpDirectory, "minidump.dmp");

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -116,7 +116,7 @@ public class CrashesAndroidTest {
 
     @After
     public void tearDown() {
-        ErrorLogHelper.clearInstance();
+        ErrorLogHelper.clearStaticState();
         Thread.setDefaultUncaughtExceptionHandler(sDefaultCrashHandler);
     }
 
@@ -437,7 +437,7 @@ public class CrashesAndroidTest {
     public void processingWithMinidump() throws Exception {
 
         /* Save device info on disk. */
-        ErrorLogHelper.getNewMinidumpSubfolderWithDeviceInfo(sApplication);
+        ErrorLogHelper.getNewMinidumpSubfolderWithContextData(sApplication);
 
         /* Simulate we have a minidump. */
         File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Semaphore;
 
 import static com.microsoft.appcenter.Flags.CRITICAL;
 import static com.microsoft.appcenter.Flags.DEFAULTS;
+import static com.microsoft.appcenter.crashes.utils.ErrorLogHelper.getNewMinidumpDirectory;
 import static com.microsoft.appcenter.test.TestUtils.TAG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -242,6 +243,11 @@ public class CrashesAndroidTest {
         assertNull(Crashes.getLastSessionCrashReport().get());
         assertFalse(Crashes.hasCrashedInLastSession().get());
         assertNull(Crashes.getMinidumpDirectory().get());
+
+        /* Simulate we have minidump from previous run. */
+        File minidumpDirectory = getNewMinidumpDirectory();
+        File sNewMinidumpDirectory = new File(minidumpDirectory, UUID.randomUUID().toString());
+        FileManager.mkdir(sNewMinidumpDirectory.getPath());
 
         /* Simulate we have a minidump. */
         File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();
@@ -576,7 +582,7 @@ public class CrashesAndroidTest {
         ErrorLogHelper.getNewMinidumpSubfolderWithContextData(sApplication);
 
         /* Simulate we have a minidump saved with a previous sdk version. */
-        File directory = ErrorLogHelper.getNewMinidumpDirectory();
+        File directory = getNewMinidumpDirectory();
         File file = new File(directory, "oldMinidump.dmp");
         FileManager.write(file, "mock old minidump");
 

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -254,7 +254,7 @@ public class CrashesAndroidTest {
         assertNull(Crashes.getMinidumpDirectory().get());
 
         /* Simulate we have a minidump. */
-        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpDirectory();
+        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();
         File minidumpFile = new File(newMinidumpDirectory, "minidump.dmp");
         FileManager.write(minidumpFile, "mock minidump");
 
@@ -282,7 +282,7 @@ public class CrashesAndroidTest {
     public void failedToMoveMinidump() throws Exception {
 
         /* Simulate we have a minidump. */
-        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpDirectory();
+        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();
         File minidumpFile = new File(newMinidumpDirectory, "minidump.dmp");
         FileManager.write(minidumpFile, "mock minidump");
 
@@ -445,7 +445,7 @@ public class CrashesAndroidTest {
     public void processingWithMinidump() throws Exception {
 
         /* Simulate we have a minidump. */
-        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpDirectory();
+        File newMinidumpDirectory = ErrorLogHelper.getNewMinidumpSubfolder();
         File minidumpFile = new File(newMinidumpDirectory, "minidump.dmp");
         FileManager.write(minidumpFile, "mock minidump");
 

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
@@ -20,8 +20,10 @@ import java.io.File;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unused")
 public class ErrorLogHelperAndroidTest {
@@ -63,6 +65,15 @@ public class ErrorLogHelperAndroidTest {
     public void getErrorStorageDirectory() {
         assertEquals(Constants.FILES_PATH, mErrorDirectory.getParent());
         assertEquals(ErrorLogHelper.ERROR_DIRECTORY, mErrorDirectory.getName());
+    }
+
+    @Test
+    public void removeMinidumpFolder() {
+        File minidumpFolder = new File(mErrorDirectory.getAbsolutePath(), "minidump");
+        ErrorLogHelper.getNewMinidumpSubfolder();
+        assertTrue(minidumpFolder.exists());
+        ErrorLogHelper.removeMinidumpFolder();
+        assertFalse(minidumpFolder.exists());
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
@@ -8,6 +8,7 @@ package com.microsoft.appcenter.crashes.utils;
 import android.support.test.InstrumentationRegistry;
 
 import com.microsoft.appcenter.Constants;
+import com.microsoft.appcenter.ingestion.models.Device;
 import com.microsoft.appcenter.utils.storage.FileManager;
 
 import org.junit.After;
@@ -139,5 +140,20 @@ public class ErrorLogHelperAndroidTest {
         /* Clean up. */
         for (int i = 0; i < 2; i++)
             FileManager.delete(testFiles[i]);
+    }
+
+    @Test
+    public void parseDevice() {
+        String deviceInfoString = "{\"sdkName\":\"appcenter.android\",\"sdkVersion\":\"2.5.4.2\",\"model\":\"Android SDK built for x86\",\"oemName\":\"Google\",\"osName\":\"Android\",\"osVersion\":\"9\",\"osBuild\":\"PSR1.180720.075\",\"osApiLevel\":28,\"locale\":\"en_US\",\"timeZoneOffset\":240,\"screenSize\":\"1080x1794\",\"appVersion\":\"2.5.4.2\",\"carrierName\":\"Android\",\"carrierCountry\":\"us\",\"appBuild\":\"59\",\"appNamespace\":\"com.microsoft.appcenter.sasquatch.project\"}";
+        Device device = ErrorLogHelper.parseDevice(deviceInfoString);
+        assertNotNull(device);
+        assertEquals(device.getAppBuild(), "59");
+        assertEquals(device.getAppVersion(), "2.5.4.2");
+        assertEquals(device.getSdkName(), "appcenter.android");
+
+        /* Test malformed string. */
+        String deviceInfo2 = "";
+        Device device2 = ErrorLogHelper.parseDevice(deviceInfo2);
+        assertNull(device2);
     }
 }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
@@ -151,9 +151,14 @@ public class ErrorLogHelperAndroidTest {
         assertEquals(device.getAppVersion(), "2.5.4.2");
         assertEquals(device.getSdkName(), "appcenter.android");
 
-        /* Test malformed string. */
+        /* Test empty string. */
         String deviceInfo2 = "";
         Device device2 = ErrorLogHelper.parseDevice(deviceInfo2);
         assertNull(device2);
+
+        /* Test malformed string. */
+        String deviceInfo3 = "abcd";
+        Device device3 = ErrorLogHelper.parseDevice(deviceInfo3);
+        assertNull(device3);
     }
 }

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
@@ -40,13 +40,13 @@ public class ErrorLogHelperAndroidTest {
     public void setUp() {
         mErrorDirectory = ErrorLogHelper.getErrorStorageDirectory();
         assertNotNull(mErrorDirectory);
-
         File[] files = mErrorDirectory.listFiles();
         if (files != null) {
             for (File file : files) {
                 file.delete();
             }
         }
+        assertTrue(mErrorDirectory.exists());
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -58,7 +58,9 @@ public class ErrorLogHelperAndroidTest {
                 file.delete();
             }
         }
+        ErrorLogHelper.clearStaticState();
         mErrorDirectory.delete();
+        assertFalse(mErrorDirectory.exists());
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -741,6 +741,7 @@ public class Crashes extends AbstractAppCenterService {
      * @param minidumpFolder a folder that contains device info and a minidump file.
      */
     private void processSingleMinidump(File minidumpFile, File minidumpFolder) {
+
         /* Create missing files from the native crash that we detected. */
         AppCenterLog.debug(LOG_TAG, "Process pending minidump file: " + minidumpFile);
         long minidumpDate = minidumpFile.lastModified();

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -363,7 +363,7 @@ public class Crashes extends AbstractAppCenterService {
 
             @Override
             public void run() {
-                future.complete(ErrorLogHelper.getNewMinidumpSubfolderWithDeviceInfo(mContext).getAbsolutePath());
+                future.complete(ErrorLogHelper.getNewMinidumpSubfolderWithContextData(mContext).getAbsolutePath());
             }
         }, future, null);
         return future;
@@ -739,7 +739,6 @@ public class Crashes extends AbstractAppCenterService {
                 try {
                     if (savedDeviceInfo != null) {
                         errorLog.setDevice(savedDeviceInfo);
-                        errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
                     }
                     saveErrorLogFiles(new NativeException(), errorLog);
                     if (!logFile.renameTo(dest)) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -464,6 +464,16 @@ public class Crashes extends AbstractAppCenterService {
     @Override
     public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         mContext = context;
+        if (!isInstanceEnabled()) {
+
+            /*
+             * Clean up minidump data when starting on persisted disabled mode. It would be dangerous
+             * to delete/create at runtime inside Crashes.applyEnabledState() method as Breakpad can
+             * be configured only once per process.
+             */
+            ErrorLogHelper.removeMinidumpFolder();
+            AppCenterLog.debug(LOG_TAG, "Clean up minidump folder.");
+        }
         super.onStarted(context, channel, appSecret, transmissionTargetToken, startedFromApp);
         if (isInstanceEnabled()) {
             processPendingErrors();

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -692,6 +692,7 @@ public class Crashes extends AbstractAppCenterService {
                 continue;
             }
             File[] minidumpSubfolderFiles = minidumpSubfolder.listFiles(new FilenameFilter() {
+
                 @Override
                 public boolean accept(File dir, String filename) {
                     return !filename.equals(DEVICE_INFO_FILE);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -737,8 +737,10 @@ public class Crashes extends AbstractAppCenterService {
                  */
                 errorLog.setUserId(UserIdContext.getInstance().getUserId());
                 try {
-                    errorLog.setDevice(savedDeviceInfo);
-                    errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+                    if (savedDeviceInfo != null) {
+                        errorLog.setDevice(savedDeviceInfo);
+                        errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+                    }
                     saveErrorLogFiles(new NativeException(), errorLog);
                     if (!logFile.renameTo(dest)) {
                         throw new IOException("Failed to move file");

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -363,7 +363,7 @@ public class Crashes extends AbstractAppCenterService {
 
             @Override
             public void run() {
-                future.complete(ErrorLogHelper.getNewMinidumpDirectoryWithDeviceInfo(mContext).getAbsolutePath());
+                future.complete(ErrorLogHelper.getNewMinidumpSubfolderWithDeviceInfo(mContext).getAbsolutePath());
             }
         }, future, null);
         return future;
@@ -731,9 +731,9 @@ public class Crashes extends AbstractAppCenterService {
                 errorLog.setProcessName("");
 
                 /*
-                 * TODO user id and device properties are read after restart contrary to Java crashes.
-                 * We should have a user/device property history like we did for session to fix that issue.
-                 * The main issue with the current code is that app version or userId can change between crash and reporting.
+                 * TODO user id is read after restart contrary to Java crashes.
+                 * We should have a user history like we did for session to fix that issue.
+                 * The main issue with the current code is that userId can change between crash and reporting.
                  */
                 errorLog.setUserId(UserIdContext.getInstance().getUserId());
                 try {
@@ -779,8 +779,8 @@ public class Crashes extends AbstractAppCenterService {
             }
         }
 
-        /* Delete new minidumps folders except for the current one. */
-        ErrorLogHelper.removeStaleMinidumpDirectories();
+        /* Remove the minidump subfolders from previous sessions. */
+        ErrorLogHelper.removeStaleMinidumpSubfolders();
     }
 
     private void processPendingErrors() {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -987,17 +987,14 @@ public class Crashes extends AbstractAppCenterService {
                         ErrorAttachmentLog dumpAttachment = null;
                         Map.Entry<UUID, ErrorLogReport> unprocessedEntry = unprocessedIterator.next();
                         ErrorLogReport errorLogReport = unprocessedEntry.getValue();
-                        android.util.Log.d("DBUG", "1234 loop1 " + errorLogReport.report.getDevice().getWrapperSdkName());
                         if (errorLogReport.report.getDevice() != null && WRAPPER_SDK_NAME_NDK.equals(errorLogReport.report.getDevice().getWrapperSdkName())) {
 
-                            android.util.Log.d("DBUG", "1234 loop2");
                             /* Get minidump file path. */
                             Exception exception = errorLogReport.log.getException();
                             String minidumpFilePath = exception.getMinidumpFilePath();
 
                             /* Erase temporary field so that it's not sent to server. */
                             exception.setMinidumpFilePath(null);
-                            android.util.Log.d("DBUG", "1234 loop3");
 
                             /*
                              * Before SDK 2.1.0, the JSON was using the stacktrace field to hold file path on file storage.

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -704,7 +704,7 @@ public class Crashes extends AbstractAppCenterService {
                 errorLog.setException(modelException);
                 errorLog.setTimestamp(new Date(minidumpDate));
                 errorLog.setFatal(true);
-                errorLog.setId(UUID.randomUUID());
+                errorLog.setId(ErrorLogHelper.parseLogFolderUuid(logFolder));
 
                 /* Lookup app launch timestamp in session history. */
                 SessionContext.SessionInfo session = SessionContext.getInstance().getSessionAt(minidumpDate);
@@ -737,9 +737,8 @@ public class Crashes extends AbstractAppCenterService {
                  */
                 errorLog.setUserId(UserIdContext.getInstance().getUserId());
                 try {
-                    if (savedDeviceInfo != null) {
-                        errorLog.setDevice(savedDeviceInfo);
-                    }
+                    Device deviceInfo = savedDeviceInfo != null ? savedDeviceInfo : getDeviceInfo(mContext);
+                    errorLog.setDevice(deviceInfo);
                     saveErrorLogFiles(new NativeException(), errorLog);
                     if (!logFile.renameTo(dest)) {
                         throw new IOException("Failed to move file");

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -683,73 +683,75 @@ public class Crashes extends AbstractAppCenterService {
         /* Convert minidump files to App Center crash files. */
         for (File logFolder : ErrorLogHelper.getNewMinidumpFiles()) {
             File[] files = logFolder.listFiles();
+            if (files == null || files.length == 0) {
+                continue;
+            }
             Device savedDeviceInfo = ErrorLogHelper.getStoredDeviceInfo(logFolder);
-            if (files != null && files.length > 0) {
-                for (File logFile : files) {
-                    if (logFile.getName().endsWith(ErrorLogHelper.DEVICE_INFO_FILE)) {
-                        continue;
-                    }
+            for (File logFile : files) {
+                if (logFile.getName().endsWith(ErrorLogHelper.DEVICE_INFO_FILE)) {
+                    continue;
+                }
 
-                    /* Create missing files from the native crash that we detected. */
-                    AppCenterLog.debug(LOG_TAG, "Process pending minidump file: " + logFile);
-                    long minidumpDate = logFile.lastModified();
-                    File dest = new File(ErrorLogHelper.getPendingMinidumpDirectory(), logFile.getName());
-                    Exception modelException = new Exception();
-                    modelException.setType("minidump");
-                    modelException.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
-                    modelException.setMinidumpFilePath(dest.getPath());
-                    ManagedErrorLog errorLog = new ManagedErrorLog();
-                    errorLog.setException(modelException);
-                    errorLog.setTimestamp(new Date(minidumpDate));
-                    errorLog.setFatal(true);
-                    errorLog.setId(UUID.randomUUID());
+                /* Create missing files from the native crash that we detected. */
+                AppCenterLog.debug(LOG_TAG, "Process pending minidump file: " + logFile);
+                long minidumpDate = logFile.lastModified();
+                File dest = new File(ErrorLogHelper.getPendingMinidumpDirectory(), logFile.getName());
+                Exception modelException = new Exception();
+                modelException.setType("minidump");
+                modelException.setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+                modelException.setMinidumpFilePath(dest.getPath());
+                ManagedErrorLog errorLog = new ManagedErrorLog();
+                errorLog.setException(modelException);
+                errorLog.setTimestamp(new Date(minidumpDate));
+                errorLog.setFatal(true);
+                errorLog.setId(UUID.randomUUID());
 
-                    /* Lookup app launch timestamp in session history. */
-                    SessionContext.SessionInfo session = SessionContext.getInstance().getSessionAt(minidumpDate);
-                    if (session != null && session.getAppLaunchTimestamp() <= minidumpDate) {
-                        errorLog.setAppLaunchTimestamp(new Date(session.getAppLaunchTimestamp()));
-                    } else {
-
-                        /*
-                         * Fall back to log date if app launch timestamp information lost
-                         * or in the future compared to crash time.
-                         * This also covers the case where app launches then crashes within 1s:
-                         * app launch timestamp would have ms accuracy while minidump file is without
-                         * ms, in that case we also falls back to log timestamp
-                         * (this would be same result as truncating ms).
-                         */
-                        errorLog.setAppLaunchTimestamp(errorLog.getTimestamp());
-                    }
+                /* Lookup app launch timestamp in session history. */
+                SessionContext.SessionInfo session = SessionContext.getInstance().getSessionAt(minidumpDate);
+                if (session != null && session.getAppLaunchTimestamp() <= minidumpDate) {
+                    errorLog.setAppLaunchTimestamp(new Date(session.getAppLaunchTimestamp()));
+                } else {
 
                     /*
-                     * TODO The following properties are placeholders because fields are required.
-                     * They should be removed from schema as not used by server.
+                     * Fall back to log date if app launch timestamp information lost
+                     * or in the future compared to crash time.
+                     * This also covers the case where app launches then crashes within 1s:
+                     * app launch timestamp would have ms accuracy while minidump file is without
+                     * ms, in that case we also falls back to log timestamp
+                     * (this would be same result as truncating ms).
                      */
-                    errorLog.setProcessId(0);
-                    errorLog.setProcessName("");
+                    errorLog.setAppLaunchTimestamp(errorLog.getTimestamp());
+                }
 
-                    /*
-                     * TODO user id and device properties are read after restart contrary to Java crashes.
-                     * We should have a user/device property history like we did for session to fix that issue.
-                     * The main issue with the current code is that app version or userId can change between crash and reporting.
-                     */
-                    errorLog.setUserId(UserIdContext.getInstance().getUserId());
-                    try {
-                        errorLog.setDevice(savedDeviceInfo);
-                        errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
-                        saveErrorLogFiles(new NativeException(), errorLog);
-                        if (!logFile.renameTo(dest)) {
-                            throw new IOException("Failed to move file");
-                        }
-                    } catch (java.lang.Exception e) {
+                /*
+                 * TODO The following properties are placeholders because fields are required.
+                 * They should be removed from schema as not used by server.
+                 */
+                errorLog.setProcessId(0);
+                errorLog.setProcessName("");
 
-                        //noinspection ResultOfMethodCallIgnored
-                        logFile.delete();
-                        removeAllStoredErrorLogFiles(errorLog.getId());
-                        AppCenterLog.error(LOG_TAG, "Failed to process new minidump file: " + logFile, e);
+                /*
+                 * TODO user id and device properties are read after restart contrary to Java crashes.
+                 * We should have a user/device property history like we did for session to fix that issue.
+                 * The main issue with the current code is that app version or userId can change between crash and reporting.
+                 */
+                errorLog.setUserId(UserIdContext.getInstance().getUserId());
+                try {
+                    errorLog.setDevice(savedDeviceInfo);
+                    errorLog.getDevice().setWrapperSdkName(WRAPPER_SDK_NAME_NDK);
+                    saveErrorLogFiles(new NativeException(), errorLog);
+                    if (!logFile.renameTo(dest)) {
+                        throw new IOException("Failed to move file");
                     }
+                } catch (java.lang.Exception e) {
+
+                    //noinspection ResultOfMethodCallIgnored
+                    logFile.delete();
+                    removeAllStoredErrorLogFiles(errorLog.getId());
+                    AppCenterLog.error(LOG_TAG, "Failed to process new minidump file: " + logFile, e);
                 }
             }
+
         }
 
         /* Check last session crash. */

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -363,7 +363,7 @@ public class Crashes extends AbstractAppCenterService {
 
             @Override
             public void run() {
-                future.complete(ErrorLogHelper.getNewMinidumpDirectory().getAbsolutePath());
+                future.complete(ErrorLogHelper.getNewMinidumpDirectoryWithDeviceInfo(mContext).getAbsolutePath());
             }
         }, future, null);
         return future;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -565,6 +565,7 @@ public class ErrorLogHelper {
      * @param logFolder a folder, e.g. lib/files/error/minidump/new/a80da2ae-8c85-43b0-a25b-d52319fb6d56
      * @return parsed UUID or random UUID.
      */
+    @NonNull
     public static UUID parseLogFolderUuid(File logFolder) {
         UUID uuid = null;
         if (logFolder.isDirectory()) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -551,4 +551,11 @@ public class ErrorLogHelper {
         }
         return result;
     }
+
+    @VisibleForTesting
+    public static void clearInstance() {
+        sNewMinidumpDirectory = null;
+        sErrorLogDirectory = null;
+        sPendingMinidumpDirectory = null;
+    }
 }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -325,7 +325,7 @@ public class ErrorLogHelper {
     /**
      * Look for 'deviceinfo' file inside the minidump folder and parse it.
      *
-     * @param logFolder - folder where to look for stored device information.
+     * @param logFolder folder where to look for stored device information.
      * @return a device information or null.
      */
     @Nullable
@@ -338,7 +338,7 @@ public class ErrorLogHelper {
             }
         });
         if (files == null || files.length == 0) {
-            AppCenterLog.warn(Crashes.LOG_TAG, "No stored deviceinfo file in a minidump folder.");
+            AppCenterLog.warn(Crashes.LOG_TAG, "No stored deviceinfo file found in a minidump folder.");
             return null;
         }
         File deviceInfoFile = files[0];

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -341,6 +341,11 @@ public class ErrorLogHelper {
             AppCenterLog.error(Crashes.LOG_TAG, "Failed to read stored device info.");
             return null;
         }
+        return parseDevice(deviceInfoString);
+    }
+
+    @VisibleForTesting
+    static Device parseDevice(String deviceInfoString) {
         try {
             Device device = new Device();
             JSONObject jsonObject = new JSONObject(deviceInfoString);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -559,6 +559,24 @@ public class ErrorLogHelper {
         return result;
     }
 
+    /**
+     * Parse log folder name UUID. Fallback to random UUID.
+     *
+     * @param logFolder a folder, e.g. lib/files/error/minidump/new/a80da2ae-8c85-43b0-a25b-d52319fb6d56
+     * @return parsed UUID or random UUID.
+     */
+    public static UUID parseLogFolderUuid(File logFolder) {
+        UUID uuid = null;
+        if (logFolder.isDirectory()) {
+            try {
+                uuid = UUID.fromString(logFolder.getName());
+            } catch (IllegalArgumentException e) {
+                AppCenterLog.warn(Crashes.LOG_TAG, "Cannot parse minidump folder name to UUID.", e);
+            }
+        }
+        return uuid == null ? UUID.randomUUID() : uuid;
+    }
+
     @VisibleForTesting
     public static void clearStaticState() {
         sNewMinidumpDirectory = null;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -231,7 +231,7 @@ public class ErrorLogHelper {
      * @return a file name e.g. /lib/files/error/minidump/new
      */
     @NonNull
-    private static synchronized File getNewMinidumDirectoryPath() {
+    public static synchronized File getNewMinidumDirectoryPath() {
         File errorStorageDirectory = getErrorStorageDirectory();
         File minidumpDirectory = new File(errorStorageDirectory.getAbsolutePath(), MINIDUMP_DIRECTORY);
         return new File(minidumpDirectory, NEW_MINIDUMP_DIRECTORY);
@@ -307,7 +307,7 @@ public class ErrorLogHelper {
 
     @NonNull
     public static File[] getNewMinidumpFiles() {
-        File[] files = getNewMinidumpDirectory().listFiles();
+        File[] files = getNewMinidumDirectoryPath().listFiles();
         return files != null ? files : new File[0];
     }
 
@@ -335,7 +335,6 @@ public class ErrorLogHelper {
         return null;
     }
 
-    @Nullable
     public static void removeStaleMinidumpDirectories() {
         final File newMinidumpDirectory = getNewMinidumpDirectory();
         File[] previousSubFolders = getNewMinidumDirectoryPath().listFiles(new FilenameFilter() {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -369,12 +369,14 @@ public class ErrorLogHelper {
      * so that they can be safely deleted.
      */
     public static void removeStaleMinidumpSubfolders() {
-        final File minidumpSubfolder = getNewMinidumpSubfolder();
         File[] previousSubFolders = getNewMinidumpDirectory().listFiles(new FilenameFilter() {
 
             @Override
             public boolean accept(File dir, String name) {
-                return !name.equals(minidumpSubfolder.getName());
+                if (sNewMinidumpDirectory != null) {
+                    return !name.equals(sNewMinidumpDirectory.getName());
+                }
+                return true;
             }
         });
         if (previousSubFolders == null || previousSubFolders.length == 0) {
@@ -384,6 +386,15 @@ public class ErrorLogHelper {
         for (File file : previousSubFolders) {
             FileManager.deleteDir(file);
         }
+    }
+
+    /**
+     * Remove the minidump folder.
+     */
+    public static void removeMinidumpFolder() {
+        File errorStorageDirectory = getErrorStorageDirectory();
+        File minidumpDirectory = new File(errorStorageDirectory.getAbsolutePath(), MINIDUMP_DIRECTORY);
+        FileManager.deleteDir(minidumpDirectory);
     }
 
     @Nullable

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -234,7 +234,7 @@ public class ErrorLogHelper {
      * @return a folder name e.g. /lib/files/error/minidump/new
      */
     @NonNull
-    private static synchronized File getNewMinidumpDirectory() {
+    public static synchronized File getNewMinidumpDirectory() {
         File errorStorageDirectory = getErrorStorageDirectory();
         File minidumpDirectory = new File(errorStorageDirectory.getAbsolutePath(), MINIDUMP_DIRECTORY);
         return new File(minidumpDirectory, NEW_MINIDUMP_DIRECTORY);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -231,7 +231,7 @@ public class ErrorLogHelper {
      * @return a file name e.g. /lib/files/error/minidump/new
      */
     @NonNull
-    public static synchronized File getNewMinidumDirectoryPath() {
+    public static synchronized File getNewMinidumpDirectoryPath() {
         File errorStorageDirectory = getErrorStorageDirectory();
         File minidumpDirectory = new File(errorStorageDirectory.getAbsolutePath(), MINIDUMP_DIRECTORY);
         return new File(minidumpDirectory, NEW_MINIDUMP_DIRECTORY);
@@ -245,7 +245,7 @@ public class ErrorLogHelper {
     @NonNull
     public static synchronized File getNewMinidumpDirectory() {
         if (sNewMinidumpDirectory == null) {
-            File minidumpDirectory = getNewMinidumDirectoryPath();
+            File minidumpDirectory = getNewMinidumpDirectoryPath();
             sNewMinidumpDirectory = new File(minidumpDirectory, UUID.randomUUID().toString());
             FileManager.mkdir(sNewMinidumpDirectory.getPath());
         }
@@ -307,7 +307,7 @@ public class ErrorLogHelper {
 
     @NonNull
     public static File[] getNewMinidumpFiles() {
-        File[] files = getNewMinidumDirectoryPath().listFiles();
+        File[] files = getNewMinidumpDirectoryPath().listFiles();
         return files != null ? files : new File[0];
     }
 
@@ -337,7 +337,7 @@ public class ErrorLogHelper {
 
     public static void removeStaleMinidumpDirectories() {
         final File newMinidumpDirectory = getNewMinidumpDirectory();
-        File[] previousSubFolders = getNewMinidumDirectoryPath().listFiles(new FilenameFilter() {
+        File[] previousSubFolders = getNewMinidumpDirectoryPath().listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
                 return !name.equals(newMinidumpDirectory.getName());

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -40,7 +40,9 @@ import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
@@ -111,6 +113,9 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 public class CrashesTest extends AbstractCrashesTest {
 
     private static final String STACK_TRACE = "Sample stacktrace";
+
+    @Rule
+    public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
 
     private ManagedErrorLog mErrorLog;
 
@@ -238,20 +243,17 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void failToListErrorStorageDirectoryOnDisable() {
+    public void failToListErrorStorageDirectoryOnDisable() throws IOException {
+        File minidumpSubFolder = mTemporaryFolder.newFolder("minidumpSubFolder");
 
-        /* Setup mock. */
-        File mockErrorFile = mock(File.class);
-        when(mockErrorFile.listFiles()).thenReturn(null);
-        when(mockErrorFile.isDirectory()).thenReturn(true);
+        /* Fake directory will return null when called listFiles(). */
+        File dir = mTemporaryFolder.newFile("dir");
         Crashes crashes = Crashes.getInstance();
         mockStatic(ErrorLogHelper.class);
         Context context = mock(Context.class);
         Channel mockChannel = mock(Channel.class);
-        File dir = mock(File.class);
         when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(dir);
-        when(dir.listFiles()).thenReturn(null);
-        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{ mockErrorFile });
+        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{minidumpSubFolder});
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{});
 
         /* Start. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1199,6 +1199,7 @@ public class CrashesTest extends AbstractCrashesTest {
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingDir);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
+        when(ErrorLogHelper.parseLogFolderUuid(any(File.class))).thenReturn(UUID.randomUUID());
         when(FileManager.read(any(File.class))).thenReturn("");
         LogSerializer logSerializer = mock(LogSerializer.class);
         ArgumentCaptor<Log> log = ArgumentCaptor.forClass(Log.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -157,7 +157,7 @@ public class CrashesTest extends AbstractCrashesTest {
         crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
         /* Test. */
-        verifyStatic(times(3));
+        verifyStatic(times(4));
         SharedPreferencesManager.getBoolean(CRASHES_ENABLED_KEY, true);
         assertFalse(Crashes.isEnabled().get());
         assertEquals(crashes.getInitializeTimestamp(), -1);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1165,6 +1165,13 @@ public class CrashesTest extends AbstractCrashesTest {
         File minidumpFile = mock(File.class);
         when(minidumpFile.getName()).thenReturn("mockFile");
         when(minidumpFile.lastModified()).thenReturn(crashTime);
+
+        /* Mock sub-folder. */
+        File minidumpSubfolder = mock(File.class);
+        when(minidumpSubfolder.getName()).thenReturn("mockFolder");
+        when(minidumpSubfolder.listFiles()).thenReturn(new File[]{minidumpFile});
+
+        /* Mock session context. */
         mockStatic(SessionContext.class);
         SessionContext sessionContext = mock(SessionContext.class);
         when(SessionContext.getInstance()).thenReturn(sessionContext);
@@ -1173,15 +1180,19 @@ public class CrashesTest extends AbstractCrashesTest {
             when(sessionContext.getSessionAt(crashTime)).thenReturn(sessionInfo);
             when(sessionInfo.getAppLaunchTimestamp()).thenReturn(appStartTime);
         }
-        mockStatic(DeviceInfoHelper.class);
-        when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenReturn(mock(Device.class));
-        ErrorReport report = new ErrorReport();
+
+        /* Mock device info and ErrorLogHelper. */
         mockStatic(ErrorLogHelper.class);
+        mockStatic(DeviceInfoHelper.class);
+        Device device = mock(Device.class);
+        when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenReturn(device);
+        when(ErrorLogHelper.getStoredDeviceInfo(any(File.class))).thenReturn(device);
+        ErrorReport report = new ErrorReport();
         File errorLogFile = mock(File.class);
         when(errorLogFile.length()).thenReturn(1L);
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(errorLogFile);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
-        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{minidumpFile});
+        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{minidumpSubfolder});
         File pendingDir = mock(File.class);
         Whitebox.setInternalState(pendingDir, "path", "");
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingDir);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -268,34 +268,6 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void directoryOnDisableWhenListFileEmpty() {
-
-        /* Setup mock. */
-        Crashes crashes = Crashes.getInstance();
-        mockStatic(ErrorLogHelper.class);
-        Context context = mock(Context.class);
-        Channel mockChannel = mock(Channel.class);
-        File dir = mock(File.class);
-        when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(dir);
-        when(dir.listFiles()).thenReturn(new File[] { });
-        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{});
-        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{});
-
-        /* Start. */
-        crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(context, mockChannel, "", null, true);
-        verify(mockChannel).removeGroup(eq(crashes.getGroupName()));
-        verify(mockChannel).addGroup(eq(crashes.getGroupName()), anyInt(), anyInt(), anyInt(), isNull(Ingestion.class), any(Channel.GroupListener.class));
-
-        /* When we disable. */
-        Crashes.setEnabled(false);
-        assertFalse(Crashes.isEnabled().get());
-
-        /* Verify we recovered file listing error. */
-        verify(context).unregisterComponentCallbacks(notNull(ComponentCallbacks.class));
-    }
-
-    @Test
     public void setEnabledWithoutContext() {
         Crashes crashes = Crashes.getInstance();
         crashes.setUncaughtExceptionHandler(null);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -40,9 +40,7 @@ import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
@@ -113,9 +111,6 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 public class CrashesTest extends AbstractCrashesTest {
 
     private static final String STACK_TRACE = "Sample stacktrace";
-
-    @Rule
-    public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
 
     private ManagedErrorLog mErrorLog;
 
@@ -243,17 +238,20 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void failToListErrorStorageDirectoryOnDisable() throws IOException {
-        File minidumpSubFolder = mTemporaryFolder.newFolder("minidumpSubFolder");
+    public void failToListErrorStorageDirectoryOnDisable() {
 
-        /* Fake directory will return null when called listFiles(). */
-        File dir = mTemporaryFolder.newFile("dir");
+        /* Setup mock. */
+        File mockErrorFile = mock(File.class);
+        when(mockErrorFile.listFiles()).thenReturn(null);
+        when(mockErrorFile.isDirectory()).thenReturn(true);
         Crashes crashes = Crashes.getInstance();
         mockStatic(ErrorLogHelper.class);
         Context context = mock(Context.class);
         Channel mockChannel = mock(Channel.class);
+        File dir = mock(File.class);
         when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(dir);
-        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{minidumpSubFolder});
+        when(dir.listFiles()).thenReturn(null);
+        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[]{mockErrorFile});
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{});
 
         /* Start. */

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -243,6 +243,7 @@ public class CrashesTest extends AbstractCrashesTest {
         /* Setup mock. */
         File mockErrorFile = mock(File.class);
         when(mockErrorFile.listFiles()).thenReturn(null);
+        when(mockErrorFile.isDirectory()).thenReturn(true);
         Crashes crashes = Crashes.getInstance();
         mockStatic(ErrorLogHelper.class);
         Context context = mock(Context.class);
@@ -1166,11 +1167,13 @@ public class CrashesTest extends AbstractCrashesTest {
         /* Setup mock for a crash in disk. */
         File minidumpFile = mock(File.class);
         when(minidumpFile.getName()).thenReturn("mockFile");
+        when(minidumpFile.isDirectory()).thenReturn(false);
         when(minidumpFile.lastModified()).thenReturn(crashTime);
 
         /* Mock sub-folder. */
         File minidumpSubfolder = mock(File.class);
         when(minidumpSubfolder.getName()).thenReturn("mockFolder");
+        when(minidumpSubfolder.isDirectory()).thenReturn(true);
         when(minidumpSubfolder.listFiles()).thenReturn(new File[]{minidumpFile});
 
         /* Mock session context. */
@@ -1187,6 +1190,7 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         mockStatic(DeviceInfoHelper.class);
         Device device = mock(Device.class);
+        when(DeviceInfoHelper.getDeviceInfo(any(Context.class))).thenReturn(mock(Device.class));
         when(ErrorLogHelper.getStoredDeviceInfo(any(File.class))).thenReturn(hasDeviceInfo ? device : null);
         ErrorReport report = new ErrorReport();
         File errorLogFile = mock(File.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -53,6 +53,7 @@ import org.powermock.reflect.Whitebox;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1174,7 +1175,7 @@ public class CrashesTest extends AbstractCrashesTest {
         File minidumpSubfolder = mock(File.class);
         when(minidumpSubfolder.getName()).thenReturn("mockFolder");
         when(minidumpSubfolder.isDirectory()).thenReturn(true);
-        when(minidumpSubfolder.listFiles()).thenReturn(new File[]{minidumpFile});
+        when(minidumpSubfolder.listFiles(any(FilenameFilter.class))).thenReturn(new File[]{minidumpFile});
 
         /* Mock session context. */
         mockStatic(SessionContext.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -23,6 +23,7 @@ import com.microsoft.appcenter.test.TestUtils;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.storage.FileManager;
 
+import org.json.JSONStringer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,8 +50,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
@@ -401,5 +404,19 @@ public class ErrorLogHelperTest {
         when(FileManager.read(eq(deviceInfoFile))).thenReturn(null);
         Device storedDeviceInfo3 = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder3);
         assertNull(storedDeviceInfo3);
+    }
+
+    @Test
+    public void throwExceptionWhenGetMinidumpSubfolderWithDeviceInfo() throws java.lang.Exception {
+
+        /* Prepare data. */
+        Context mockContext = mock(Context.class);
+        File mockFile = mock(File.class);
+        whenNew(JSONStringer.class).withAnyArguments().thenThrow(new java.lang.Exception());
+        whenNew(File.class).withAnyArguments().thenReturn(mockFile);
+
+        /* Verify. */
+        ErrorLogHelper.getNewMinidumpSubfolderWithDeviceInfo(mockContext);
+        verify(mockFile).delete();
     }
 }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -49,6 +49,7 @@ import java.util.UUID;
 import static com.microsoft.appcenter.test.TestUtils.generateString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -58,6 +59,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -466,5 +468,36 @@ public class ErrorLogHelperTest {
         /* Verify. */
         ErrorLogHelper.getNewMinidumpSubfolderWithContextData(mockContext);
         verify(mockFile).delete();
+    }
+
+    @Test
+    public void parseLogFolderUuid() {
+        String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
+        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName);
+        File spy = spy(logFolder);
+        when(spy.isDirectory()).thenReturn(true);
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
+        assertEquals(uuid.toString(), originalFolderName);
+    }
+
+    @Test
+    public void parseLogFolderUuidFallback() {
+        String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
+        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName);
+        File spy = spy(logFolder);
+        when(spy.isDirectory()).thenReturn(false);
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
+        assertNotEquals(uuid.toString(), "a80da2ae-8c85-43b0-a25b-d52319fb6d56");
+    }
+
+    @Test
+    public void parseLogFolderUuidIllegalArgument() {
+        String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
+        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName + ".dmp");
+        File spy = spy(logFolder);
+        when(spy.isDirectory()).thenReturn(true);
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
+        System.out.println(uuid.toString());
+        assertNotEquals(uuid.toString(), originalFolderName);
     }
 }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -59,7 +60,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -71,6 +71,9 @@ public class ErrorLogHelperTest {
 
     @Rule
     public PowerMockRule mRule = new PowerMockRule();
+
+    @Rule
+    public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
 
     @Before
     public void setUp() {
@@ -471,33 +474,26 @@ public class ErrorLogHelperTest {
     }
 
     @Test
-    public void parseLogFolderUuid() {
+    public void parseLogFolderUuid() throws IOException {
         String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
-        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName);
-        File spy = spy(logFolder);
-        when(spy.isDirectory()).thenReturn(true);
-        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
+        File logFolder = mTemporaryFolder.newFolder("new", originalFolderName);
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(logFolder);
         assertEquals(uuid.toString(), originalFolderName);
     }
 
     @Test
-    public void parseLogFolderUuidFallback() {
+    public void parseLogFolderUuidFallback() throws IOException {
         String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
-        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName);
-        File spy = spy(logFolder);
-        when(spy.isDirectory()).thenReturn(false);
-        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
-        assertNotEquals(uuid.toString(), "a80da2ae-8c85-43b0-a25b-d52319fb6d56");
+        File logFile = mTemporaryFolder.newFile(originalFolderName);
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(logFile);
+        assertNotEquals(uuid.toString(), originalFolderName);
     }
 
     @Test
-    public void parseLogFolderUuidIllegalArgument() {
+    public void parseLogFolderUuidIllegalArgument() throws IOException {
         String originalFolderName = "a80da2ae-8c85-43b0-a25b-d52319fb6d56";
-        File logFolder = new File("lib/files/error/minidump/new/" + originalFolderName + ".dmp");
-        File spy = spy(logFolder);
-        when(spy.isDirectory()).thenReturn(true);
-        UUID uuid = ErrorLogHelper.parseLogFolderUuid(spy);
-        System.out.println(uuid.toString());
+        File logFolder = mTemporaryFolder.newFolder("new", originalFolderName + ".dmp");
+        UUID uuid = ErrorLogHelper.parseLogFolderUuid(logFolder);
         assertNotEquals(uuid.toString(), originalFolderName);
     }
 }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -380,11 +380,11 @@ public class ErrorLogHelperTest {
     }
 
     @Test
-    public void getStoredDeviceInfo() {
+    public void getStoredDeviceInfo() throws IOException {
         String deviceInfoString = "{\"sdkName\":\"appcenter.android\",\"sdkVersion\":\"2.5.4.2\",\"model\":\"Android SDK built for x86\",\"oemName\":\"Google\",\"osName\":\"Android\",\"osVersion\":\"9\",\"osBuild\":\"PSR1.180720.075\",\"osApiLevel\":28,\"locale\":\"en_US\",\"timeZoneOffset\":240,\"screenSize\":\"1080x1794\",\"appVersion\":\"2.5.4.2\",\"carrierName\":\"Android\",\"carrierCountry\":\"us\",\"appBuild\":\"59\",\"appNamespace\":\"com.microsoft.appcenter.sasquatch.project\"}";
-        File deviceInfoFile = mock(File.class);
-        File minidumpFolder = mock(File.class);
-        when(minidumpFolder.listFiles(any(FilenameFilter.class))).thenReturn(new File[]{deviceInfoFile});
+        File minidumpFolder = mTemporaryFolder.newFolder("minidump");
+        File deviceInfoFile = new File(minidumpFolder, ErrorLogHelper.DEVICE_INFO_FILE);
+        assertTrue(deviceInfoFile.createNewFile());
         mockStatic(FileManager.class);
         when(FileManager.read(eq(deviceInfoFile))).thenReturn(deviceInfoString);
         Device storedDeviceInfo = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder);
@@ -393,26 +393,27 @@ public class ErrorLogHelperTest {
 
     @Test
     public void getStoredDeviceInfoNull() {
-
-        /* Test null directory. */
         File minidumpFolder = mock(File.class);
         when(minidumpFolder.listFiles(any(FilenameFilter.class))).thenReturn(null);
         Device storedDeviceInfo = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder);
         assertNull(storedDeviceInfo);
+    }
 
-        /* Test empty directory. */
-        File minidumpFolder2 = mock(File.class);
-        when(minidumpFolder2.listFiles(any(FilenameFilter.class))).thenReturn(new File[]{});
-        Device storedDeviceInfo2 = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder2);
-        assertNull(storedDeviceInfo2);
+    @Test
+    public void getStoredDeviceInfoEmpty() throws IOException {
+        File minidumpFolder = mTemporaryFolder.newFolder("minidump");
+        Device storedDeviceInfo = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder);
+        assertNull(storedDeviceInfo);
+    }
 
-        /* Cannot read device info. */
-        File deviceInfoFile = mock(File.class);
-        File minidumpFolder3 = mock(File.class);
-        when(minidumpFolder3.listFiles(any(FilenameFilter.class))).thenReturn(new File[]{deviceInfoFile});
+    @Test
+    public void getStoredDeviceInfoCannotRead() throws IOException {
+        File minidumpFolder = mTemporaryFolder.newFolder("minidump");
+        File deviceInfoFile = new File(minidumpFolder, ErrorLogHelper.DEVICE_INFO_FILE);
+        assertTrue(deviceInfoFile.createNewFile());
         mockStatic(FileManager.class);
         when(FileManager.read(eq(deviceInfoFile))).thenReturn(null);
-        Device storedDeviceInfo3 = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder3);
+        Device storedDeviceInfo3 = ErrorLogHelper.getStoredDeviceInfo(minidumpFolder);
         assertNull(storedDeviceInfo3);
     }
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -226,6 +226,12 @@ public class FileManager {
         return file.delete();
     }
 
+    /**
+     * Delete a directory with files.
+     *
+     * @param file The file or directory to delete.
+     * @return {@code true} if it was deleted, {@code false} otherwise.
+     */
     public static boolean deleteDir(File file) {
         File[] contents = file.listFiles();
         if (contents != null) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -226,6 +226,16 @@ public class FileManager {
         return file.delete();
     }
 
+    public static boolean deleteDir(File file) {
+        File[] contents = file.listFiles();
+        if (contents != null) {
+            for (File f : contents) {
+                deleteDir(f);
+            }
+        }
+        return file.delete();
+    }
+
     /**
      * Create a directory if it does not already exist.
      * Will create the whole directory tree if necessary.

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -12,7 +12,6 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 
@@ -38,6 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -165,7 +165,7 @@ public class FileManagerTest {
         when(mockFile.listFiles())
                 .thenReturn(null)
                 .thenReturn(new File[]{ });
-        PowerMockito.spy(FileManager.class);
+        spy(FileManager.class);
         FileManager.deleteDir(mockFile);
 
         /* Verify. */
@@ -188,7 +188,7 @@ public class FileManagerTest {
         File mockFileOne = mock(File.class);
         File mockFileTwo = mock(File.class);
         when(mockFile.listFiles()).thenReturn(new File[] { mockFileOne, mockFileTwo});
-        PowerMockito.spy(FileManager.class);
+        spy(FileManager.class);
         FileManager.deleteDir(mockFile);
 
         /* Verify. */

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -12,6 +12,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 
@@ -32,6 +33,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -153,5 +155,44 @@ public class FileManagerTest {
         verify(fileInputStream).close();
         verifyStatic();
         AppCenterLog.error(anyString(), anyString(), any(IOException.class));
+    }
+
+    @Test
+    public void deleteFilesWhenFileListIsNull() {
+
+        /* Prepare data. */
+        File mockFile = mock(File.class);
+        when(mockFile.listFiles())
+                .thenReturn(null)
+                .thenReturn(new File[]{ });
+        PowerMockito.spy(FileManager.class);
+        FileManager.deleteDir(mockFile);
+
+        /* Verify. */
+        verifyStatic();
+        FileManager.deleteDir(any(File.class));
+
+        /* Remove again. */
+        FileManager.deleteDir(mockFile);
+
+        /* Verify. */
+        verifyStatic(times(2));
+        FileManager.deleteDir(any(File.class));
+    }
+
+    @Test
+    public void deleteFiles() {
+
+        /* Prepare data. */
+        File mockFile = mock(File.class);
+        File mockFileOne = mock(File.class);
+        File mockFileTwo = mock(File.class);
+        when(mockFile.listFiles()).thenReturn(new File[] { mockFileOne, mockFileTwo});
+        PowerMockito.spy(FileManager.class);
+        FileManager.deleteDir(mockFile);
+
+        /* Verify. */
+        verifyStatic(times(3));
+        FileManager.deleteDir(any(File.class));
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

- When crashes start, create a random sub-folder
- In that folder, save device properties
- Configure breakpad to save in that folder (modify getMinidumpDir to return sub folder)
- When restarting, process files from each sub folder, minidump gets paired with device properties that are in same folder. Clean up sub-folders on processing.

## Related PRs or issues

[AB#70052](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/70052)
[Github issue](https://github.com/microsoft/appcenter-sdk-android/issues/1265/)
