### PR TITLE
Fix possible deadlock when activity resumed during SDK background init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Version 2.5.2 (Under development)
 
+### App Center Crashes
+
+* **[Fix]** Fix incorrect app version when an NDK crash is sent after updating the app.
+* **[Behavior change]** Change the path to the minidump directory to use a subfolder in which the current contextual data (device information, etc.) is saved along with the .dmp file.
+
 ### App Center Distribute
 
 * **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
 * **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
-* **[Fix]** Fix incorrect app version when an NDK crash is sent after updating the app.
-* **[Behavior change]** Change the path to the minidump directory to use a subfolder in which the current contextual data (device information, etc.) is saved along with the .dmp file.
+* **[Fix]** Fix possible deadlock when activity resumed during SDK background init.
+
 ___
 
 ## Version 2.5.1

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -494,13 +494,19 @@ public class Distribute extends AbstractAppCenterService {
             String distributionGroupId = SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
             mDistributeInfoTracker = new DistributeInfoTracker(distributionGroupId);
             mChannel.addListener(mDistributeInfoTracker);
-            HandlerUtils.runOnUiThread(new Runnable() {
 
-                @Override
-                public void run() {
-                    resumeDistributeWorkflow();
-                }
-            });
+            /* Resume distribute workflow only if there is foreground activity. */
+            if (mForegroundActivity != null) {
+                HandlerUtils.runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        resumeDistributeWorkflow();
+                    }
+                });
+            } else {
+                AppCenterLog.verbose(LOG_TAG, "Distribute workflow will be resumed on activity resume event.");
+            }
         } else {
 
             /* Clean all state on disabling, cancel everything. Keep only redirection parameters. */
@@ -623,6 +629,7 @@ public class Distribute extends AbstractAppCenterService {
      */
     @UiThread
     private synchronized void resumeDistributeWorkflow() {
+        AppCenterLog.verbose(LOG_TAG, "Resume distribute workflow...");
         if (mPackageInfo != null && mForegroundActivity != null && !mWorkflowCompleted && isInstanceEnabled()) {
 
             /* Don't go any further it this is a debug app. */
@@ -929,6 +936,8 @@ public class Distribute extends AbstractAppCenterService {
         } else if (requestId.equals(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID))) {
             AppCenterLog.debug(LOG_TAG, "Stored update setup failed parameter.");
             SharedPreferencesManager.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY, updateSetupFailed);
+        } else {
+            AppCenterLog.warn(LOG_TAG, "Ignoring redirection parameters as requestId is invalid.");
         }
     }
 
@@ -945,6 +954,8 @@ public class Distribute extends AbstractAppCenterService {
         } else if (requestId.equals(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID))) {
             AppCenterLog.debug(LOG_TAG, "Stored tester app update setup failed parameter.");
             SharedPreferencesManager.putString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY, testerAppUpdateSetupFailed);
+        } else {
+            AppCenterLog.warn(LOG_TAG, "Ignoring redirection parameters as requestId is invalid.");
         }
     }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -991,6 +991,12 @@ public class Distribute extends AbstractAppCenterService {
         });
     }
 
+    /**
+     * Request latest release details from server.
+     *
+     * @param url     url to latest release details endpoint.
+     * @param headers additional request headers.
+     */
     private synchronized void requestLatestReleaseDetails(String url, Map<String, String> headers) {
         HttpClient httpClient = createHttpClient(mContext);
         final Object releaseCallId = mCheckReleaseCallId = new Object();

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -216,6 +216,7 @@ class DistributeUtils {
         String requestId = UUID.randomUUID().toString();
 
         /* Store request id. */
+        AppCenterLog.debug(LOG_TAG, "Update setup requestId=" + requestId);
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId);
 
         /* Build URL. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -189,6 +189,7 @@ class DistributeUtils {
     /**
      * Check if latest downloaded release was installed (app was updated).
      *
+     * @param packageInfo               current package info.
      * @param lastDownloadedReleaseHash hash of the last downloaded release.
      * @return true if current release was updated.
      */
@@ -203,6 +204,7 @@ class DistributeUtils {
     /**
      * Check if the fetched release information should be installed.
      *
+     * @param packageInfo    current package info.
      * @param releaseDetails latest release on server.
      * @return true if latest release on server should be used.
      */
@@ -218,6 +220,17 @@ class DistributeUtils {
         return moreRecent;
     }
 
+    /**
+     * Get endpoint url to request latest release details.
+     *
+     * @param apiUrl              current API base URL.
+     * @param appSecret           application secret.
+     * @param packageInfo         current package info.
+     * @param distributionGroupId distribution group id.
+     * @param updateToken         token to secure API call.
+     * @return future with result being the endpoint url.
+     * @see AppCenterFuture
+     */
     static AppCenterFuture<String> getLatestReleaseDetailsUrlAsync(String apiUrl, final String appSecret, final PackageInfo packageInfo, final String distributionGroupId, String updateToken) {
         final DefaultAppCenterFuture<String> future = new DefaultAppCenterFuture<>();
         final String releaseHash = computeReleaseHash(packageInfo);
@@ -243,9 +256,11 @@ class DistributeUtils {
     /**
      * Get reporting parameters for updated release.
      *
+     * @param packageInfo         current package info.
      * @param isPublic            are the parameters for public group or not.
      *                            For public group we report install_id and release_id.
      *                            For private group we report distribution_group_id and release_id.
+     * @param installId           installation id.
      * @param distributionGroupId distribution group id.
      */
     @NonNull

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -32,7 +32,7 @@ import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.HashUtils;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
-import com.microsoft.appcenter.utils.async.AppCenterFuture;
+import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
 import com.microsoft.appcenter.utils.crypto.CryptoUtils;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
@@ -47,6 +47,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.powermock.reflect.Whitebox;
 
+import java.util.UUID;
+
 import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCES_NAME_MOBILE_CENTER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
@@ -56,7 +58,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
@@ -137,9 +138,6 @@ public class AbstractDistributeTest {
     SharedPreferences mMobileCenterPreferencesStorage;
 
     @Mock
-    private AppCenterFuture<Boolean> mBooleanAppCenterFuture;
-
-    @Mock
     DistributeInfoTracker mDistributeInfoTracker;
 
     @Mock
@@ -163,6 +161,8 @@ public class AbstractDistributeTest {
     @Mock
     NotificationManager mNotificationManager;
 
+    protected UUID mInstallId = UUID.randomUUID();
+
     @Before
     @SuppressLint("ShowToast")
     @SuppressWarnings("ResourceType")
@@ -170,8 +170,9 @@ public class AbstractDistributeTest {
         Distribute.unsetInstance();
         mockStatic(AppCenterLog.class);
         mockStatic(AppCenter.class);
-        when(AppCenter.isEnabled()).thenReturn(mBooleanAppCenterFuture);
-        when(mBooleanAppCenterFuture.get()).thenReturn(true);
+        DefaultAppCenterFuture<Boolean> isEnabled = new DefaultAppCenterFuture<>();
+        isEnabled.complete(true);
+        when(AppCenter.isEnabled()).thenReturn(isEnabled);
         doAnswer(new Answer<Void>() {
 
             @Override
@@ -180,6 +181,9 @@ public class AbstractDistributeTest {
                 return null;
             }
         }).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
+        DefaultAppCenterFuture<UUID> installId = new DefaultAppCenterFuture<>();
+        installId.complete(mInstallId);
+        when(AppCenter.getInstallId()).thenReturn(installId);
         whenNew(DistributeInfoTracker.class).withAnyArguments().thenReturn(mDistributeInfoTracker);
 
         /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -31,6 +31,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.HashUtils;
+import com.microsoft.appcenter.utils.IdHelper;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
 import com.microsoft.appcenter.utils.crypto.CryptoUtils;
@@ -77,6 +78,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
         DistributeUtils.class,
         HandlerUtils.class,
         HttpUtils.class,
+        IdHelper.class,
         InstallerUtils.class,
         NetworkStateHelper.class,
         ReleaseDetails.class,
@@ -181,9 +183,8 @@ public class AbstractDistributeTest {
                 return null;
             }
         }).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
-        DefaultAppCenterFuture<UUID> installId = new DefaultAppCenterFuture<>();
-        installId.complete(mInstallId);
-        when(AppCenter.getInstallId()).thenReturn(installId);
+        mockStatic(IdHelper.class);
+        when(IdHelper.getInstallId()).thenReturn(mInstallId);
         whenNew(DistributeInfoTracker.class).withAnyArguments().thenReturn(mDistributeInfoTracker);
 
         /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -1163,13 +1163,13 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
             public ServiceCall answer(InvocationOnMock invocation) {
 
                 /* Do the call so that ids do not match. */
-                Distribute.getInstance().getLatestReleaseDetails("mockGroup", "token");
+                Distribute.getInstance().requestLatestReleaseDetails("mockGroup", "token");
                 ((ServiceCallback) invocation.getArguments()[4]).onCallFailed(new HttpException(new HttpResponse(503)));
                 return mock(ServiceCall.class);
             }
         }).thenAnswer(new Answer<ServiceCall>() {
 
-            /* On second time we don't answer as it's callback from getLatestReleaseDetails above. */
+            /* On second time we don't answer as it's callback from requestLatestReleaseDetails above. */
             @Override
             public ServiceCall answer(InvocationOnMock invocation) {
                 return mock(ServiceCall.class);
@@ -1270,13 +1270,13 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
             public ServiceCall answer(InvocationOnMock invocation) {
 
                 /* Do the call so that id had changed. */
-                Distribute.getInstance().getLatestReleaseDetails("mockGroup", "token");
+                Distribute.getInstance().requestLatestReleaseDetails("mockGroup", "token");
                 ((ServiceCallback) invocation.getArguments()[4]).onCallSucceeded(new HttpResponse(200, "mock", null));
                 return mock(ServiceCall.class);
             }
         }).thenAnswer(new Answer<ServiceCall>() {
 
-            /* On second time we don't answer as it's callback from getLatestReleaseDetails above. */
+            /* On second time we don't answer as it's callback from requestLatestReleaseDetails above. */
             @Override
             public ServiceCall answer(InvocationOnMock invocation) {
                 return mock(ServiceCall.class);
@@ -1310,7 +1310,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
             }
         }).thenAnswer(new Answer<ServiceCall>() {
 
-            /* On second time we don't answer as it's callback from getLatestReleaseDetails above. */
+            /* On second time we don't answer as it's callback from requestLatestReleaseDetails above. */
             @Override
             public ServiceCall answer(InvocationOnMock invocation) {
                 return mock(ServiceCall.class);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -195,7 +195,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -559,7 +559,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
     }
@@ -606,7 +606,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* Start and resume: open tester app. */
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mActivity).startActivity(any(Intent.class));
+        verify(mContext).startActivity(any(Intent.class));
 
         /* Start and resume: open browser. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("true");
@@ -622,14 +622,14 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
 
         /* Start and resume: open browser. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn(null);
         Distribute.getInstance().onActivityPaused(mActivity);
         Distribute.getInstance().onActivityResumed(mActivity);
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
     }
 
     @Test
@@ -656,7 +656,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* Start and resume: open tester app. */
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mActivity).startActivity(any(Intent.class));
+        verify(mContext).startActivity(any(Intent.class));
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -707,7 +707,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         restartResumeLauncher(mActivity);
 
         /* Verify behavior not changed. */
-        verify(mActivity).startActivity(any(Intent.class));
+        verify(mContext).startActivity(any(Intent.class));
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_UPDATE_TOKEN, "some token");
         verifyStatic();
@@ -761,7 +761,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -769,7 +769,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.getInstance().onActivityPaused(mActivity);
         Distribute.getInstance().onActivityResumed(mActivity);
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -823,7 +823,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Verify behavior not changed. */
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_UPDATE_TOKEN, "some token");
         verifyStatic();
@@ -878,7 +878,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -886,7 +886,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.getInstance().onActivityPaused(mActivity);
         Distribute.getInstance().onActivityResumed(mActivity);
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -939,7 +939,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Verify behavior not changed. */
         verifyStatic();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_TOKEN);
         verifyStatic();
@@ -995,7 +995,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 
@@ -1055,7 +1055,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
-        BrowserUtils.openBrowser(url, mActivity);
+        BrowserUtils.openBrowser(url, mContext);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -102,7 +104,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         mockForCustomizationTest(false);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
         Distribute.unsetInstance();
         Distribute distribute = spy(Distribute.getInstance());
         doNothing().when(distribute).completeWorkflow();
@@ -154,7 +156,8 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         AppCenterLog.error(anyString(), anyString());
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
-        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
+        doReturn(DOWNLOAD_STATE_AVAILABLE).when(DistributeUtils.class);
+        DistributeUtils.getStoredDownloadState();
 
         /* Call handleUpdateAction. */
         distribute.handleUpdateAction(UpdateAction.POSTPONE);
@@ -176,7 +179,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         mockForCustomizationTest(false);
         DistributeListener listener = mock(DistributeListener.class);
         when(listener.onReleaseAvailable(eq(mActivity), any(ReleaseDetails.class))).thenReturn(false);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
         Distribute.unsetInstance();
         Distribute.setListener(listener);
         Distribute distribute = spy(Distribute.getInstance());
@@ -221,7 +224,8 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         AppCenterLog.error(anyString(), anyString());
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
-        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
+        doReturn(DOWNLOAD_STATE_AVAILABLE).when(DistributeUtils.class);
+        DistributeUtils.getStoredDownloadState();
 
         /* Call handleUpdateAction. */
         distribute.handleUpdateAction(UpdateAction.POSTPONE);
@@ -241,7 +245,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         ReleaseDetails details = mockForCustomizationTest(false);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
@@ -273,7 +277,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         when(mReleaseDownloader.isDownloading()).thenReturn(true);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
 
         /* Set Distribute listener so that Distribute doesn't use default update dialog. */
@@ -302,7 +306,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         when(mReleaseDownloader.isDownloading()).thenReturn(true);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
         when(DistributeUtils.getStoredDownloadState()).thenReturn(-1);
 
         /* Set Distribute listener so that Distribute doesn't use default update dialog. */
@@ -328,7 +332,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         ReleaseDetails details = mockForCustomizationTest(false);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
@@ -357,7 +361,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         ReleaseDetails details = mockForCustomizationTest(true);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
@@ -387,7 +391,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         ReleaseDetails details = mockForCustomizationTest(true);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
 
         /* Mock the download state to DOWNLOAD_STATE_AVAILABLE. */
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_AVAILABLE);
@@ -417,7 +421,7 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Mock. */
         mockForCustomizationTest(false);
-        mockStatic(DistributeUtils.class);
+        mockStatic(DistributeUtils.class, CALLS_REAL_METHODS);
 
         /* Set Distribute listener so that Distribute doesn't use default update dialog. */
         DistributeListener listener = mock(DistributeListener.class);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeHttpTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeHttpTest.java
@@ -59,7 +59,7 @@ public class DistributeHttpTest extends AbstractDistributeTest {
         /* Put api token to header. */
         headers.put(HEADER_API_TOKEN, apiToken);
 
-         /* Call onBeforeCalling with parameters. */
+        /* Call onBeforeCalling with parameters. */
         callTemplate.onBeforeCalling(url, headers);
 
         /* Verify url log. */
@@ -152,7 +152,7 @@ public class DistributeHttpTest extends AbstractDistributeTest {
                 return call;
             }
         });
-        Distribute.getInstance().getLatestReleaseDetails("mockGroup", apiToken);
+        Distribute.getInstance().requestLatestReleaseDetails("mockGroup", apiToken);
         return callTemplate.get();
     }
 }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
@@ -22,7 +22,7 @@ public class IdHelper {
      * @return the installID
      */
     @NonNull
-    public static UUID getInstallId() {
+    public synchronized static UUID getInstallId() {
         String installIdString = SharedPreferencesManager.getString(KEY_INSTALL_ID, "");
         UUID installId;
         try {


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Android SDK can deadlock with distribute while opening browser if the SDK background thread is initializing. The cause is code using `AppCenter.getInstallId.get()` inside `DistributeUtils` to open browser instead of using asynchronous version (`thenAccept`).

## Related PRs or issues

[AB#74885](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74885)
