### PR TITLE
Add unset network helper instance method

### DIFF
--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
@@ -100,6 +100,7 @@ public class AppCenterAndroidTest {
         final Semaphore lock = new Semaphore(0);
         final AtomicReference<Boolean> isEnabled = new AtomicReference<>();
         AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
+
             @Override
             public void accept(Boolean aBoolean) {
                 isEnabled.set(aBoolean);

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
@@ -116,6 +116,7 @@ public class AppCenterAndroidTest {
         final Semaphore lock1 = new Semaphore(0);
         final AtomicReference<Boolean> isEnabled1 = new AtomicReference<>();
         AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
+
             @Override
             public void accept(Boolean aBoolean) {
                 isEnabled1.set(aBoolean);

--- a/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
+++ b/sdk/appcenter/src/androidTest/java/com/microsoft/appcenter/AppCenterAndroidTest.java
@@ -21,6 +21,7 @@ import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -85,6 +86,45 @@ public class AppCenterAndroidTest {
         AppCenterLog.setLogLevel(Log.ASSERT);
         AppCenter.start(mApplication, UUID.randomUUID().toString());
         assertEquals(Log.WARN, AppCenter.getLogLevel());
+    }
+
+    @Test
+    public void enableDisable() {
+        String appSecret = UUID.randomUUID().toString();
+        AppCenter.start(mApplication, appSecret, DummyService.class);
+
+        /* Disable SDK. */
+        AppCenter.setEnabled(false);
+
+        /* Verify disabled. */
+        final Semaphore lock = new Semaphore(0);
+        final AtomicReference<Boolean> isEnabled = new AtomicReference<>();
+        AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
+            @Override
+            public void accept(Boolean aBoolean) {
+                isEnabled.set(aBoolean);
+                lock.release();
+            }
+        });
+        lock.acquireUninterruptibly();
+        Assert.assertFalse(isEnabled.get());
+
+        /* Restart SDK. */
+        AppCenter.unsetInstance();
+        AppCenter.start(mApplication, appSecret, DummyService.class);
+        final Semaphore lock1 = new Semaphore(0);
+        final AtomicReference<Boolean> isEnabled1 = new AtomicReference<>();
+        AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
+            @Override
+            public void accept(Boolean aBoolean) {
+                isEnabled1.set(aBoolean);
+                lock1.release();
+            }
+        });
+        lock1.acquireUninterruptibly();
+
+        /* Verify SDK is still disabled. */
+        Assert.assertFalse(isEnabled1.get());
     }
 
     private static class DummyService extends AbstractAppCenterService {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -232,6 +232,7 @@ public class AppCenter {
     @VisibleForTesting
     static synchronized void unsetInstance() {
         sInstance = null;
+        NetworkStateHelper.unsetInstance();
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -82,7 +82,6 @@ public class NetworkStateHelper implements Closeable {
         reopen();
     }
 
-    @VisibleForTesting
     public static synchronized void unsetInstance() {
         sSharedInstance = null;
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -82,6 +82,11 @@ public class NetworkStateHelper implements Closeable {
         reopen();
     }
 
+    @VisibleForTesting
+    public static synchronized void unsetInstance() {
+        sSharedInstance = null;
+    }
+
     /**
      * Get shared instance.
      *


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fixes restart SDK case for instrumentational testing or Xamarin.
Without that we would get:
```
java.lang.IllegalArgumentException: Receiver not registered: 
com.microsoft.appcenter.utils.NetworkStateHelper$ConnectivityReceiver@a502c740
```
or
```
 java.lang.IllegalArgumentException: NetworkCallback was already unregistered
```

## Related PRs or issues

[AB#74715](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/74715)
