### PR TITLE
Fix possible deadlock when activity resumed during SDK background init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
 * **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
+* **[Fix]** Fix a possible deadlock when activity resumes during background operation for `Distribute.isEnabled()` call.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * **[Fix]** Avoid opening browser to check for sign-in information after receiving an SSL error while checking for app updates (which often happens when using a public WIFI).
 * **[Fix]** When in-app update permissions become invalid and need to open browser again, updates are no longer postponed after sign-in (if user previously selected the action to postpone for a day).
-* **[Fix]** Fix a possible deadlock when activity resumes during background operation for `Distribute.isEnabled()` call.
+* **[Fix]** Fix a possible deadlock when activity resumes during background operation for some `Distribute` public APIs like `Distribute.isEnabled()`.
 
 ___
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -507,7 +507,7 @@ public class Distribute extends AbstractAppCenterService {
                     }
                 });
             } else {
-                AppCenterLog.verbose(LOG_TAG, "Distribute workflow will be resumed on activity resume event.");
+                AppCenterLog.debug(LOG_TAG, "Distribute workflow will be resumed on activity resume event.");
             }
         } else {
 
@@ -631,7 +631,7 @@ public class Distribute extends AbstractAppCenterService {
      */
     @UiThread
     private synchronized void resumeDistributeWorkflow() {
-        AppCenterLog.verbose(LOG_TAG, "Resume distribute workflow...");
+        AppCenterLog.debug(LOG_TAG, "Resume distribute workflow...");
         if (mPackageInfo != null && mForegroundActivity != null && !mWorkflowCompleted && isInstanceEnabled()) {
 
             /* Don't go any further it this is a debug app. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -34,7 +34,6 @@ import android.text.TextUtils;
 import android.widget.Toast;
 
 import com.microsoft.appcenter.AbstractAppCenterService;
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.Flags;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.distribute.channel.DistributeInfoTracker;
@@ -53,6 +52,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
+import com.microsoft.appcenter.utils.IdHelper;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
@@ -496,13 +496,19 @@ public class Distribute extends AbstractAppCenterService {
             String distributionGroupId = SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
             mDistributeInfoTracker = new DistributeInfoTracker(distributionGroupId);
             mChannel.addListener(mDistributeInfoTracker);
-            HandlerUtils.runOnUiThread(new Runnable() {
 
-                @Override
-                public void run() {
-                    resumeDistributeWorkflow();
-                }
-            });
+            /* Resume distribute workflow only if there is foreground activity. */
+            if (mForegroundActivity != null) {
+                HandlerUtils.runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        resumeDistributeWorkflow();
+                    }
+                });
+            } else {
+                AppCenterLog.verbose(LOG_TAG, "Distribute workflow will be resumed on activity resume event.");
+            }
         } else {
 
             /* Clean all state on disabling, cancel everything. Keep only redirection parameters. */
@@ -625,6 +631,7 @@ public class Distribute extends AbstractAppCenterService {
      */
     @UiThread
     private synchronized void resumeDistributeWorkflow() {
+        AppCenterLog.verbose(LOG_TAG, "Resume distribute workflow...");
         if (mPackageInfo != null && mForegroundActivity != null && !mWorkflowCompleted && isInstanceEnabled()) {
 
             /* Don't go any further it this is a debug app. */
@@ -925,6 +932,8 @@ public class Distribute extends AbstractAppCenterService {
         } else if (requestId.equals(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID))) {
             AppCenterLog.debug(LOG_TAG, "Stored update setup failed parameter.");
             SharedPreferencesManager.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY, updateSetupFailed);
+        } else {
+            AppCenterLog.warn(LOG_TAG, "Ignoring redirection parameters as requestId is invalid.");
         }
     }
 
@@ -941,6 +950,8 @@ public class Distribute extends AbstractAppCenterService {
         } else if (requestId.equals(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID))) {
             AppCenterLog.debug(LOG_TAG, "Stored tester app update setup failed parameter.");
             SharedPreferencesManager.putString(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY, testerAppUpdateSetupFailed);
+        } else {
+            AppCenterLog.warn(LOG_TAG, "Ignoring redirection parameters as requestId is invalid.");
         }
     }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1219,7 +1219,7 @@ public class Distribute extends AbstractAppCenterService {
             if (isCurrentReleaseWasUpdated(lastDownloadedReleaseHash)) {
                 AppCenterLog.debug(LOG_TAG, "Current release was updated but not reported yet, reporting..");
                 if (isPublic) {
-                    reportingParameters += "&" + PARAMETER_INSTALL_ID + "=" + AppCenter.getInstallId().get();
+                    reportingParameters += "&" + PARAMETER_INSTALL_ID + "=" + IdHelper.getInstallId();
                 } else {
                     reportingParameters += "&" + PARAMETER_DISTRIBUTION_GROUP_ID + "=" + distributionGroupId;
                 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -11,10 +11,10 @@ import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.HashUtils;
+import com.microsoft.appcenter.utils.IdHelper;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
@@ -138,7 +138,7 @@ class DistributeUtils {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + AppCenter.getInstallId().get().toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + IdHelper.getInstallId().toString();
         AppCenterLog.debug(LOG_TAG, "No token, need to open browser to url=" + url);
 
         /* Store request id. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -31,8 +31,8 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.HashUtils;
+import com.microsoft.appcenter.utils.IdHelper;
 import com.microsoft.appcenter.utils.NetworkStateHelper;
-import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.crypto.CryptoUtils;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
@@ -47,6 +47,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.powermock.reflect.Whitebox;
 
+import java.util.UUID;
+
 import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCES_NAME_MOBILE_CENTER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
@@ -56,7 +58,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
@@ -76,6 +77,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
         DistributeUtils.class,
         HandlerUtils.class,
         HttpUtils.class,
+        IdHelper.class,
         InstallerUtils.class,
         NetworkStateHelper.class,
         ReleaseDetails.class,
@@ -137,9 +139,6 @@ public class AbstractDistributeTest {
     SharedPreferences mMobileCenterPreferencesStorage;
 
     @Mock
-    private AppCenterFuture<Boolean> mBooleanAppCenterFuture;
-
-    @Mock
     DistributeInfoTracker mDistributeInfoTracker;
 
     @Mock
@@ -163,6 +162,8 @@ public class AbstractDistributeTest {
     @Mock
     NotificationManager mNotificationManager;
 
+    protected UUID mInstallId = UUID.randomUUID();
+
     @Before
     @SuppressLint("ShowToast")
     @SuppressWarnings("ResourceType")
@@ -170,8 +171,6 @@ public class AbstractDistributeTest {
         Distribute.unsetInstance();
         mockStatic(AppCenterLog.class);
         mockStatic(AppCenter.class);
-        when(AppCenter.isEnabled()).thenReturn(mBooleanAppCenterFuture);
-        when(mBooleanAppCenterFuture.get()).thenReturn(true);
         doAnswer(new Answer<Void>() {
 
             @Override
@@ -181,6 +180,8 @@ public class AbstractDistributeTest {
             }
         }).when(mAppCenterHandler).post(any(Runnable.class), any(Runnable.class));
         whenNew(DistributeInfoTracker.class).withAnyArguments().thenReturn(mDistributeInfoTracker);
+        mockStatic(IdHelper.class);
+        when(IdHelper.getInstallId()).thenReturn(mInstallId);
 
         /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */
         mockStatic(SharedPreferencesManager.class);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -17,7 +17,6 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.distribute.ingestion.models.DistributionStartSessionLog;
 import com.microsoft.appcenter.http.HttpClient;
@@ -27,7 +26,6 @@ import com.microsoft.appcenter.http.ServiceCall;
 import com.microsoft.appcenter.http.ServiceCallback;
 import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
-import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.context.SessionContext;
 import com.microsoft.appcenter.utils.crypto.CryptoUtils;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
@@ -36,7 +34,6 @@ import org.json.JSONException;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mock;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -100,9 +97,6 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 @PrepareForTest({ErrorDetails.class, DistributeUtils.class, SessionContext.class, UUID.class})
 public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
-    @Mock
-    private AppCenterFuture<UUID> mAppCenterFuture;
-
     /**
      * Shared code to mock a restart of an activity considered to be the launcher.
      */
@@ -112,11 +106,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         ComponentName componentName = mock(ComponentName.class);
         when(intent.resolveActivity(mPackageManager)).thenReturn(componentName);
         when(componentName.getClassName()).thenReturn(activity.getClass().getName());
-
-        /* Mock install id from AppCenter. */
-        UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
         Distribute.getInstance().onActivityPaused(activity);
         Distribute.getInstance().onActivityStopped(activity);
         Distribute.getInstance().onActivityDestroyed(activity);
@@ -184,15 +173,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.setInstallUrl("http://mock");
         Distribute.setApiUrl("https://mock2");
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -206,7 +190,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -546,15 +530,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Setup mock. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -568,7 +547,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -579,16 +558,11 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Setup mock. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenReturn(mock(PackageInfo.class));
         when(mContext.getPackageName()).thenReturn(DistributeUtils.TESTER_APP_PACKAGE_NAME);
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -602,7 +576,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Setup mock. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
@@ -614,10 +587,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         whenNew(Intent.class).withArguments(Intent.ACTION_VIEW, Uri.parse(url)).thenReturn(mock(Intent.class));
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenReturn(mock(PackageInfo.class));
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open tester app. */
         start();
@@ -637,7 +606,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         verifyStatic();
         BrowserUtils.openBrowser(url, mActivity);
 
@@ -758,15 +727,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Setup mock. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -780,7 +744,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -880,15 +844,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Setup mock. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -902,7 +861,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -1002,15 +961,10 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.setInstallUrl("http://mock");
         Distribute.setApiUrl("https://mock2");
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_REQUEST_ID)).thenReturn(requestId.toString());
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -1024,7 +978,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -1048,11 +1002,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* Mock package manager. */
         when(mPackageManager.getPackageInfo("com.contoso", 0)).thenThrow(new PackageManager.NameNotFoundException());
 
-        /* Mock install id from AppCenter. */
-        UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
-
         /* Start and resume: open browser. */
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
@@ -1073,13 +1022,8 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
         /* Start and resume: open browser. */
         UUID requestId = UUID.randomUUID();
-        UUID installId = UUID.randomUUID();
         mockStatic(UUID.class);
         when(UUID.randomUUID()).thenReturn(requestId);
-
-        /* Mock install id from AppCenter. */
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Start and resume: open browser. */
         start();
@@ -1093,7 +1037,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
         url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
-        url += "&" + PARAMETER_INSTALL_ID + "=" + installId.toString();
+        url += "&" + PARAMETER_INSTALL_ID + "=" + mInstallId.toString();
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         SharedPreferencesManager.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -1521,11 +1465,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn(TEST_HASH);
         when(SharedPreferencesManager.getInt(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID)).thenReturn(4);
 
-        /* Mock install id from AppCenter. */
-        final UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
-
         /* Mock httpClient. */
         HashMap<String, String> headers = new HashMap<>();
         headers.put(DistributeConstants.HEADER_API_TOKEN, "some token MC");
@@ -1550,11 +1489,6 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn(TEST_HASH);
         when(SharedPreferencesManager.getInt(PREFERENCE_KEY_DOWNLOADED_RELEASE_ID)).thenReturn(4);
 
-        /* Mock install id from AppCenter. */
-        final UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
-
         /* Mock httpClient. */
         HashMap<String, String> headers = new HashMap<>();
 
@@ -1565,7 +1499,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
 
             @Override
             public boolean matches(Object argument) {
-                return argument.toString().matches("^https://.*?/public/sdk/apps/a/distribution_groups/fake-distribution-id/releases/latest\\?release_hash=" + TEST_HASH + "&install_id=" + installId + "&downloaded_release_id=4$");
+                return argument.toString().matches("^https://.*?/public/sdk/apps/a/distribution_groups/fake-distribution-id/releases/latest\\?release_hash=" + TEST_HASH + "&install_id=" + mInstallId + "&downloaded_release_id=4$");
             }
         };
         verify(mHttpClient).callAsync(argThat(urlArg), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -15,7 +15,6 @@ import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.os.Build;
 
-import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.distribute.download.ReleaseDownloader;
 import com.microsoft.appcenter.distribute.download.ReleaseDownloaderFactory;
 import com.microsoft.appcenter.http.HttpClient;
@@ -26,21 +25,18 @@ import com.microsoft.appcenter.test.TestUtils;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.AppNameHelper;
 import com.microsoft.appcenter.utils.AsyncTaskUtils;
-import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.HashMap;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.microsoft.appcenter.distribute.DistributeConstants.DOWNLOAD_STATE_AVAILABLE;
@@ -76,9 +72,6 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @PrepareForTest(DistributeUtils.class)
 public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
-
-    @Mock
-    private AppCenterFuture<UUID> mAppCenterFuture;
 
     @Test
     public void moreRecentWithIncompatibleMinApiLevel() throws Exception {
@@ -813,11 +806,6 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         mockStatic(DistributeUtils.class);
         when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-hash");
 
-        /* Mock install id from AppCenter. */
-        UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
-
         /* Mock we already have token and no group. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
         when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class))).thenAnswer(new Answer<ServiceCall>() {
@@ -851,11 +839,6 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_DOWNLOADED_RELEASE_HASH)).thenReturn("fake-hash");
         mockStatic(DistributeUtils.class);
         when(DistributeUtils.computeReleaseHash(any(PackageInfo.class))).thenReturn("fake-old-hash");
-
-        /* Mock install id from AppCenter. */
-        UUID installId = UUID.randomUUID();
-        when(mAppCenterFuture.get()).thenReturn(installId);
-        when(AppCenter.getInstallId()).thenReturn(mAppCenterFuture);
 
         /* Mock we already have token and no group. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -197,6 +197,14 @@ public class DistributeTest extends AbstractDistributeTest {
     }
 
     @Test
+    public void resumeNullActivity() {
+        start();
+        Distribute.getInstance().onActivityResumed(null);
+
+        /* No exceptions. */
+    }
+
+    @Test
     public void setDownloadingReleaseDetailsEqualTest() {
 
         /* Mock release details and startFromBackground to apply it. */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
@@ -22,7 +22,7 @@ public class IdHelper {
      * @return the installID
      */
     @NonNull
-    public static UUID getInstallId() {
+    public static synchronized UUID getInstallId() {
         String installIdString = SharedPreferencesManager.getString(KEY_INSTALL_ID, "");
         UUID installId;
         try {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/IdHelper.java
@@ -22,7 +22,7 @@ public class IdHelper {
      * @return the installID
      */
     @NonNull
-    public static synchronized UUID getInstallId() {
+    public static UUID getInstallId() {
         String installIdString = SharedPreferencesManager.getString(KEY_INSTALL_ID, "");
         UUID installId;
         try {


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Android SDK can deadlock with distribute while opening browser if the SDK background thread is initializing. The cause is code using `AppCenter.getInstallId.get()` inside `DistributeUtils` to open browser instead of using asynchronous version (`thenAccept`).

## Related PRs or issues

#1345
[AB#74885](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74885)
