### PR TITLE
Add UI to switch between Public and Private update track

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -122,7 +122,9 @@ public class MainActivity extends AppCompatActivity {
              */
             int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1);
 
-            /* TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);' * when updating the demo during release process. */
+            /* TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);'
+             * when updating the demo during release process.
+             */
             try {
                 Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
                 setUpdateTrackMethod.invoke(null, savedTrack);

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -50,6 +50,7 @@ import com.microsoft.appcenter.sasquatch.listeners.SasquatchPushListener;
 import com.microsoft.appcenter.sasquatch.util.AttachmentsUtil;
 import com.microsoft.appcenter.utils.async.AppCenterConsumer;
 
+import java.lang.reflect.Method;
 import java.util.UUID;
 
 import static com.microsoft.appcenter.sasquatch.activities.ActivityConstants.ANALYTICS_TRANSMISSION_INTERVAL_KEY;
@@ -112,8 +113,25 @@ public class MainActivity extends AppCompatActivity {
     }
 
     static void startAppCenter(Application application, String startTypeString) {
-        if (MainActivity.sSharedPreferences.contains(ANALYTICS_TRANSMISSION_INTERVAL_KEY)) {
-            int latency = MainActivity.sSharedPreferences.getInt(ANALYTICS_TRANSMISSION_INTERVAL_KEY, DEFAULT_TRANSMISSION_INTERVAL_IN_SECONDS);
+        if (sSharedPreferences.getBoolean(application.getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
+
+            /*
+             * TODO Replace the next line with:
+             *  'int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
+             *  when updating the demo during release process.
+             */
+            int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_value), 1);
+
+            /* TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);' * when updating the demo during release process. */
+            try {
+                Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
+                setUpdateTrackMethod.invoke(null, savedTrack);
+            } catch (Exception e) {
+                Toast.makeText(application, "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+            }
+        }
+        if (sSharedPreferences.contains(ANALYTICS_TRANSMISSION_INTERVAL_KEY)) {
+            int latency = sSharedPreferences.getInt(ANALYTICS_TRANSMISSION_INTERVAL_KEY, DEFAULT_TRANSMISSION_INTERVAL_IN_SECONDS);
             try {
                 boolean result = Analytics.setTransmissionInterval(latency);
                 if (result) {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -120,14 +120,14 @@ public class MainActivity extends AppCompatActivity {
              *  'int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
              *  when updating the demo during release process.
              */
-            int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_value), 1);
+            int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1);
 
             /* TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);' * when updating the demo during release process. */
             try {
                 Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
                 setUpdateTrackMethod.invoke(null, savedTrack);
             } catch (Exception e) {
-                Toast.makeText(application, "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                Toast.makeText(application, "No Update Track API in this build", Toast.LENGTH_SHORT).show();
             }
         }
         if (sSharedPreferences.contains(ANALYTICS_TRANSMISSION_INTERVAL_KEY)) {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -37,6 +37,7 @@ import com.microsoft.appcenter.auth.Auth;
 import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.data.Data;
 import com.microsoft.appcenter.distribute.Distribute;
+import com.microsoft.appcenter.distribute.UpdateTrack;
 import com.microsoft.appcenter.push.Push;
 import com.microsoft.appcenter.sasquatch.R;
 import com.microsoft.appcenter.sasquatch.activities.MainActivity.StartType;
@@ -309,6 +310,18 @@ public class SettingsActivity extends AppCompatActivity {
                 public void setEnabled(boolean enabled) {
                     MainActivity.sSharedPreferences.edit().putBoolean(getString(R.string.appcenter_distribute_debug_state_key), enabled).apply();
                     Distribute.setEnabledForDebuggableBuild(enabled);
+                }
+            });
+            initCheckBoxSetting(R.string.appcenter_distribute_track_state_key, R.string.appcenter_distribute_track_public_enabled, R.string.appcenter_distribute_track_private_enabled, new HasEnabled() {
+
+                @Override
+                public boolean isEnabled() {
+                    return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
+                }
+
+                @Override
+                public void setEnabled(boolean enabled) {
+                    Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
                 }
             });
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -315,6 +315,7 @@ public class SettingsActivity extends AppCompatActivity {
 
                 @Override
                 public boolean isEnabled() {
+
                     /*
                      * TODO: Replace the whole block with
                      * return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
@@ -332,6 +333,7 @@ public class SettingsActivity extends AppCompatActivity {
 
                 @Override
                 public void setEnabled(boolean enabled) {
+
                     /*
                      * TODO: Replace the whole block with
                      * Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -37,7 +37,6 @@ import com.microsoft.appcenter.auth.Auth;
 import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.data.Data;
 import com.microsoft.appcenter.distribute.Distribute;
-import com.microsoft.appcenter.distribute.UpdateTrack;
 import com.microsoft.appcenter.push.Push;
 import com.microsoft.appcenter.sasquatch.R;
 import com.microsoft.appcenter.sasquatch.activities.MainActivity.StartType;
@@ -316,12 +315,34 @@ public class SettingsActivity extends AppCompatActivity {
 
                 @Override
                 public boolean isEnabled() {
-                    return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
+                    /*
+                     * TODO: Replace the whole block with
+                     * return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
+                     * when updating the demo during release process.
+                     */
+                    try {
+                        Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
+                        int updateTrack = (int) getUpdateTrackMethod.invoke(null);
+                        return updateTrack == 1;
+                    } catch (Exception e) {
+                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                    }
+                    return false;
                 }
 
                 @Override
                 public void setEnabled(boolean enabled) {
-                    Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
+                    /*
+                     * TODO: Replace the whole block with
+                     * Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
+                     * when updating the demo during release process.
+                     */
+                    try {
+                        Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
+                        setUpdateTrackMethod.invoke(null, enabled ? 1 : 2);
+                    } catch (Exception e) {
+                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                    }
                 }
             });
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -311,16 +311,27 @@ public class SettingsActivity extends AppCompatActivity {
                     Distribute.setEnabledForDebuggableBuild(enabled);
                 }
             });
-            initCheckBoxSetting(R.string.appcenter_distribute_update_track_before_start_key, R.string.appcenter_distribute_update_track_before_start_enabled, R.string.appcenter_distribute_update_track_before_start_disabled, new HasEnabled() {
-
+            final IsEnabled updateTrackBeforeStartIsEnabled = new IsEnabled() {
                 @Override
                 public boolean isEnabled() {
                     return MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false);
                 }
 
                 @Override
-                public void setEnabled(boolean enabled) {
-                    MainActivity.sSharedPreferences.edit().putBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), enabled).apply();
+                public String getSummary() {
+                    return getString(this.isEnabled() ? R.string.appcenter_distribute_update_track_before_start_enabled : R.string.appcenter_distribute_update_track_before_start_disabled);
+                }
+            };
+            initChangeableSetting(R.string.appcenter_distribute_update_track_before_start_key, updateTrackBeforeStartIsEnabled.getSummary(), new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    if (newValue == null) {
+                        return false;
+                    }
+                    String[] whenToUpdateTrackEntries = getResources().getStringArray(R.array.appcenter_distribute_when_to_update_track_entries);
+                    boolean updateTrackBeforeStartNewValue = newValue.toString().equals(whenToUpdateTrackEntries[1]);
+                    MainActivity.sSharedPreferences.edit().putBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), updateTrackBeforeStartNewValue).apply();
 
                     /*
                      * TODO when updating the demo during release process:
@@ -332,12 +343,14 @@ public class SettingsActivity extends AppCompatActivity {
                         Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
                         currentTrack = (int) getUpdateTrackMethod.invoke(null);
                     } catch (Exception e) {
-                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
                     }
-                    MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), currentTrack).apply();
+                    MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), currentTrack).apply();
+                    preference.setSummary(updateTrackBeforeStartIsEnabled.getSummary());
+                    return true;
                 }
             });
-            initCheckBoxSetting(R.string.appcenter_distribute_track_state_key, R.string.appcenter_distribute_track_public_enabled, R.string.appcenter_distribute_track_private_enabled, new HasEnabled() {
+            final IsEnabled updateTrackIsEnabled = new IsEnabled() {
 
                 @Override
                 public boolean isEnabled() {
@@ -347,7 +360,7 @@ public class SettingsActivity extends AppCompatActivity {
                          * TODO Replace the next line with:
                          *  'return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC) == UpdateTrack.PUBLIC;'
                          */
-                        return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), 1) == 1;
+                        return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1) == 1;
                     }
 
                     /*
@@ -360,35 +373,57 @@ public class SettingsActivity extends AppCompatActivity {
                         int updateTrack = (int) getUpdateTrackMethod.invoke(null);
                         return updateTrack == 1;
                     } catch (Exception e) {
-                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
                     }
                     return false;
                 }
 
                 @Override
-                public void setEnabled(boolean enabled) {
+                public String getSummary() {
+                    return getString(this.isEnabled() ? R.string.appcenter_distribute_track_public_enabled : R.string.appcenter_distribute_track_private_enabled);
+                }
+            };
+            initChangeableSetting(R.string.appcenter_distribute_track_state_key, updateTrackIsEnabled.getSummary(), new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    if (newValue == null) {
+                        return false;
+                    }
+                    String[] updateTrackEntries = getResources().getStringArray(R.array.appcenter_distribute_update_track_entries);
+
+                    /*
+                     * TODO Replace the next line with:
+                     *  'int updateTrackNewValue = newValue.toString().equals(updateTrackEntries[0]) ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE;'
+                     *  when updating the demo during release process.
+                     */
+                    int updateTrackNewValue = newValue.toString().equals(updateTrackEntries[0]) ? 1 : 2;
+
                     if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
 
                         /*
                          * TODO Replace the next line with:
-                         *  'MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE).apply();'
+                         *  'MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), updateTrackNewValue).apply();'
                          *  when updating the demo during release process.
                          */
-                        MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), enabled ? 1 : 2).apply();
-                        return;
+                        MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), updateTrackNewValue).apply();
+                        preference.setSummary(updateTrackIsEnabled.getSummary());
+                        return true;
                     }
 
                     /*
-                     * TODO: Replace the whole block with
-                     *  Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
+                     * TODO: Replace the try/catch block with
+                     *  Distribute.setUpdateTrack(updateTrackNewValue);
                      *  when updating the demo during release process.
                      */
                     try {
                         Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
-                        setUpdateTrackMethod.invoke(null, enabled ? 1 : 2);
+                        setUpdateTrackMethod.invoke(null, updateTrackNewValue);
                     } catch (Exception e) {
-                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
                     }
+                    preference.setSummary(updateTrackIsEnabled.getSummary());
+                    return true;
                 }
             });
 
@@ -1000,6 +1035,14 @@ public class SettingsActivity extends AppCompatActivity {
             boolean isEnabled();
 
             void setEnabled(boolean enabled);
+        }
+
+        private interface IsEnabled {
+
+            boolean isEnabled();
+
+            String getSummary();
+
         }
 
         private interface EditTextListener {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -312,6 +312,7 @@ public class SettingsActivity extends AppCompatActivity {
                 }
             });
             final IsEnabled updateTrackBeforeStartIsEnabled = new IsEnabled() {
+
                 @Override
                 public boolean isEnabled() {
                     return MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false);
@@ -1042,7 +1043,6 @@ public class SettingsActivity extends AppCompatActivity {
             boolean isEnabled();
 
             String getSummary();
-
         }
 
         private interface EditTextListener {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -354,12 +354,14 @@ public class SettingsActivity extends AppCompatActivity {
                 public String getSummary() {
                     UpdateTrackEnum updateTrackEnum = null;
                     if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
+
                         /*
                          * TODO Replace the next line with:
                          *  'return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
                          */
                         updateTrackEnum = UpdateTrackEnum.init(MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1));
                     } else {
+
                         /*
                          * TODO: Replace the whole block with
                          *  'updateTrack = Distribute.getUpdateTrack();'
@@ -517,7 +519,7 @@ public class SettingsActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    @SuppressWarnings("unchecked")
+                    @SuppressWarnings({"unchecked", "ConstantConditions"})
                     public boolean isEnabled() {
                         try {
                             return sRumStarted && ((AppCenterFuture<Boolean>) isEnabled.invoke(null)).get();

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -311,15 +311,49 @@ public class SettingsActivity extends AppCompatActivity {
                     Distribute.setEnabledForDebuggableBuild(enabled);
                 }
             });
+            initCheckBoxSetting(R.string.appcenter_distribute_update_track_before_start_key, R.string.appcenter_distribute_update_track_before_start_enabled, R.string.appcenter_distribute_update_track_before_start_disabled, new HasEnabled() {
+
+                @Override
+                public boolean isEnabled() {
+                    return MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false);
+                }
+
+                @Override
+                public void setEnabled(boolean enabled) {
+                    MainActivity.sSharedPreferences.edit().putBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), enabled).apply();
+
+                    /*
+                     * TODO when updating the demo during release process:
+                     *  1) Replace the next line with 'int currentTrack = Distribute.getUpdateTrack();'
+                     *  2) remove try/catch block
+                     */
+                    int currentTrack = 1;
+                    try {
+                        Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
+                        currentTrack = (int) getUpdateTrackMethod.invoke(null);
+                    } catch (Exception e) {
+                        Toast.makeText(getActivity(), "No Update Track api in this build", Toast.LENGTH_SHORT).show();
+                    }
+                    MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), currentTrack).apply();
+                }
+            });
             initCheckBoxSetting(R.string.appcenter_distribute_track_state_key, R.string.appcenter_distribute_track_public_enabled, R.string.appcenter_distribute_track_private_enabled, new HasEnabled() {
 
                 @Override
                 public boolean isEnabled() {
+                    if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
+
+                        /*
+                         * TODO Replace the next line with:
+                         *  'return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC) == UpdateTrack.PUBLIC;'
+                         */
+                        return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), 1) == 1;
+                    }
 
                     /*
                      * TODO: Replace the whole block with
-                     * return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
-                     * when updating the demo during release process.
+                     *  return Distribute.getUpdateTrack() == UpdateTrack.PUBLIC;
+                     *  when updating the demo during release process.
                      */
                     try {
                         Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
@@ -333,11 +367,21 @@ public class SettingsActivity extends AppCompatActivity {
 
                 @Override
                 public void setEnabled(boolean enabled) {
+                    if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
+
+                        /*
+                         * TODO Replace the next line with:
+                         *  'MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE).apply();'
+                         *  when updating the demo during release process.
+                         */
+                        MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), enabled ? 1 : 2).apply();
+                        return;
+                    }
 
                     /*
                      * TODO: Replace the whole block with
-                     * Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
-                     * when updating the demo during release process.
+                     *  Distribute.setUpdateTrack(enabled ? UpdateTrack.PUBLIC : UpdateTrack.PRIVATE);
+                     *  when updating the demo during release process.
                      */
                     try {
                         Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);

--- a/apps/sasquatch/src/main/res/values/array.xml
+++ b/apps/sasquatch/src/main/res/values/array.xml
@@ -18,11 +18,11 @@
         <item>Custom</item>
     </string-array>
     <string-array name="appcenter_distribute_when_to_update_track_entries" tools:ignore="MissingTranslation">
-        <item>NOW</item>
-        <item>BEFORE_NEXT_START</item>
+        <item>Now</item>
+        <item>Before next start</item>
     </string-array>
     <string-array name="appcenter_distribute_update_track_entries" tools:ignore="MissingTranslation">
-        <item>PUBLIC</item>
-        <item>PRIVATE</item>
+        <item>Public</item>
+        <item>Private</item>
     </string-array>
 </resources>

--- a/apps/sasquatch/src/main/res/values/array.xml
+++ b/apps/sasquatch/src/main/res/values/array.xml
@@ -17,4 +17,12 @@
         <item>AAD</item>
         <item>Custom</item>
     </string-array>
+    <string-array name="appcenter_distribute_when_to_update_track_entries" tools:ignore="MissingTranslation">
+        <item>NOW</item>
+        <item>BEFORE_NEXT_START</item>
+    </string-array>
+    <string-array name="appcenter_distribute_update_track_entries" tools:ignore="MissingTranslation">
+        <item>PUBLIC</item>
+        <item>PRIVATE</item>
+    </string-array>
 </resources>

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -67,6 +67,10 @@
     <string name="appcenter_distribute_debug_state_title" tools:ignore="MissingTranslation">Distribute in debug state</string>
     <string name="appcenter_distribute_debug_summary_enabled" tools:ignore="MissingTranslation">Distribute in debug is enabled</string>
     <string name="appcenter_distribute_debug_summary_disabled" tools:ignore="MissingTranslation">Distribute in debug is disabled</string>
+    <string name="appcenter_distribute_track_state_key" tools:ignore="MissingTranslation">appcenter_distribute_track_state_key</string>
+    <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update source</string>
+    <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
+    <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
 
     <string name="push_key" tools:ignore="MissingTranslation">appcenter_push</string>
     <string name="push_title" tools:ignore="MissingTranslation">Push</string>

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -68,7 +68,7 @@
     <string name="appcenter_distribute_debug_summary_enabled" tools:ignore="MissingTranslation">Distribute in debug is enabled</string>
     <string name="appcenter_distribute_debug_summary_disabled" tools:ignore="MissingTranslation">Distribute in debug is disabled</string>
     <string name="appcenter_distribute_track_state_key" tools:ignore="MissingTranslation">appcenter_distribute_track_state_key</string>
-    <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update source</string>
+    <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update track</string>
     <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
 

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -63,16 +63,19 @@
     <string name="appcenter_distribute_state_title" tools:ignore="MissingTranslation">Distribute state</string>
     <string name="appcenter_distribute_state_summary_enabled" tools:ignore="MissingTranslation">Distribute is enabled</string>
     <string name="appcenter_distribute_state_summary_disabled" tools:ignore="MissingTranslation">Distribute is disabled</string>
+
     <string name="appcenter_distribute_debug_state_key" tools:ignore="MissingTranslation">appcenter_distribute_debug_state_key</string>
     <string name="appcenter_distribute_debug_state_title" tools:ignore="MissingTranslation">Distribute in debug state</string>
     <string name="appcenter_distribute_debug_summary_enabled" tools:ignore="MissingTranslation">Distribute in debug is enabled</string>
     <string name="appcenter_distribute_debug_summary_disabled" tools:ignore="MissingTranslation">Distribute in debug is disabled</string>
+
     <string name="appcenter_distribute_track_state_key" tools:ignore="MissingTranslation">appcenter_distribute_track_state_key</string>
     <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update track</string>
     <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
+
     <string name="appcenter_distribute_update_track_before_start_key" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_key</string>
-    <string name="appcenter_distribute_update_track_before_start_value" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_value</string>
+    <string name="appcenter_distribute_update_track_before_start_chosen_track" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_chosen_track</string>
     <string name="appcenter_distribute_update_track_before_start_title" tools:ignore="MissingTranslation">When to update track</string>
     <string name="appcenter_distribute_update_track_before_start_enabled" tools:ignore="MissingTranslation">Will update track before next start</string>
     <string name="appcenter_distribute_update_track_before_start_disabled" tools:ignore="MissingTranslation">Update track now</string>

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -73,7 +73,7 @@
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
     <string name="appcenter_distribute_update_track_before_start_key" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_key</string>
     <string name="appcenter_distribute_update_track_before_start_value" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_value</string>
-    <string name="appcenter_distribute_update_track_before_start_title" tools:ignore="MissingTranslation">Update track before start</string>
+    <string name="appcenter_distribute_update_track_before_start_title" tools:ignore="MissingTranslation">When to update track</string>
     <string name="appcenter_distribute_update_track_before_start_enabled" tools:ignore="MissingTranslation">Will update track before next start</string>
     <string name="appcenter_distribute_update_track_before_start_disabled" tools:ignore="MissingTranslation">Update track now</string>
 

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -71,6 +71,11 @@
     <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update track</string>
     <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
+    <string name="appcenter_distribute_update_track_before_start_key" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_key</string>
+    <string name="appcenter_distribute_update_track_before_start_value" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_value</string>
+    <string name="appcenter_distribute_update_track_before_start_title" tools:ignore="MissingTranslation">Update track before start</string>
+    <string name="appcenter_distribute_update_track_before_start_enabled" tools:ignore="MissingTranslation">Will update track before next start</string>
+    <string name="appcenter_distribute_update_track_before_start_disabled" tools:ignore="MissingTranslation">Update track now</string>
 
     <string name="push_key" tools:ignore="MissingTranslation">appcenter_push</string>
     <string name="push_title" tools:ignore="MissingTranslation">Push</string>

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -63,6 +63,9 @@
         <CheckBoxPreference
             android:key="@string/appcenter_distribute_debug_state_key"
             android:title="@string/appcenter_distribute_debug_state_title" />
+        <CheckBoxPreference
+            android:key="@string/appcenter_distribute_track_state_key"
+            android:title="@string/appcenter_distribute_track_state_title" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -64,6 +64,9 @@
             android:key="@string/appcenter_distribute_debug_state_key"
             android:title="@string/appcenter_distribute_debug_state_title" />
         <CheckBoxPreference
+            android:key="@string/appcenter_distribute_update_track_before_start_key"
+            android:title="@string/appcenter_distribute_update_track_before_start_title" />
+        <CheckBoxPreference
             android:key="@string/appcenter_distribute_track_state_key"
             android:title="@string/appcenter_distribute_track_state_title" />
     </PreferenceCategory>

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -63,11 +63,15 @@
         <CheckBoxPreference
             android:key="@string/appcenter_distribute_debug_state_key"
             android:title="@string/appcenter_distribute_debug_state_title" />
-        <CheckBoxPreference
+        <ListPreference
             android:key="@string/appcenter_distribute_update_track_before_start_key"
+            android:entries="@array/appcenter_distribute_when_to_update_track_entries"
+            android:entryValues="@array/appcenter_distribute_when_to_update_track_entries"
             android:title="@string/appcenter_distribute_update_track_before_start_title" />
-        <CheckBoxPreference
+        <ListPreference
             android:key="@string/appcenter_distribute_track_state_key"
+            android:entries="@array/appcenter_distribute_update_track_entries"
+            android:entryValues="@array/appcenter_distribute_update_track_entries"
             android:title="@string/appcenter_distribute_track_state_title" />
     </PreferenceCategory>
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Add UI to switch between Public and Private update track.

## Related PRs or issues

[AB#75360](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/75360)

<img width="268" alt="Screenshot 2020-01-27 at 19 39 28" src="https://user-images.githubusercontent.com/10907757/73188752-c9573400-413c-11ea-882f-5feff26fd28f.png">
<img width="269" alt="Screenshot 2020-01-27 at 19 39 09" src="https://user-images.githubusercontent.com/10907757/73188756-c9efca80-413c-11ea-9dbd-8bbc8aa18d6c.png">
<img width="262" alt="Screenshot 2020-01-27 at 19 35 33" src="https://user-images.githubusercontent.com/10907757/73188761-cb20f780-413c-11ea-92e6-a3e63435306a.png">
