### PR TITLE
Feature/in app update track before start only

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/MainActivity.java
@@ -113,19 +113,16 @@ public class MainActivity extends AppCompatActivity {
     }
 
     static void startAppCenter(Application application, String startTypeString) {
-        if (sSharedPreferences.getBoolean(application.getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
 
-            /*
-             * TODO Replace the next line with:
-             *  'int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
-             *  when updating the demo during release process.
-             */
-            int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1);
-
-            /* TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);'
-             * when updating the demo during release process.
-             */
+        /* Set the track explicitly only if we set it in settings, to test the initial public by default at first launch. */
+        int savedTrack = sSharedPreferences.getInt(application.getString(R.string.appcenter_distribute_track_state_key), 0);
+        if (savedTrack != 0) {
             try {
+
+                /*
+                 * TODO replace the next line with 'Distribute.setUpdateTrack(savedTrack);'
+                 * when updating the demo during release process.
+                 */
                 Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
                 setUpdateTrackMethod.invoke(null, savedTrack);
             } catch (Exception e) {

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -348,6 +348,7 @@ public class SettingsActivity extends AppCompatActivity {
                      */
                     MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_track_state_key), updateTrackNewValue).apply();
                     preference.setSummary(updateTrackHasSummary.getSummary());
+                    Toast.makeText(getActivity(), R.string.appcenter_distribute_track_state_updated, Toast.LENGTH_SHORT).show();
                     return true;
                 }
             });

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -312,69 +312,16 @@ public class SettingsActivity extends AppCompatActivity {
                     Distribute.setEnabledForDebuggableBuild(enabled);
                 }
             });
-            final HasSummary updateTrackBeforeStartHasSummary = new HasSummary() {
-
-                @Override
-                public String getSummary() {
-                    boolean updateTrackBeforeStart = MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false);
-                    return getString(updateTrackBeforeStart ? R.string.appcenter_distribute_update_track_before_start_enabled : R.string.appcenter_distribute_update_track_before_start_disabled);
-                }
-            };
-            initChangeableSetting(R.string.appcenter_distribute_update_track_before_start_key, updateTrackBeforeStartHasSummary.getSummary(), new Preference.OnPreferenceChangeListener() {
-
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    if (newValue == null) {
-                        return false;
-                    }
-                    String[] whenToUpdateTrackEntries = getResources().getStringArray(R.array.appcenter_distribute_when_to_update_track_entries);
-                    boolean updateTrackBeforeStartNewValue = newValue.toString().equals(whenToUpdateTrackEntries[1]);
-                    MainActivity.sSharedPreferences.edit().putBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), updateTrackBeforeStartNewValue).apply();
-
-                    /*
-                     * TODO when updating the demo during release process:
-                     *  1) Replace the next line with 'int currentTrack = Distribute.getUpdateTrack();'
-                     *  2) remove try/catch block
-                     */
-                    int currentTrack = 1;
-                    try {
-                        Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
-                        currentTrack = (int) getUpdateTrackMethod.invoke(null);
-                    } catch (Exception e) {
-                        Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
-                    }
-                    MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), currentTrack).apply();
-                    preference.setSummary(updateTrackBeforeStartHasSummary.getSummary());
-                    return true;
-                }
-            });
             final HasSummary updateTrackHasSummary = new HasSummary() {
 
                 @Override
                 public String getSummary() {
-                    UpdateTrackEnum updateTrackEnum = null;
-                    if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
 
-                        /*
-                         * TODO Replace the next line with:
-                         *  'return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
-                         */
-                        updateTrackEnum = UpdateTrackEnum.init(MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), 1));
-                    } else {
-
-                        /*
-                         * TODO: Replace the whole block with
-                         *  'updateTrack = Distribute.getUpdateTrack();'
-                         *  when updating the demo during release process.
-                         */
-                        try {
-                            Method getUpdateTrackMethod = Distribute.class.getMethod("getUpdateTrack");
-                            int updateTrack = (int) getUpdateTrackMethod.invoke(null);
-                            updateTrackEnum = UpdateTrackEnum.init(updateTrack);
-                        } catch (Exception e) {
-                            Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
-                        }
-                    }
+                    /*
+                     * TODO Replace the next line with:
+                     *  'return MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_update_track_before_start_value), UpdateTrack.PUBLIC);'
+                     */
+                    UpdateTrackEnum updateTrackEnum = UpdateTrackEnum.init(MainActivity.sSharedPreferences.getInt(getString(R.string.appcenter_distribute_track_state_key), 1));
                     return updateTrackEnum != null ? getString(updateTrackEnum.summaryRes) : "Couldn't parse update track";
                 }
             };
@@ -394,29 +341,12 @@ public class SettingsActivity extends AppCompatActivity {
                      */
                     int updateTrackNewValue = newValue.toString().equals(updateTrackEntries[0]) ? 1 : 2;
 
-                    if (MainActivity.sSharedPreferences.getBoolean(getString(R.string.appcenter_distribute_update_track_before_start_key), false)) {
-
-                        /*
-                         * TODO Replace the next line with:
-                         *  'MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), updateTrackNewValue).apply();'
-                         *  when updating the demo during release process.
-                         */
-                        MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_chosen_track), updateTrackNewValue).apply();
-                        preference.setSummary(updateTrackHasSummary.getSummary());
-                        return true;
-                    }
-
                     /*
-                     * TODO: Replace the try/catch block with
-                     *  Distribute.setUpdateTrack(updateTrackNewValue);
+                     * TODO Replace the next line with:
+                     *  'MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_update_track_before_start_value), updateTrackNewValue).apply();'
                      *  when updating the demo during release process.
                      */
-                    try {
-                        Method setUpdateTrackMethod = Distribute.class.getMethod("setUpdateTrack", int.class);
-                        setUpdateTrackMethod.invoke(null, updateTrackNewValue);
-                    } catch (Exception e) {
-                        Toast.makeText(getActivity(), "No Update Track API in this build", Toast.LENGTH_SHORT).show();
-                    }
+                    MainActivity.sSharedPreferences.edit().putInt(getString(R.string.appcenter_distribute_track_state_key), updateTrackNewValue).apply();
                     preference.setSummary(updateTrackHasSummary.getSummary());
                     return true;
                 }

--- a/apps/sasquatch/src/main/res/values/array.xml
+++ b/apps/sasquatch/src/main/res/values/array.xml
@@ -17,10 +17,6 @@
         <item>AAD</item>
         <item>Custom</item>
     </string-array>
-    <string-array name="appcenter_distribute_when_to_update_track_entries" tools:ignore="MissingTranslation">
-        <item>Now</item>
-        <item>Before next start</item>
-    </string-array>
     <string-array name="appcenter_distribute_update_track_entries" tools:ignore="MissingTranslation">
         <item>Public</item>
         <item>Private</item>

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -74,12 +74,6 @@
     <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
 
-    <string name="appcenter_distribute_update_track_before_start_key" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_key</string>
-    <string name="appcenter_distribute_update_track_before_start_chosen_track" tools:ignore="MissingTranslation">appcenter_distribute_update_track_before_start_chosen_track</string>
-    <string name="appcenter_distribute_update_track_before_start_title" tools:ignore="MissingTranslation">When to update track</string>
-    <string name="appcenter_distribute_update_track_before_start_enabled" tools:ignore="MissingTranslation">Will update track before next start</string>
-    <string name="appcenter_distribute_update_track_before_start_disabled" tools:ignore="MissingTranslation">Update track now</string>
-
     <string name="push_key" tools:ignore="MissingTranslation">appcenter_push</string>
     <string name="push_title" tools:ignore="MissingTranslation">Push</string>
 

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -73,6 +73,7 @@
     <string name="appcenter_distribute_track_state_title" tools:ignore="MissingTranslation">Update track</string>
     <string name="appcenter_distribute_track_public_enabled" tools:ignore="MissingTranslation">Distribute uses public track</string>
     <string name="appcenter_distribute_track_private_enabled" tools:ignore="MissingTranslation">Distribute uses private track</string>
+    <string name="appcenter_distribute_track_state_updated" tools:ignore="MissingTranslation">Update track will be changed only when the application is restarted.</string>
 
     <string name="push_key" tools:ignore="MissingTranslation">appcenter_push</string>
     <string name="push_title" tools:ignore="MissingTranslation">Push</string>

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -64,11 +64,6 @@
             android:key="@string/appcenter_distribute_debug_state_key"
             android:title="@string/appcenter_distribute_debug_state_title" />
         <ListPreference
-            android:key="@string/appcenter_distribute_update_track_before_start_key"
-            android:entries="@array/appcenter_distribute_when_to_update_track_entries"
-            android:entryValues="@array/appcenter_distribute_when_to_update_track_entries"
-            android:title="@string/appcenter_distribute_update_track_before_start_title" />
-        <ListPreference
             android:key="@string/appcenter_distribute_track_state_key"
             android:entries="@array/appcenter_distribute_update_track_entries"
             android:entryValues="@array/appcenter_distribute_update_track_entries"

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -354,6 +354,7 @@ public class Distribute extends AbstractAppCenterService {
      * Get the current update track (public vs private).
      */
     // TODO Remove suppress when app uses it without reflection on jCenter
+    @SuppressWarnings("WeakerAccess")
     public static int getUpdateTrack() {
         return getInstance().getInstanceUpdateTrack();
     }
@@ -363,7 +364,6 @@ public class Distribute extends AbstractAppCenterService {
      *
      * @param updateTrack update track.
      */
-    // TODO Remove suppress when app uses it without reflection on jCenter
     public static void setUpdateTrack(@UpdateTrack int updateTrack) {
         getInstance().setInstanceUpdateTrack(updateTrack);
     }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -628,7 +628,7 @@ public class Distribute extends AbstractAppCenterService {
      */
     private synchronized void setInstanceUpdateTrack(final int updateTrack) {
         if (mContext != null) {
-            AppCenterLog.error(LOG_TAG, "Update track cannot be changed after start.");
+            AppCenterLog.error(LOG_TAG, "Update track cannot be set after Distribute is started.");
             return;
         }
         if (DistributeUtils.isInvalidUpdateTrack(updateTrack)) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -101,7 +101,6 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TOKEN;
-import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TRACK;
 import static com.microsoft.appcenter.distribute.DistributeConstants.SERVICE_NAME;
 import static com.microsoft.appcenter.distribute.DistributeUtils.computeReleaseHash;
 import static com.microsoft.appcenter.distribute.DistributeUtils.getStoredDownloadState;
@@ -192,12 +191,7 @@ public class Distribute extends AbstractAppCenterService {
     /**
      * Update track as set and returned by the API. The change with that value might not have been processed yet.
      */
-    private Integer mUpdateTrack;
-
-    /**
-     * Last used value for update check.
-     */
-    private Integer mLastCheckedUpdateTrack;
+    private int mUpdateTrack = UpdateTrack.PUBLIC;
 
     /**
      * Current API call identifier to check latest release from server, used for state check.
@@ -360,7 +354,6 @@ public class Distribute extends AbstractAppCenterService {
      * Get the current update track (public vs private).
      */
     // TODO Remove suppress when app uses it without reflection on jCenter
-    @SuppressWarnings("WeakerAccess")
     public static int getUpdateTrack() {
         return getInstance().getInstanceUpdateTrack();
     }
@@ -371,7 +364,6 @@ public class Distribute extends AbstractAppCenterService {
      * @param updateTrack update track.
      */
     // TODO Remove suppress when app uses it without reflection on jCenter
-    @SuppressWarnings("WeakerAccess")
     public static void setUpdateTrack(@UpdateTrack int updateTrack) {
         getInstance().setInstanceUpdateTrack(updateTrack);
     }
@@ -443,15 +435,6 @@ public class Distribute extends AbstractAppCenterService {
             mPackageInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
         } catch (PackageManager.NameNotFoundException e) {
             AppCenterLog.error(LOG_TAG, "Could not get self package info.", e);
-        }
-
-        /* Store update track if it has been changed before start. */
-        if (mUpdateTrack != null) {
-            SharedPreferencesManager.putInt(PREFERENCE_KEY_UPDATE_TRACK, mUpdateTrack);
-        } else {
-
-            /* Otherwise use previous run value that was persisted. */
-            mUpdateTrack = DistributeUtils.getStoredUpdateTrack();
         }
 
         /*
@@ -543,7 +526,6 @@ public class Distribute extends AbstractAppCenterService {
             mTesterAppOpenedOrAborted = false;
             mBrowserOpenedOrAborted = false;
             mWorkflowCompleted = false;
-            mLastCheckedUpdateTrack = null;
             cancelPreviousTasks();
             SharedPreferencesManager.remove(PREFERENCE_KEY_REQUEST_ID);
             SharedPreferencesManager.remove(PREFERENCE_KEY_POSTPONE_TIME);
@@ -638,42 +620,22 @@ public class Distribute extends AbstractAppCenterService {
      * Implements {@link #getUpdateTrack()}.
      */
     private synchronized int getInstanceUpdateTrack() {
-        return mUpdateTrack == null ? UpdateTrack.PUBLIC : mUpdateTrack;
+        return mUpdateTrack;
     }
 
     /**
      * Implements {@link #setUpdateTrack(int)}.
      */
     private synchronized void setInstanceUpdateTrack(final int updateTrack) {
+        if (mContext != null) {
+            AppCenterLog.error(LOG_TAG, "Update track cannot be changed after start.");
+            return;
+        }
         if (DistributeUtils.isInvalidUpdateTrack(updateTrack)) {
             AppCenterLog.error(LOG_TAG, "Invalid argument passed to Distribute.setUpdateTrack().");
             return;
         }
         mUpdateTrack = updateTrack;
-        Runnable disabledRunnable = new Runnable() {
-
-            @Override
-            public void run() {
-                SharedPreferencesManager.putInt(PREFERENCE_KEY_UPDATE_TRACK, updateTrack);
-            }
-        };
-        Runnable enabledRunnable = new Runnable() {
-
-            @Override
-            public void run() {
-                SharedPreferencesManager.putInt(PREFERENCE_KEY_UPDATE_TRACK, updateTrack);
-                processUpdateTrackChange(updateTrack);
-            }
-        };
-        post(enabledRunnable, disabledRunnable, disabledRunnable);
-    }
-
-    @WorkerThread
-    private synchronized void processUpdateTrackChange(int updateTrack) {
-        if (mLastCheckedUpdateTrack == null || updateTrack != mLastCheckedUpdateTrack) {
-            resetWorkflow();
-            resumeWorkflowIfForeground();
-        }
     }
 
     /**
@@ -887,7 +849,6 @@ public class Distribute extends AbstractAppCenterService {
             /*
              * Check if we have previously stored the redirection parameters from private group or we simply use public track.
              */
-            mLastCheckedUpdateTrack = mUpdateTrack;
             String updateToken = SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN);
             String distributionGroupId = SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
             boolean isPublicTrack = mUpdateTrack == UpdateTrack.PUBLIC;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -189,7 +189,7 @@ public class Distribute extends AbstractAppCenterService {
     private String mBeforeStartTesterAppUpdateSetupFailed;
 
     /**
-     * Update track as set and returned by the API. The change with that value might not have been processed yet.
+     * Update track as set and returned by the API. Can only be set before start.
      */
     private int mUpdateTrack = UpdateTrack.PUBLIC;
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -211,11 +211,6 @@ public final class DistributeConstants {
     private static final String PREFERENCE_PREFIX = SERVICE_NAME + ".";
 
     /**
-     * Preference key to store tracking mode (public/private), value format is string value of {@link UpdateTrack}.
-     */
-    static final String PREFERENCE_KEY_UPDATE_TRACK = PREFERENCE_PREFIX + "update_track";
-
-    /**
      * Preference key to store the current/last download identifier (we keep download until a next
      * one is scheduled as the file can be opened from device downloads U.I.).
      */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -35,7 +35,6 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_R
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_REQUEST_ID;
-import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TRACK;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PRIVATE_UPDATE_SETUP_PATH_FORMAT;
 
 /**
@@ -165,21 +164,6 @@ class DistributeUtils {
             }
         }
         return null;
-    }
-
-    /**
-     * Get stored update track.
-     *
-     * @return stored update track (public by default).
-     */
-    @UpdateTrack
-    static int getStoredUpdateTrack() {
-        int updateTrack = SharedPreferencesManager.getInt(PREFERENCE_KEY_UPDATE_TRACK, UpdateTrack.PUBLIC);
-        if (isInvalidUpdateTrack(updateTrack)) {
-            AppCenterLog.warn(LOG_TAG, "Corrupted stored update track, switching to public.");
-            updateTrack = UpdateTrack.PUBLIC;
-        }
-        return updateTrack;
     }
 
     static boolean isInvalidUpdateTrack(int updateTrack) {

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AbstractDistributeTest.java
@@ -50,7 +50,6 @@ import java.util.UUID;
 
 import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
-import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TRACK;
 import static com.microsoft.appcenter.utils.PrefStorageConstants.KEY_ENABLED;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -196,32 +195,6 @@ public class AbstractDistributeTest {
             }
         }).when(SharedPreferencesManager.class);
         SharedPreferencesManager.putBoolean(eq(DISTRIBUTE_ENABLED_KEY), anyBoolean());
-
-        /* Mock storage of update track. */
-        when(SharedPreferencesManager.getInt(eq(PREFERENCE_KEY_UPDATE_TRACK), anyInt())).thenReturn(UpdateTrack.PUBLIC);
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-
-                /* Whenever the new state is persisted, make further calls return the new state. */
-                int updateTrack = (Integer) invocation.getArguments()[1];
-                when(SharedPreferencesManager.getInt(eq(PREFERENCE_KEY_UPDATE_TRACK), anyInt())).thenReturn(updateTrack);
-                return null;
-            }
-        }).when(SharedPreferencesManager.class);
-        SharedPreferencesManager.putInt(eq(PREFERENCE_KEY_UPDATE_TRACK), anyInt());
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-
-                /* When key removed, restore default value. */
-                when(SharedPreferencesManager.getInt(eq(PREFERENCE_KEY_UPDATE_TRACK), anyInt())).thenReturn(UpdateTrack.PUBLIC);
-                return null;
-            }
-        }).when(SharedPreferencesManager.class);
-        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_TRACK);
 
         /* Default download id when not found. */
         when(SharedPreferencesManager.getLong(PREFERENCE_KEY_DOWNLOAD_ID, INVALID_DOWNLOAD_IDENTIFIER)).thenReturn(INVALID_DOWNLOAD_IDENTIFIER);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -734,7 +734,9 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* If process is restarted, a new call will be made. Need to mock storage for that. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("g");
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
-        restartProcessAndSdk();
+        Distribute.unsetInstance();
+        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
+        start();
         Distribute.getInstance().onActivityResumed(mActivity);
         verify(mHttpClient, times(2)).callAsync(argThat(new ArgumentMatcher<String>() {
 
@@ -852,7 +854,9 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* If process is restarted, a new call will be made. Need to mock storage for that. */
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("g");
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
-        restartProcessAndSdk();
+        Distribute.unsetInstance();
+        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
+        start();
         Distribute.getInstance().onActivityResumed(mActivity);
         verify(mHttpClient, times(2)).callAsync(argThat(new ArgumentMatcher<String>() {
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -1004,8 +1004,6 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         SharedPreferencesManager.putString(eq(PREFERENCE_KEY_RELEASE_DETAILS), anyString());
 
         /* Mock we receive a second update. */
-        when(SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID)).thenReturn("some group");
-        when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
         when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class))).thenAnswer(new Answer<ServiceCall>() {
 
             @Override
@@ -1014,13 +1012,11 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
                 return mock(ServiceCall.class);
             }
         });
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put(DistributeConstants.HEADER_API_TOKEN, "some token");
 
         /* Trigger call. */
         start();
         Distribute.getInstance().onActivityResumed(mock(Activity.class));
-        verify(mHttpClient).callAsync(anyString(), anyString(), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        verify(mHttpClient).callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
 
         /* Verify prompt is shown. */
         verify(mDialog).show();
@@ -1071,6 +1067,7 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         headers.put(DistributeConstants.HEADER_API_TOKEN, "some token");
 
         /* Start SDK. */
+        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
         start();
 
         /* Disable SDK. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUpdateTrackTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUpdateTrackTest.java
@@ -11,24 +11,19 @@ import android.content.pm.PackageManager;
 import com.microsoft.appcenter.http.HttpClient;
 import com.microsoft.appcenter.http.HttpResponse;
 import com.microsoft.appcenter.http.ServiceCallback;
-import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 
-import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TRACK;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
@@ -43,13 +38,13 @@ public class DistributeUpdateTrackTest extends AbstractDistributeTest {
     public void getAndSetValueBeforeStart() {
 
         /* Check default value. */
-        Assert.assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
+        assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
 
         /* Check changes. */
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
-        Assert.assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
+        assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
         Distribute.setUpdateTrack(UpdateTrack.PUBLIC);
-        Assert.assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
+        assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
     }
 
     @Test
@@ -64,78 +59,11 @@ public class DistributeUpdateTrackTest extends AbstractDistributeTest {
         Distribute.setUpdateTrack(42);
 
         /* Check value didn't change. */
-        Assert.assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
+        assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
     }
 
     @Test
-    public void invalidPersistedTrackFallsBackToPublic() {
-
-        /* Corrupt storage. */
-        when(SharedPreferencesManager.getInt(eq(PREFERENCE_KEY_UPDATE_TRACK), anyInt())).thenReturn(42);
-
-        /* Start. */
-        start();
-
-        /* Check value didn't change. */
-        Assert.assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
-    }
-
-    @Test
-    public void persistValueWhenDisabled() {
-
-        /* Start and disable SDK. */
-        start();
-        Distribute.setEnabled(false).get();
-        Distribute.getInstance().onActivityResumed(mock(Activity.class));
-
-        /* Switch track. */
-        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
-
-        /* Verify it's persisted. */
-        Distribute.unsetInstance();
-        start();
-        Assert.assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
-
-        /* Verify no check for update call (or browser). */
-        verifyNoMoreInteractions(mHttpClient);
-        verifyStatic(never());
-        BrowserUtils.openBrowser(anyString(), any(Activity.class));
-    }
-
-    @Test
-    public void persistValueWhenSwitchBeforeStart() {
-
-        /* Switch track before start. */
-        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
-
-        /* Start. */
-        start();
-
-        /* Restart. */
-        Distribute.unsetInstance();
-        start();
-
-        /* Check. */
-        Assert.assertEquals(UpdateTrack.PRIVATE, Distribute.getUpdateTrack());
-    }
-
-    @Test
-    public void switchTrackBeforeCallCompletes() {
-
-        /* Start (in public mode). */
-        start();
-        Distribute.getInstance().onActivityResumed(mock(Activity.class));
-
-        /* Check http call done. */
-        verify(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
-
-        /* If we switch before flow is completed, it has no effect. */
-        Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
-        verify(mHttpClient).callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
-    }
-
-    @Test
-    public void switchTrackAfterCallCompletes() throws PackageManager.NameNotFoundException {
+    public void switchTrack() throws PackageManager.NameNotFoundException {
 
         /* Start (in public mode). */
         when(mPackageManager.getPackageInfo(DistributeUtils.TESTER_APP_PACKAGE_NAME, 0)).thenThrow(new PackageManager.NameNotFoundException());
@@ -153,9 +81,9 @@ public class DistributeUpdateTrackTest extends AbstractDistributeTest {
         /* Complete call with no new release (this will return the default mock mReleaseDetails with version 0). */
         httpCallback.getValue().onCallSucceeded(mock(HttpResponse.class));
 
-        /* If we switch to private, browser must open. */
+        /* If we switch to private, browser must not open. We disallow changes. */
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
-        verifyStatic();
+        verifyStatic(never());
         BrowserUtils.openBrowser(anyString(), eq(mActivity));
     }
 
@@ -169,30 +97,14 @@ public class DistributeUpdateTrackTest extends AbstractDistributeTest {
         /* Switch to private. */
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
 
+        /* Check value didn't change. */
+        assertEquals(UpdateTrack.PUBLIC, Distribute.getUpdateTrack());
+
         /* Go foreground. */
         Distribute.getInstance().onActivityResumed(mActivity);
 
-        /* Verify browser is opened. */
-        verifyStatic();
+        /* Verify browser is not opened. Changes are allowed only before start. */
+        verifyStatic(never());
         BrowserUtils.openBrowser(anyString(), eq(mActivity));
-    }
-
-    @Test
-    public void switchToSameTrackDoesNothing() {
-
-        /* Start (in public mode). */
-        start();
-        Distribute.getInstance().onActivityResumed(mock(Activity.class));
-
-        /* Check http call done. */
-        ArgumentCaptor<ServiceCallback> httpCallback = ArgumentCaptor.forClass(ServiceCallback.class);
-        verify(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), httpCallback.capture());
-
-        /* Complete call with no new release (this will return the default mock mReleaseDetails with version 0). */
-        httpCallback.getValue().onCallSucceeded(mock(HttpResponse.class));
-
-        /* If we switch to public from public, no action. */
-        Distribute.setUpdateTrack(UpdateTrack.PUBLIC);
-        verify(mHttpClient).callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Implement the spec change where setInAppUpdateTrack works only before start.

## Related PRs or issues

[AB#75928](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/75928)
