### PR TITLE
Allows updates to work on public track if sideloading failed on private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
+* **[Fix]** If user clicked "Ignore" on the error dialog after browser redirection on the private track, and if the application switches to public track after restart, the SDK now checks for updates correctly.
 
 ## Version 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
-* **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track
+* **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track.
 
 ## Version 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
-* **[Fix]** If user clicked "Ignore" on the error dialog after browser redirection on the private track, and if the application switches to public track after restart, the SDK now checks for updates correctly.
+* **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track
 
 ## Version 3.0.0
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -769,18 +769,22 @@ public class Distribute extends AbstractAppCenterService {
             /*
              * If failed to enable in-app updates on the same app build before, don't go any further.
              * Only if the app build is different (different package hash), try enabling in-app updates again.
+             * This applies to private track only.
              */
-            String releaseHash = DistributeUtils.computeReleaseHash(this.mPackageInfo);
-            String updateSetupFailedPackageHash = SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
-            if (updateSetupFailedPackageHash != null) {
-                if (releaseHash.equals(updateSetupFailedPackageHash)) {
-                    AppCenterLog.info(LOG_TAG, "Skipping in-app updates setup, because it already failed on this release before.");
-                    return;
-                } else {
-                    AppCenterLog.info(LOG_TAG, "Re-attempting in-app updates setup and cleaning up failure info from storage.");
-                    SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
-                    SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-                    SharedPreferencesManager.remove(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+            boolean isPublicTrack = mUpdateTrack == UpdateTrack.PUBLIC;
+            if (!isPublicTrack) {
+                String updateSetupFailedPackageHash = SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+                if (updateSetupFailedPackageHash != null) {
+                    String releaseHash = DistributeUtils.computeReleaseHash(this.mPackageInfo);
+                    if (releaseHash.equals(updateSetupFailedPackageHash)) {
+                        AppCenterLog.info(LOG_TAG, "Skipping in-app updates setup, because it already failed on this release before.");
+                        return;
+                    } else {
+                        AppCenterLog.info(LOG_TAG, "Re-attempting in-app updates setup and cleaning up failure info from storage.");
+                        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+                        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+                        SharedPreferencesManager.remove(PREFERENCE_KEY_TESTER_APP_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+                    }
                 }
             }
 
@@ -927,7 +931,6 @@ public class Distribute extends AbstractAppCenterService {
              */
             String updateToken = SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN);
             String distributionGroupId = SharedPreferencesManager.getString(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
-            boolean isPublicTrack = mUpdateTrack == UpdateTrack.PUBLIC;
             if (isPublicTrack || updateToken != null) {
 
                 /* We have what we need to check for updates via API. */


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

iOS already has this behavior.

## Related PRs or issues

[AB#77140](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/77140)