### PR TITLE
Remove warning about attachments amount when sending crash report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 3.1.1 (Under development)
 
+### App Center Crashes
+
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
 
 ___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 3.1.1 (Under development)
 
+* **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+
 ___
 
 ## Version 3.1.0

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -117,11 +117,6 @@ public class Crashes extends AbstractAppCenterService {
     public static final String LOG_TAG = AppCenterLog.LOG_TAG + SERVICE_NAME;
 
     /**
-     * Max allowed attachments per crash.
-     */
-    private static final int MAX_ATTACHMENT_PER_CRASH = 2;
-
-    /**
      * Maximum size for attachment data in bytes.
      */
     private static final int MAX_ATTACHMENT_SIZE = 7 * 1024 * 1024;
@@ -1070,7 +1065,6 @@ public class Crashes extends AbstractAppCenterService {
         if (attachments == null) {
             AppCenterLog.debug(LOG_TAG, "Error report: " + errorId.toString() + " does not have any attachment.");
         } else {
-            int totalErrorAttachments = 0;
             for (ErrorAttachmentLog attachment : attachments) {
                 if (attachment != null) {
                     attachment.setId(UUID.randomUUID());
@@ -1082,15 +1076,11 @@ public class Crashes extends AbstractAppCenterService {
                                 "Discarding attachment with size above %d bytes: size=%d, fileName=%s.",
                                 MAX_ATTACHMENT_SIZE, attachment.getData().length, attachment.getFileName()));
                     } else {
-                        ++totalErrorAttachments;
                         mChannel.enqueue(attachment, ERROR_GROUP, Flags.DEFAULTS);
                     }
                 } else {
                     AppCenterLog.warn(LOG_TAG, "Skipping null ErrorAttachmentLog.");
                 }
-            }
-            if (totalErrorAttachments > MAX_ATTACHMENT_PER_CRASH) {
-                AppCenterLog.warn(LOG_TAG, "A limit of " + MAX_ATTACHMENT_PER_CRASH + " attachments per error report might be enforced by server.");
             }
         }
     }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -921,49 +921,6 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void sendMoreThan2ErrorAttachments() throws JSONException {
-        int MAX_ATTACHMENT_PER_CRASH = 2;
-        int numOfAttachments = MAX_ATTACHMENT_PER_CRASH + 1;
-
-        ArrayList<ErrorAttachmentLog> errorAttachmentLogs = new ArrayList<>(3);
-        for (int i = 0; i < numOfAttachments; ++i) {
-            ErrorAttachmentLog log = mock(ErrorAttachmentLog.class);
-            when(log.isValid()).thenReturn(true);
-            when(log.getData()).thenReturn(new byte[1]);
-            errorAttachmentLogs.add(log);
-        }
-
-        CrashesListener listener = mock(CrashesListener.class);
-        when(listener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
-        when(listener.getErrorAttachments(any(ErrorReport.class))).thenReturn(errorAttachmentLogs);
-
-        ManagedErrorLog log = mock(ManagedErrorLog.class);
-        when(log.getId()).thenReturn(UUID.randomUUID());
-
-        LogSerializer logSerializer = mock(LogSerializer.class);
-        when(logSerializer.deserializeLog(anyString(), anyString())).thenReturn(log);
-
-        mockStatic(ErrorLogHelper.class);
-        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
-        when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
-        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
-
-        when(FileManager.read(any(File.class))).thenReturn("");
-
-        Crashes crashes = Crashes.getInstance();
-        crashes.setInstanceListener(listener);
-        crashes.setLogSerializer(logSerializer);
-
-        crashes.onStarting(mAppCenterHandler);
-        crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
-
-        String expectedMessage = "A limit of " + MAX_ATTACHMENT_PER_CRASH + " attachments per error report might be enforced by server.";
-        PowerMockito.verifyStatic();
-        AppCenterLog.warn(Crashes.LOG_TAG, expectedMessage);
-    }
-
-    @Test
     public void discardHugeErrorAttachments() throws JSONException {
 
         /* Prepare a big (too big) attachment and a small one. */


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

This PR removes warning about attachments count when sending crash.
With that, test which was created to verify this message rendered redundant, and so did constant and local counter.

## Related PRs or issues

[AB#78240](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78240)