### PR TITLE
The update dialog is not shown after interrupting downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ___
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
 * **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track.
+* **[Fix]** Fix repeated sending a request for check updates after disabling the Distribution module during downloading the new release.
 
 ## Version 3.0.0
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -706,8 +706,8 @@ public class Distribute extends AbstractAppCenterService {
         if (mCheckReleaseApiCall != null) {
             mCheckReleaseApiCall.cancel();
             mCheckReleaseApiCall = null;
-            mCheckReleaseCallId = null;
         }
+        mCheckReleaseCallId = null;
         mUpdateDialog = null;
         mUnknownSourcesDialog = null;
         mCompletedDownloadDialog = null;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -29,6 +29,7 @@ import com.microsoft.appcenter.http.ServiceCall;
 import com.microsoft.appcenter.http.ServiceCallback;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.test.TestUtils;
+import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.junit.After;
@@ -41,8 +42,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.DOWNLOAD_STATE_COMPLETED;
@@ -75,7 +74,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-@PrepareForTest({DistributeUtils.class, HttpUtils.class})
+@PrepareForTest({DistributeUtils.class, HttpUtils.class, DeviceInfoHelper.class })
 public class DistributeTest extends AbstractDistributeTest {
 
     private static final String DISTRIBUTION_GROUP_ID = "group_id";
@@ -753,46 +752,29 @@ public class DistributeTest extends AbstractDistributeTest {
 
         /* Prepare data. */
         mockStatic(DistributeUtils.class);
-        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_COMPLETED);
-        final ServiceCall call = mock(ServiceCall.class);
-        doAnswer(new Answer<ServiceCall>() {
-
-            @Override
-            public ServiceCall answer(final InvocationOnMock invocationOnMock) {
-                new Timer().schedule(new TimerTask() {
-                    @Override
-                    public void run() {
-                        ((ServiceCallback) invocationOnMock.getArguments()[4]).onCallSucceeded(new HttpResponse(200, ""));
-                    }
-                }, 2000);
-                return call;
-            }
-        }).when(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        mockStatic(DeviceInfoHelper.class);
+        when(mReleaseDetails.getVersion()).thenReturn(1);
+        when(mReleaseDetails.isMandatoryUpdate()).thenReturn(true);
+        when(DeviceInfoHelper.getVersionCode(any(PackageInfo.class))).thenReturn(0);
+        when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(mReleaseDetails);
 
         /* Start distribute. */
         start();
 
         /* Start activity. */
-        Distribute.getInstance().onApplicationEnterForeground();
         Distribute.getInstance().onActivityResumed(mActivity);
+        ArgumentCaptor<ServiceCallback> httpCallback = ArgumentCaptor.forClass(ServiceCallback.class);
+        verify(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), httpCallback.capture());
 
-        /* Verify that checkForUpdate was called. */
-        verifyStatic(times(2));
-        Distribute.checkForUpdate();
+        /* Complete call with no new release (this will return the default mock mReleaseDetails with version 0). */
+        httpCallback.getValue().onCallSucceeded(mock(HttpResponse.class));
 
-        /* Verify download is checked after we reset workflow. */
-        verify(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
-
-        // Disable and enable distribute module.
+        /* Disable and enable distribute module. */
         Distribute.setEnabled(false);
         Distribute.setEnabled(true);
 
         /* Verify download is not called again. */
-        verify(mHttpClient, times(2)).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
-
-        /* Verify that checkForUpdate was called again. */
-        verifyStatic(times(7));
-        Distribute.checkForUpdate();
+        verify(mHttpClient, times(2)).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), httpCallback.capture());
     }
 
     private void firstDownloadNotification(int apiLevel) throws Exception {


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

1. Open application
2. The update dialog is shown. Click downloading.
3. During downloading disable distribute a module. The downloading is stopped.
4. Enable distribute a module. The update dialog is not shown.
5. Collapse and expand the app.
6. The update dialog still is not shown.

Expected
After 4 steps the updates dialog is shown.

Actual
After 4 steps the updates dialog is not shown.

## Related PRs or issues

[AB#78590](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78590)
