### PR TITLE
The update dialog is not shown after interrupting downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ___
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
 * **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track.
+* **[Fix]** Fix checking updates after disabling the Distribute module during downloading the release.
 
 ## Version 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### App Center Crashes
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+
+### App Center Distribute
+
 * **[Fix]** Fix checking for updates after disabling the Distribute module while downloading the release.
 
 ___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Crashes
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+* **[Fix]** Fix checking for updates after disabling the Distribute module while downloading the release.
 
 ___
 
@@ -15,7 +16,6 @@ ___
 * **[Feature]** Add a `disableAutomaticCheckForUpdate` API that needs to be called before SDK start in order to turn off automatic check for update. 
 * **[Feature]** Add a `checkForUpdate` API to manually check for update.
 * **[Fix]** Fix not checking updates on public track if it was ignored on error while initializing in-app update for private track.
-* **[Fix]** Fix checking updates after disabling the Distribute module during downloading the release.
 
 ## Version 3.0.0
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -726,8 +726,8 @@ public class Distribute extends AbstractAppCenterService {
         if (mCheckReleaseApiCall != null) {
             mCheckReleaseApiCall.cancel();
             mCheckReleaseApiCall = null;
-            mCheckReleaseCallId = null;
         }
+        mCheckReleaseCallId = null;
         mUpdateDialog = null;
         mUnknownSourcesDialog = null;
         mCompletedDownloadDialog = null;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -691,17 +691,19 @@ public class DistributeTest extends AbstractDistributeTest {
 
         /* Start activity. */
         Distribute.getInstance().onActivityResumed(mActivity);
+
+        /* Verify that check release for update was called. */
         ArgumentCaptor<ServiceCallback> httpCallback = ArgumentCaptor.forClass(ServiceCallback.class);
         verify(mHttpClient).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), httpCallback.capture());
 
-        /* Complete call with no new release (this will return the default mock mReleaseDetails with version 0). */
+        /* Complete the first call. */
         httpCallback.getValue().onCallSucceeded(mock(HttpResponse.class));
 
         /* Disable and enable distribute module. */
         Distribute.setEnabled(false);
         Distribute.setEnabled(true);
 
-        /* Verify download is not called again. */
+        /* Verify that check release for update was called again. */
         verify(mHttpClient, times(2)).callAsync(anyString(), anyString(), eq(Collections.<String, String>emptyMap()), any(HttpClient.CallTemplate.class), httpCallback.capture());
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x]  Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

A few sentences describing the overall goals of the pull request.

1. Open application
2. The update dialog is shown. Click downloading.
3. During downloading disable distribute a module. The downloading is stopped.
4. Enable distribute a module. The update dialog is not shown.
5. Collapse and expand the app.
6. The update dialog still is not shown.

Expected
After 4 steps the updates dialog is shown.

Actual
After 4 steps the updates dialog is not shown.
