### PR TITLE
Fix filter of minidump files for NDK crash dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Crashes
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+* **[Fix]** Fix remove minidump files when the sending crash report was discarded.
 
 ### App Center Distribute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Crashes
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+* **[Fix]** Change minidump filter to use file extension instead of name.
 * **[Fix]** Fix remove minidump files when the sending crash report was discarded.
 
 ### App Center Distribute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
 * **[Fix]** Change minidump filter to use file extension instead of name.
-* **[Fix]** Fix remove minidump files when the sending crash report was discarded.
+* **[Fix]** Fix removing minidump files when the sending crash report was discarded.
 
 ### App Center Distribute
 

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -111,7 +111,7 @@ public class CrashesAndroidTest {
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles();
         assertNotNull(files);
         for (File logFile : files) {
-            assertTrue(FileManager.deleteDir(logFile));
+            assertTrue(FileManager.deleteDirectory(logFile));
         }
         mChannel = mock(Channel.class);
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -982,7 +982,7 @@ public class Crashes extends AbstractAppCenterService {
                         iterator.remove();
                         removeAllStoredErrorLogFiles(id);
                     }
-                    ErrorLogHelper.cleanPendingMinidumpDirectory();
+                    ErrorLogHelper.cleanDirectory(ErrorLogHelper.getPendingMinidumpDirectory());
                 }
 
                 /* We send the crash. */

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -700,7 +700,7 @@ public class Crashes extends AbstractAppCenterService {
 
                 @Override
                 public boolean accept(File dir, String filename) {
-                    return !filename.equals(DEVICE_INFO_FILE);
+                    return filename.endsWith(".dmp");
                 }
             });
             if (minidumpSubfolderFiles == null || minidumpSubfolderFiles.length == 0) {
@@ -982,6 +982,7 @@ public class Crashes extends AbstractAppCenterService {
                         iterator.remove();
                         removeAllStoredErrorLogFiles(id);
                     }
+                    ErrorLogHelper.cleanPendingMinidumpDirectory();
                 }
 
                 /* We send the crash. */

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -982,7 +982,7 @@ public class Crashes extends AbstractAppCenterService {
                         iterator.remove();
                         removeAllStoredErrorLogFiles(id);
                     }
-                    ErrorLogHelper.cleanDirectory(ErrorLogHelper.getPendingMinidumpDirectory());
+                    ErrorLogHelper.cleanPendingMinidumps();
                 }
 
                 /* We send the crash. */

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -66,7 +66,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE;
 import static android.util.Log.getStackTraceString;
 import static com.microsoft.appcenter.Constants.WRAPPER_SDK_NAME_NDK;
-import static com.microsoft.appcenter.crashes.utils.ErrorLogHelper.DEVICE_INFO_FILE;
+import static com.microsoft.appcenter.crashes.utils.ErrorLogHelper.MINIDUMP_FILE_EXTENSION;
 
 /**
  * Crashes service.
@@ -700,7 +700,7 @@ public class Crashes extends AbstractAppCenterService {
 
                 @Override
                 public boolean accept(File dir, String filename) {
-                    return filename.endsWith(".dmp");
+                    return filename.endsWith(MINIDUMP_FILE_EXTENSION);
                 }
             });
             if (minidumpSubfolderFiles == null || minidumpSubfolderFiles.length == 0) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -574,8 +574,7 @@ public class ErrorLogHelper {
      * Clear directory.
      * @param dir a folder.
      */
-    @NonNull
-    public static void cleanDirectory(File dir) {
+    public static void cleanDirectory(@NonNull File dir) {
         if (dir.isDirectory()) {
             File[] files = dir.listFiles();
             if (files != null && files.length > 0) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -574,8 +574,9 @@ public class ErrorLogHelper {
      * Clear directory.
      * @param dir a folder.
      */
+    @NonNull
     public static void cleanDirectory(File dir) {
-        if (dir != null && dir.isDirectory()) {
+        if (dir.isDirectory()) {
             File[] files = dir.listFiles();
             if (files != null && files.length > 0) {
                 for (File file : files) {

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -571,14 +571,17 @@ public class ErrorLogHelper {
     }
 
     /**
-     * Clear pending minidump directory.
+     * Clear directory.
+     * @param dir a folder.
      */
-    public static void cleanPendingMinidumpDirectory() {
-        File[] files = getPendingMinidumpDirectory().listFiles();
-        if (files != null && files.length > 0) {
-            for (File file : files) {
-                boolean isDelete = file.delete();
-                AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '$s'", file.getPath(), isDelete));
+    public static void cleanDirectory(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null && files.length > 0) {
+                for (File file : files) {
+                    boolean isDelete = file.delete();
+                    AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '$s'", file.getPath(), isDelete));
+                }
             }
         }
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -389,7 +389,7 @@ public class ErrorLogHelper {
             return;
         }
         for (File file : previousSubFolders) {
-            FileManager.deleteDir(file);
+            FileManager.deleteDirectory(file);
         }
     }
 
@@ -399,7 +399,7 @@ public class ErrorLogHelper {
     public static void removeMinidumpFolder() {
         File errorStorageDirectory = getErrorStorageDirectory();
         File minidumpDirectory = new File(errorStorageDirectory.getAbsolutePath(), MINIDUMP_DIRECTORY);
-        FileManager.deleteDir(minidumpDirectory);
+        FileManager.deleteDirectory(minidumpDirectory);
     }
 
     @Nullable
@@ -579,7 +579,7 @@ public class ErrorLogHelper {
      * Clear (delete all content) pending minidump directory.
      */
     public static void cleanPendingMinidumps() {
-        FileManager.cleanDir(ErrorLogHelper.getPendingMinidumpDirectory());
+        FileManager.cleanDirectory(ErrorLogHelper.getPendingMinidumpDirectory());
     }
 
     /**

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -576,19 +576,10 @@ public class ErrorLogHelper {
     }
 
     /**
-     * Clear directory.
-     * @param dir a folder.
+     * Clear (delete all content) pending minidump directory.
      */
-    public static void cleanDirectory(@NonNull File dir) {
-        if (dir.isDirectory()) {
-            File[] files = dir.listFiles();
-            if (files != null && files.length > 0) {
-                for (File file : files) {
-                    //noinspection ResultOfMethodCallIgnored
-                    file.delete();
-                }
-            }
-        }
+    public static void cleanPendingMinidumps() {
+        FileManager.cleanDir(ErrorLogHelper.getPendingMinidumpDirectory());
     }
 
     /**

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -580,8 +580,8 @@ public class ErrorLogHelper {
             File[] files = dir.listFiles();
             if (files != null && files.length > 0) {
                 for (File file : files) {
-                    boolean isDelete = file.delete();
-                    AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '%s'", file.getPath(), isDelete));
+                    //noinspection ResultOfMethodCallIgnored
+                    file.delete();
                 }
             }
         }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -581,7 +581,7 @@ public class ErrorLogHelper {
             if (files != null && files.length > 0) {
                 for (File file : files) {
                     boolean isDelete = file.delete();
-                    AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '$s'", file.getPath(), isDelete));
+                    AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '%s'", file.getPath(), isDelete));
                 }
             }
         }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -575,9 +575,10 @@ public class ErrorLogHelper {
      */
     public static void cleanPendingMinidumpDirectory() {
         File[] files = getPendingMinidumpDirectory().listFiles();
-        if (files != null) {
+        if (files != null && files.length > 0) {
             for (File file : files) {
-                file.delete();
+                boolean isDelete = file.delete();
+                AppCenterLog.debug(Crashes.LOG_TAG, String.format("Minidump file '%s' has delete status: '$s'", file.getPath(), isDelete));
             }
         }
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -124,6 +124,11 @@ public class ErrorLogHelper {
     public static final int MAX_PROPERTY_ITEM_LENGTH = 125;
 
     /**
+     * Minidump file extension for the NDK crashes.
+     */
+    public static final String MINIDUMP_FILE_EXTENSION = ".dmp";
+
+    /**
      * Directory for new minidump files.
      */
     private static File sNewMinidumpDirectory;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -571,6 +571,18 @@ public class ErrorLogHelper {
     }
 
     /**
+     * Clear pending minidump directory.
+     */
+    public static void cleanPendingMinidumpDirectory() {
+        File[] files = getPendingMinidumpDirectory().listFiles();
+        if (files != null) {
+            for (File file : files) {
+                file.delete();
+            }
+        }
+    }
+
+    /**
      * Parse log folder name UUID. Fallback to random UUID.
      *
      * @param logFolder a folder, e.g. lib/files/error/minidump/new/a80da2ae-8c85-43b0-a25b-d52319fb6d56

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1133,7 +1133,6 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Create minidump sub-folder. */
         File minidumpSubfolder = mTemporaryFolder.newFolder("mockFolder");
-        assertTrue(minidumpSubfolder.mkdir());
 
         /* Create a file for a crash in disk. */
         File minidumpFile = new File(minidumpSubfolder, "mockFile.dmp");

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1141,7 +1141,7 @@ public class CrashesTest extends AbstractCrashesTest {
         minidumpFile.createNewFile();
         minidumpFile.setLastModified(crashTime);
 
-        /* Create an additional file in a folder to be filtered later */
+        /* Create an additional file in a folder to be filtered later. */
         File otherFile = new File(minidumpSubfolder, "otherFile.txt");
         long fakeCrashTime = new Date().getTime();
         otherFile.createNewFile();

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -635,7 +635,7 @@ public class CrashesTest extends AbstractCrashesTest {
         verify(mockListener, never()).getErrorAttachments(any(ErrorReport.class));
 
         verifyStatic();
-        ErrorLogHelper.cleanDirectory(pendingFolder);
+        ErrorLogHelper.cleanPendingMinidumps();
         verifyStatic();
         ErrorLogHelper.removeStoredErrorLogFile(mErrorLog.getId());
         verifyStatic();

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -604,20 +604,14 @@ public class CrashesTest extends AbstractCrashesTest {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     public void handleUserConfirmationDoNotSend() throws JSONException {
-        File pendingFolder = mock(File.class);
-        File minidumpFile = mock(File.class);
-        when(pendingFolder.listFiles()).thenReturn(new File[] {minidumpFile});
-        when(pendingFolder.isDirectory()).thenReturn(true);
-
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
+        File pendingFolder = mock(File.class);
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingFolder);
         when(FileManager.read(any(File.class))).thenReturn("");
-        doCallRealMethod().when(ErrorLogHelper.class);
-        ErrorLogHelper.cleanDirectory(any(File.class));
 
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
@@ -637,12 +631,11 @@ public class CrashesTest extends AbstractCrashesTest {
         verify(mockListener, never()).getErrorAttachments(any(ErrorReport.class));
 
         verifyStatic();
-        ErrorLogHelper.cleanDirectory(any(File.class));
+        ErrorLogHelper.cleanDirectory(pendingFolder);
         verifyStatic();
         ErrorLogHelper.removeStoredErrorLogFile(mErrorLog.getId());
         verifyStatic();
         ErrorLogHelper.removeStoredThrowableFile(mErrorLog.getId());
-        verify(minidumpFile).delete();
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -608,6 +608,8 @@ public class CrashesTest extends AbstractCrashesTest {
 
     @Test
     public void handleUserConfirmationDoNotSend() throws JSONException {
+
+        /* Prepare data. Mock classes */
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
@@ -616,24 +618,22 @@ public class CrashesTest extends AbstractCrashesTest {
         File pendingFolder = mock(File.class);
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingFolder);
         when(FileManager.read(any(File.class))).thenReturn("");
-
         CrashesListener mockListener = mock(CrashesListener.class);
         when(mockListener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
         when(mockListener.shouldAwaitUserConfirmation()).thenReturn(true);
 
+        /* Prepare data. Set values. */
         Crashes crashes = Crashes.getInstance();
         LogSerializer logSerializer = mock(LogSerializer.class);
         when(logSerializer.deserializeLog(anyString(), anyString())).thenReturn(mErrorLog);
-
         crashes.setLogSerializer(logSerializer);
         crashes.setInstanceListener(mockListener);
         crashes.onStarting(mAppCenterHandler);
         crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
+        /* Verify */
         Crashes.notifyUserConfirmation(Crashes.DONT_SEND);
-
         verify(mockListener, never()).getErrorAttachments(any(ErrorReport.class));
-
         verifyStatic();
         ErrorLogHelper.cleanPendingMinidumps();
         verifyStatic();

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -609,7 +609,7 @@ public class CrashesTest extends AbstractCrashesTest {
     @Test
     public void handleUserConfirmationDoNotSend() throws JSONException {
 
-        /* Prepare data. Mock classes */
+        /* Prepare data. Mock classes. */
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
@@ -631,7 +631,7 @@ public class CrashesTest extends AbstractCrashesTest {
         crashes.onStarting(mAppCenterHandler);
         crashes.onStarted(mock(Context.class), mock(Channel.class), "", null, true);
 
-        /* Verify */
+        /* Verify. */
         Crashes.notifyUserConfirmation(Crashes.DONT_SEND);
         verify(mockListener, never()).getErrorAttachments(any(ErrorReport.class));
         verifyStatic();

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1129,23 +1129,22 @@ public class CrashesTest extends AbstractCrashesTest {
         verify(mockChannel, never()).enqueue(any(ManagedErrorLog.class), eq(crashes.getGroupName()), anyInt());
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     private ManagedErrorLog testNativeCrashLog(long appStartTime, long crashTime, boolean correlateSession, boolean hasDeviceInfo) throws Exception {
 
         /* Create minidump sub-folder. */
         File minidumpSubfolder = mTemporaryFolder.newFolder("mockFolder");
-        minidumpSubfolder.mkdir();
+        assertTrue(minidumpSubfolder.mkdir());
 
         /* Create a file for a crash in disk. */
         File minidumpFile = new File(minidumpSubfolder, "mockFile.dmp");
-        minidumpFile.createNewFile();
-        minidumpFile.setLastModified(crashTime);
+        assertTrue(minidumpFile.createNewFile());
+        assertTrue(minidumpFile.setLastModified(crashTime));
 
         /* Create an additional file in a folder to be filtered later. */
         File otherFile = new File(minidumpSubfolder, "otherFile.txt");
         long fakeCrashTime = new Date().getTime();
-        otherFile.createNewFile();
-        otherFile.setLastModified(fakeCrashTime);
+        assertTrue(otherFile.createNewFile());
+        assertTrue(otherFile.setLastModified(fakeCrashTime));
 
         /* Mock session context. */
         mockStatic(SessionContext.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -40,7 +40,9 @@ import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
@@ -125,6 +127,9 @@ public class CrashesTest extends AbstractCrashesTest {
         assertEquals(errorLog.getDevice(), report.getDevice());
         assertNotNull(errorLog.getDevice());
     }
+
+    @Rule
+    public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
 
     @Before
     public void setUp() {
@@ -601,7 +606,6 @@ public class CrashesTest extends AbstractCrashesTest {
         Mockito.verifyNoMoreInteractions(mockListener);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     public void handleUserConfirmationDoNotSend() throws JSONException {
         mockStatic(ErrorLogHelper.class);
@@ -1129,16 +1133,16 @@ public class CrashesTest extends AbstractCrashesTest {
     private ManagedErrorLog testNativeCrashLog(long appStartTime, long crashTime, boolean correlateSession, boolean hasDeviceInfo) throws Exception {
 
         /* Create minidump sub-folder. */
-        File minidumpSubfolder = new File("./mockFolder");
+        File minidumpSubfolder = mTemporaryFolder.newFolder("mockFolder");
         minidumpSubfolder.mkdir();
 
         /* Create a file for a crash in disk. */
-        File minidumpFile = new File("./mockFolder/mockFile.dmp");
+        File minidumpFile = new File(minidumpSubfolder, "mockFile.dmp");
         minidumpFile.createNewFile();
         minidumpFile.setLastModified(crashTime);
 
         /* Create an additional file in a folder to be filtered later */
-        File otherFile = new File("./mockFolder/otherFile.txt");
+        File otherFile = new File(minidumpSubfolder, "otherFile.txt");
         long fakeCrashTime = new Date().getTime();
         otherFile.createNewFile();
         otherFile.setLastModified(fakeCrashTime);
@@ -1196,9 +1200,6 @@ public class CrashesTest extends AbstractCrashesTest {
         assertTrue(log.getValue() instanceof ManagedErrorLog);
         assertEquals(1, log.getAllValues().size());
         assertNotEquals(new Date(fakeCrashTime), log.getValue().getTimestamp());
-
-        /* Clear created files */
-        FileManager.deleteDir(minidumpFile);
         return (ManagedErrorLog) log.getValue();
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -379,7 +379,7 @@ public class ErrorLogHelperTest {
 
         /* Verify clean function was called. */
         verifyStatic();
-        FileManager.cleanDir(ErrorLogHelper.getPendingMinidumpDirectory());
+        FileManager.cleanDirectory(ErrorLogHelper.getPendingMinidumpDirectory());
 
         /* Clean up. */
         ErrorLogHelper.setErrorLogDirectory(null);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -61,7 +61,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -369,51 +368,21 @@ public class ErrorLogHelperTest {
     }
 
     @Test
-    public void cleanDirectory() {
-
+    public void cleanDirectory() throws java.lang.Exception {
         /* Prepare data. */
-        mockStatic(AppCenterLog.class);
-        File pendingFolder = mock(File.class);
-        File mockFile = mock(File.class);
-        when(pendingFolder.isDirectory()).thenReturn(true);
-        when(pendingFolder.listFiles()).thenReturn(new File[] { mockFile });
+        mockStatic(FileManager.class);
+        File errorLogFolder = mTemporaryFolder.newFolder("errorLogFolder");
+        ErrorLogHelper.setErrorLogDirectory(errorLogFolder);
 
-        /* Verify. */
-        ErrorLogHelper.cleanDirectory(pendingFolder);
-        verify(mockFile).delete();
-    }
+        /* Clean pending minidump. */
+        ErrorLogHelper.cleanPendingMinidumps();
 
-    @Test
-    public void cleanDirectoryWhenFileListIsNullOrEmpty() {
+        /* Verify clean function was called. */
+        verifyStatic();
+        FileManager.cleanDir(ErrorLogHelper.getPendingMinidumpDirectory());
 
-        /* Prepare data. */
-        mockStatic(AppCenterLog.class);
-        File pendingFolder = mock(File.class);
-        when(pendingFolder.isDirectory()).thenReturn(true);
-
-        /* Verify when file list is empty. */
-        when(pendingFolder.listFiles()).thenReturn(new File[] {});
-        ErrorLogHelper.cleanDirectory(pendingFolder);
-        verifyStatic(never());
-        AppCenterLog.debug(anyString(), anyString());
-
-        /* Verify when file list is null. */
-        when(pendingFolder.listFiles()).thenReturn(null);
-        ErrorLogHelper.cleanDirectory(pendingFolder);
-        verifyStatic(never());
-        AppCenterLog.debug(anyString(), anyString());
-    }
-
-    @Test
-    public void cleanDirectoryWhenNotDirectory() {
-
-        /* Prepare data. */
-        File pendingFolder = mock(File.class);
-
-        /* Verify when directory is not directory. */
-        when(pendingFolder.isDirectory()).thenReturn(false);
-        ErrorLogHelper.cleanDirectory(pendingFolder);
-        verify(pendingFolder, never()).listFiles();
+        /* Clean up. */
+        ErrorLogHelper.setErrorLogDirectory(null);
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -398,14 +398,14 @@ public class ErrorLogHelperTest {
         AppCenterLog.debug(anyString(), anyString());
 
         /* Verify when file list is null. */
-        when(pendingFolder.listFiles()).thenReturn(new File[] {});
+        when(pendingFolder.listFiles()).thenReturn(null);
         ErrorLogHelper.cleanDirectory(pendingFolder);
         verifyStatic(never());
         AppCenterLog.debug(anyString(), anyString());
     }
 
     @Test
-    public void cleanDirectoryWhenDirectoryIsNullOrNotDirectory() {
+    public void cleanDirectoryWhenNotDirectory() {
 
         /* Prepare data. */
         File pendingFolder = mock(File.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -414,11 +414,6 @@ public class ErrorLogHelperTest {
         when(pendingFolder.isDirectory()).thenReturn(false);
         ErrorLogHelper.cleanDirectory(pendingFolder);
         verify(pendingFolder, never()).listFiles();
-
-        /* Verify when directory is null. */
-        ErrorLogHelper.cleanDirectory(null);
-        verifyStatic(never());
-        AppCenterLog.debug(anyString(), anyString());
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -369,6 +369,7 @@ public class ErrorLogHelperTest {
 
     @Test
     public void cleanDirectory() throws java.lang.Exception {
+
         /* Prepare data. */
         mockStatic(FileManager.class);
         File errorLogFolder = mTemporaryFolder.newFolder("errorLogFolder");

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -245,13 +245,13 @@ public class FileManager {
     /**
      * Delete all files inside this directory, without deleting directory itself.
      *
-     * @param file The directory to delete.
+     * @param directory The directory to delete.
      */
-    public static void cleanDir(@NonNull File file) {
-        File[] contents = file.listFiles();
+    public static void cleanDir(@NonNull File directory) {
+        File[] contents = directory.listFiles();
         if (contents != null) {
-            for (File f : contents) {
-                deleteDir(f);
+            for (File file : contents) {
+                deleteDir(file);
             }
         }
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -232,7 +232,7 @@ public class FileManager {
      * @param file The file or directory to delete.
      * @return {@code true} if it was deleted, {@code false} otherwise.
      */
-    public static boolean deleteDir(File file) {
+    public static boolean deleteDir(@NonNull File file) {
         File[] contents = file.listFiles();
         if (contents != null) {
             for (File f : contents) {
@@ -240,6 +240,20 @@ public class FileManager {
             }
         }
         return file.delete();
+    }
+
+    /**
+     * Delete all files inside this directory, without deleting directory itself.
+     *
+     * @param file The directory to delete.
+     */
+    public static void cleanDir(@NonNull File file) {
+        File[] contents = file.listFiles();
+        if (contents != null) {
+            for (File f : contents) {
+                deleteDir(f);
+            }
+        }
     }
 
     /**

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/storage/FileManager.java
@@ -232,11 +232,11 @@ public class FileManager {
      * @param file The file or directory to delete.
      * @return {@code true} if it was deleted, {@code false} otherwise.
      */
-    public static boolean deleteDir(@NonNull File file) {
+    public static boolean deleteDirectory(@NonNull File file) {
         File[] contents = file.listFiles();
         if (contents != null) {
             for (File f : contents) {
-                deleteDir(f);
+                deleteDirectory(f);
             }
         }
         return file.delete();
@@ -247,11 +247,11 @@ public class FileManager {
      *
      * @param directory The directory to delete.
      */
-    public static void cleanDir(@NonNull File directory) {
+    public static void cleanDirectory(@NonNull File directory) {
         File[] contents = directory.listFiles();
         if (contents != null) {
             for (File file : contents) {
-                deleteDir(file);
+                deleteDirectory(file);
             }
         }
     }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -172,12 +172,12 @@ public class FileManagerTest {
         assertTrue(folder.exists());
 
         /* Remove directory. */
-        FileManager.deleteDir(folder);
+        FileManager.deleteDirectory(folder);
 
         /* Verify. */
         assertFalse(folder.exists());
         verifyStatic();
-        FileManager.deleteDir(any(File.class));
+        FileManager.deleteDirectory(any(File.class));
     }
 
     @Test
@@ -197,7 +197,7 @@ public class FileManagerTest {
         assertTrue(file2.exists());
 
         /* Remove directory. */
-        FileManager.deleteDir(folder);
+        FileManager.deleteDirectory(folder);
 
         assertFalse(file2.exists());
         assertFalse(file1.exists());
@@ -206,11 +206,11 @@ public class FileManagerTest {
 
         /* Verify. */
         verifyStatic(times(4));
-        FileManager.deleteDir(any(File.class));
+        FileManager.deleteDirectory(any(File.class));
     }
 
     @Test
-    public void cleanDir() throws IOException {
+    public void cleanDirectory() throws IOException {
 
         /* Prepare data. */
         File folder = mTemporaryFolder.newFolder();
@@ -222,7 +222,7 @@ public class FileManagerTest {
         assertTrue(file2.exists());
 
         /* Clean directory. */
-        FileManager.cleanDir(folder);
+        FileManager.cleanDirectory(folder);
 
         /* Verify. */
         assertFalse(file2.exists());
@@ -231,7 +231,7 @@ public class FileManagerTest {
     }
 
     @Test
-    public void cleanDirWhenNotDirectory() throws IOException {
+    public void cleanDirectoryWhenNotDirectory() throws IOException {
 
         /* Prepare data. */
         File folder = mTemporaryFolder.newFolder();
@@ -240,6 +240,6 @@ public class FileManagerTest {
         assertTrue(file1.exists());
 
         /* Verify when directory is not directory, that no crashes happen */
-        FileManager.cleanDir(file1);
+        FileManager.cleanDirectory(file1);
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/storage/FileManagerTest.java
@@ -208,4 +208,38 @@ public class FileManagerTest {
         verifyStatic(times(4));
         FileManager.deleteDir(any(File.class));
     }
+
+    @Test
+    public void cleanDir() throws IOException {
+
+        /* Prepare data. */
+        File folder = mTemporaryFolder.newFolder();
+        File file1 = new File(folder, "file1");
+        assertTrue(file1.createNewFile());
+        assertTrue(file1.exists());
+        File file2 = new File(folder, "file2");
+        assertTrue(file2.createNewFile());
+        assertTrue(file2.exists());
+
+        /* Clean directory. */
+        FileManager.cleanDir(folder);
+
+        /* Verify. */
+        assertFalse(file2.exists());
+        assertFalse(file1.exists());
+        assertTrue(folder.exists());
+    }
+
+    @Test
+    public void cleanDirWhenNotDirectory() throws IOException {
+
+        /* Prepare data. */
+        File folder = mTemporaryFolder.newFolder();
+        File file1 = new File(folder, "file1");
+        assertTrue(file1.createNewFile());
+        assertTrue(file1.exists());
+
+        /* Verify when directory is not directory, that no crashes happen */
+        FileManager.cleanDir(file1);
+    }
 }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Change filter of minidump files fro NDK crash dumps, in the way that only "*.dmp" files can pass. Also clear directory with minidumps files after processing those files. 

Modify time while testing crash to be in seconds instead of milliseconds, because setLastModified do not work correctly with milliseconds, and also when the equal check fails between two dates differs only in milliseconds, it is hard to find a reason, because Date not show milliseconds in string

## Related PRs or issues

[AB#78588](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78588)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
