### PR TITLE
Fix LifecycleListener when SDK started after onCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.2.1 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Fix checking updates when application switches from background to foreground if the SDK was started after `onCreate` callback.
+
 ___
 
 ## Version 3.2.0

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
@@ -141,8 +141,10 @@ public class ApplicationLifecycleListener implements ActivityLifecycleCallbacks 
 
     @Override
     public void onActivityPaused(@NonNull Activity activity) {
-        if (mResumedCounter == 0) {
+        if (mStartedCounter == 0 && mStopSent) {
             mStopSent = false;
+        }
+        if (mResumedCounter == 0 && mPauseSent) {
             mPauseSent = false;
         }
         mResumedCounter = max(mResumedCounter - 1, 0);
@@ -154,7 +156,6 @@ public class ApplicationLifecycleListener implements ActivityLifecycleCallbacks 
              * ApplicationLifecycleListener won't send any events if activities are destroyed
              * and recreated due to a configuration change.
              */
-            mHandler.removeCallbacks(mDelayedPauseRunnable);
             mHandler.postDelayed(mDelayedPauseRunnable, TIMEOUT_MS);
         }
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
@@ -141,6 +141,11 @@ public class ApplicationLifecycleListener implements ActivityLifecycleCallbacks 
 
     @Override
     public void onActivityPaused(@NonNull Activity activity) {
+
+        /*
+         * If the SDK starts from onStart or onResume, the first onActivityStarted/onActivityResumed isn't called.
+         * This breaks the flags logic and we need to restore their state.
+         */
         if (mStartedCounter == 0 && mStopSent) {
             mStopSent = false;
         }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
@@ -146,7 +146,7 @@ public class ApplicationLifecycleListener implements ActivityLifecycleCallbacks 
          * If the SDK starts from onStart or onResume, the first onActivityStarted/onActivityResumed isn't called.
          * This breaks the flags logic and we need to restore their state.
          */
-        if (mStartedCounter == 0 && mStopSent) {
+        if (mStartedCounter == 0) {
             mStopSent = false;
         }
         if (mResumedCounter == 0) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/ApplicationLifecycleListener.java
@@ -149,7 +149,7 @@ public class ApplicationLifecycleListener implements ActivityLifecycleCallbacks 
         if (mStartedCounter == 0 && mStopSent) {
             mStopSent = false;
         }
-        if (mResumedCounter == 0 && mPauseSent) {
+        if (mResumedCounter == 0) {
             mPauseSent = false;
         }
         mResumedCounter = max(mResumedCounter - 1, 0);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
@@ -297,7 +297,6 @@ public class ApplicationLifecycleListenerTest {
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
         verify(callbacks).onApplicationEnterForeground();
-        verify(callbacks).onApplicationEnterForeground();
 
         /* Call onActivityResumed. */
         mApplicationLifecycleListener.onActivityResumed(mActivityMock);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
@@ -262,7 +262,7 @@ public class ApplicationLifecycleListenerTest {
 
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
-        verify(callbacks1, times(1)).onApplicationEnterForeground();
+        verify(callbacks1).onApplicationEnterForeground();
 
         /* Go to another activity. */
         mApplicationLifecycleListener.onActivityPaused(mActivityMock);
@@ -270,7 +270,7 @@ public class ApplicationLifecycleListenerTest {
         mApplicationLifecycleListener.onActivityResumed(secondActivityMock);
 
         /* Verify that onApplicationEnterForeground was called once. */
-        verify(callbacks1, times(1)).onApplicationEnterForeground();
+        verify(callbacks1).onApplicationEnterForeground();
     }
 
     @Test
@@ -296,6 +296,6 @@ public class ApplicationLifecycleListenerTest {
 
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
-        verify(callbacks, times(1)).onApplicationEnterForeground();
+        verify(callbacks).onApplicationEnterForeground();
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
@@ -14,13 +14,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -41,13 +38,6 @@ public class ApplicationLifecycleListenerTest {
     @Before
     public void setUp() {
         mApplicationLifecycleListener = new ApplicationLifecycleListener(mHandlerMock);
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-                return null;
-            }
-        }).when(mHandlerMock).postDelayed(any(Runnable.class), anyLong());
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/ApplicationLifecycleListenerTest.java
@@ -18,15 +18,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import java.util.Timer;
-import java.util.TimerTask;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -49,7 +45,6 @@ public class ApplicationLifecycleListenerTest {
 
             @Override
             public Void answer(InvocationOnMock invocation) {
-                ((Runnable) invocation.getArguments()[0]).run();
                 return null;
             }
         }).when(mHandlerMock).postDelayed(any(Runnable.class), anyLong());
@@ -61,9 +56,6 @@ public class ApplicationLifecycleListenerTest {
         /* Prepare data. */
         ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
         mApplicationLifecycleListener.registerApplicationLifecycleCallbacks(callbacks);
-
-        /* Do nothing and trigger manually captured runnable later to ensure that application resumes first. */
-        reset(mHandlerMock);
 
         /* Call onActivityResumed. */
         mApplicationLifecycleListener.onActivityResumed(mActivityMock);
@@ -86,8 +78,10 @@ public class ApplicationLifecycleListenerTest {
         mApplicationLifecycleListener.onActivityResumed(mActivityMock);
         verify(mHandlerMock).removeCallbacks(any(Runnable.class));
 
-        /* Verify that enter background callback won't call after the delay. */
+        /* Runnable from onActivityPaused is called after the timeout. */
         postDelayed.getValue().run();
+
+        /* Verify that enter background callback won't call after the delay. */
         verify(callbacks, never()).onApplicationEnterBackground();
     }
 
@@ -168,14 +162,20 @@ public class ApplicationLifecycleListenerTest {
         /* Call onActivityResumed. */
         mApplicationLifecycleListener.onActivityResumed(mActivityMock);
         verify(mHandlerMock, never()).removeCallbacks(any(Runnable.class));
-        mApplicationLifecycleListener.onActivitySaveInstanceState(mActivityMock, mockBundle);
 
         /* Call onActivityPaused. */
         mApplicationLifecycleListener.onActivityPaused(mActivityMock);
-        verify(mHandlerMock).postDelayed(any(Runnable.class), anyLong());
+        ArgumentCaptor<Runnable> postDelayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        verify(mHandlerMock).postDelayed(postDelayedRunnable.capture(), anyLong());
 
         /* Call onActivityStopped. */
         mApplicationLifecycleListener.onActivityStopped(mActivityMock);
+        mApplicationLifecycleListener.onActivitySaveInstanceState(mActivityMock, mockBundle);
+
+        /* Runnable from onActivityPaused is called after the timeout. */
+        postDelayedRunnable.getValue().run();
+
+        /* Verify background callbacks called once. */
         verify(callbacks1).onApplicationEnterBackground();
         verify(callbacks2).onApplicationEnterBackground();
 
@@ -184,6 +184,16 @@ public class ApplicationLifecycleListenerTest {
 
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
+
+        /* Call onActivityResumed. */
+        mApplicationLifecycleListener.onActivityResumed(mActivityMock);
+        verify(mHandlerMock, never()).removeCallbacks(any(Runnable.class));
+
+        /* Verify background callbacks still were called once. */
+        verify(callbacks1).onApplicationEnterBackground();
+        verify(callbacks2).onApplicationEnterBackground();
+
+        /* Verify foreground callbacks were called twice. */
         verify(callbacks1, times(2)).onApplicationEnterForeground();
         verify(callbacks2, times(2)).onApplicationEnterForeground();
     }
@@ -194,10 +204,6 @@ public class ApplicationLifecycleListenerTest {
         /* Prepare data. */
         Activity anotherActivityMock = mock(Activity.class);
         Bundle mockBundle = mock(Bundle.class);
-
-        /* Do nothing and trigger manually captured runnable later to ensure that application resumes first. */
-        reset(mHandlerMock);
-
         ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks1 = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
         ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks2 = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
         mApplicationLifecycleListener.registerApplicationLifecycleCallbacks(callbacks1);
@@ -224,78 +230,91 @@ public class ApplicationLifecycleListenerTest {
         mApplicationLifecycleListener.onActivityStarted(anotherActivityMock);
         mApplicationLifecycleListener.onActivityResumed(anotherActivityMock);
 
+        /* Verify the runnable was removed in onActivityResumed. */
+        verify(mHandlerMock).removeCallbacks(any(Runnable.class));
+
+        /* Call onActivityStopped. */
+        mApplicationLifecycleListener.onActivityStopped(mActivityMock);
+
         /* Verify that delayed callback doesn't trigger enter background callbacks. */
         postDelayed.getValue().run();
         verify(callbacks1, never()).onApplicationEnterBackground();
         verify(callbacks2, never()).onApplicationEnterBackground();
-
-        /* Call onActivityStopped. */
-        mApplicationLifecycleListener.onActivityStopped(mActivityMock);
 
         /* Verify the callback was not called if we transition to another activity inside the app. */
         verifyNoMoreInteractions(callbacks1, callbacks2);
     }
 
     @Test
-    public void skipCallOnStart() {
+    public void skipCallOnStartOpenFoldOpen() {
 
         /* Prepare data. */
-        Activity secondActivityMock = mock(Activity.class);
-        Bundle mockBundle = mock(Bundle.class);
-        ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks1 = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
-        mApplicationLifecycleListener.registerApplicationLifecycleCallbacks(callbacks1);
+        ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
+        mApplicationLifecycleListener.registerApplicationLifecycleCallbacks(callbacks);
 
         /* Skip call onActivityStarted. */
 
         /* Call onActivityResumed. */
         mApplicationLifecycleListener.onActivityResumed(mActivityMock);
         verify(mHandlerMock, never()).removeCallbacks(any(Runnable.class));
-        mApplicationLifecycleListener.onActivitySaveInstanceState(mActivityMock, mockBundle);
 
         /* Call onActivityPaused. */
         mApplicationLifecycleListener.onActivityPaused(mActivityMock);
-        verify(mHandlerMock).postDelayed(any(Runnable.class), anyLong());
+        ArgumentCaptor<Runnable> postDelayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        verify(mHandlerMock).postDelayed(postDelayedRunnable.capture(), anyLong());
 
         /* Call onActivityStopped. */
         mApplicationLifecycleListener.onActivityStopped(mActivityMock);
-        verify(callbacks1, times(2)).onApplicationEnterBackground();
+
+        /* Runnable from onActivityPaused is called after the timeout. */
+        postDelayedRunnable.getValue().run();
+
+        /* Verify onApplicationEnterBackground was called only once. */
+        verify(callbacks).onApplicationEnterBackground();
 
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
-        verify(callbacks1).onApplicationEnterForeground();
+        verify(callbacks).onApplicationEnterForeground();
 
-        /* Go to another activity. */
-        mApplicationLifecycleListener.onActivityPaused(mActivityMock);
-        mApplicationLifecycleListener.onActivityStarted(secondActivityMock);
-        mApplicationLifecycleListener.onActivityResumed(secondActivityMock);
-
-        /* Verify that onApplicationEnterForeground was called once. */
-        verify(callbacks1).onApplicationEnterForeground();
+        /* Call onActivityResumed. */
+        mApplicationLifecycleListener.onActivityResumed(mActivityMock);
+        verify(mHandlerMock, never()).removeCallbacks(any(Runnable.class));
     }
 
     @Test
-    public void skipCallOnResume() {
+    public void skipCallOnResumeOpenFoldOpen() {
 
         /* Prepare data. */
-        Bundle mockBundle = mock(Bundle.class);
         ApplicationLifecycleListener.ApplicationLifecycleCallbacks callbacks = mock(ApplicationLifecycleListener.ApplicationLifecycleCallbacks.class);
         mApplicationLifecycleListener.registerApplicationLifecycleCallbacks(callbacks);
 
         /* Skip call onActivityStarted and onActivityResume. */
 
-        /* Call onActivityResumed. */
-        mApplicationLifecycleListener.onActivitySaveInstanceState(mActivityMock, mockBundle);
-
         /* Call onActivityPaused. */
         mApplicationLifecycleListener.onActivityPaused(mActivityMock);
-        verify(mHandlerMock).postDelayed(any(Runnable.class), anyLong());
+        ArgumentCaptor<Runnable> postDelayedRunnable = ArgumentCaptor.forClass(Runnable.class);
+        verify(mHandlerMock).postDelayed(postDelayedRunnable.capture(), anyLong());
 
         /* Call onActivityStopped. */
         mApplicationLifecycleListener.onActivityStopped(mActivityMock);
-        verify(callbacks, times(2)).onApplicationEnterBackground();
+
+        /* Runnable for onActivityPaused is called after the timeout. */
+        postDelayedRunnable.getValue().run();
+
+        /* Verify onApplicationEnterBackground called. */
+        verify(callbacks).onApplicationEnterBackground();
 
         /* Call onActivityStarted. */
         mApplicationLifecycleListener.onActivityStarted(mActivityMock);
+        verify(callbacks).onApplicationEnterForeground();
+        verify(callbacks).onApplicationEnterForeground();
+
+        /* Call onActivityResumed. */
+        mApplicationLifecycleListener.onActivityResumed(mActivityMock);
+        verify(mHandlerMock, never()).removeCallbacks(any(Runnable.class));
+
+        /* Verify the callbacks were called only once. */
+        verify(callbacks).onApplicationEnterBackground();
         verify(callbacks).onApplicationEnterForeground();
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

[AB#79328](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/79328)