### PR TITLE
Remove sync from UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.2.2 (Under development)
 
+### App Center
+
+* **[Fix]** Fix possible delays in UI thread when queueing a large number of events.
+
 ___
 
 ## Version 3.2.1

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/Analytics.java
@@ -632,6 +632,7 @@ public class Analytics extends AbstractAppCenterService {
      *
      * @param activity current activity.
      */
+    @WorkerThread
     private void processOnResume(Activity activity) {
         if (mSessionTracker != null) {
             mSessionTracker.onActivityResumed();

--- a/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/channel/SessionTracker.java
+++ b/sdk/appcenter-analytics/src/main/java/com/microsoft/appcenter/analytics/channel/SessionTracker.java
@@ -7,6 +7,7 @@ package com.microsoft.appcenter.analytics.channel;
 
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.Flags;
 import com.microsoft.appcenter.analytics.Analytics;
@@ -118,6 +119,7 @@ public class SessionTracker extends AbstractChannelListener {
      * the session even when no pages are triggered but at the same time we want to keep using
      * the same session as long as the current activity is not paused (long video for example).
      */
+    @WorkerThread
     private void sendStartSessionIfNeeded() {
         if (mSid == null || hasSessionTimedOut()) {
 
@@ -143,6 +145,7 @@ public class SessionTracker extends AbstractChannelListener {
     /**
      * Call this whenever an activity is resumed to update session tracker state.
      */
+    @WorkerThread
     public void onActivityResumed() {
 
         /* Record resume time for session timeout management. */
@@ -154,6 +157,7 @@ public class SessionTracker extends AbstractChannelListener {
     /**
      * Call this whenever an activity is paused to update session tracker state.
      */
+    @WorkerThread
     public void onActivityPaused() {
 
         /* Record pause time for session timeout management. */

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1128,20 +1128,12 @@ public class Distribute extends AbstractAppCenterService {
 
             @Override
             public void onCallSucceeded(final HttpResponse httpResponse) {
-
-                /* onPostExecute is not always called on UI thread due to an old Android bug. */
-                HandlerUtils.runOnUiThread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            String payload = httpResponse.getPayload();
-                            handleApiCallSuccess(releaseCallId, payload, ReleaseDetails.parse(payload), distributionGroupId);
-                        } catch (JSONException e) {
-                            onCallFailed(e);
-                        }
-                    }
-                });
+                try {
+                    String payload = httpResponse.getPayload();
+                    handleApiCallSuccess(releaseCallId, payload, ReleaseDetails.parse(payload), distributionGroupId);
+                } catch (JSONException e) {
+                    onCallFailed(e);
+                }
             }
 
             @Override

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -9,6 +9,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
 
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
@@ -136,6 +137,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
         return SharedPreferencesManager.getBoolean(getEnabledPreferenceKey(), true);
     }
 
+    @WorkerThread
     @Override
     public synchronized void setInstanceEnabled(boolean enabled) {
 
@@ -173,6 +175,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
         }
     }
 
+    @WorkerThread
     protected synchronized void applyEnabledState(boolean enabled) {
 
         /* Optional callback to react to enabled state change. */
@@ -193,6 +196,7 @@ public abstract class AbstractAppCenterService implements AppCenterService {
         mHandler = handler;
     }
 
+    @WorkerThread
     @Override
     public synchronized void onStarted(@NonNull Context context, @NonNull Channel channel, String appSecret, String transmissionTargetToken, boolean startedFromApp) {
         String groupName = getGroupName();

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -840,6 +840,7 @@ public class AppCenter {
         AppCenterLog.debug(LOG_TAG, "App Center initialized.");
     }
 
+    @WorkerThread
     private void applyStorageMaxSize() {
         boolean resizeResult = mChannel.setMaxStorageSize(mMaxStorageSizeInBytes);
         if (mSetMaxStorageSizeFuture != null) {

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -496,27 +496,7 @@ public class DefaultChannel implements Channel {
 
         /* Remember this batch. */
         groupState.mSendingBatches.put(batchId, batch);
-
-        /*
-         * Due to bug on old Android versions (verified on 4.0.4),
-         * if we start an async task from here, i.e. the async handler thread,
-         * we end up with AsyncTask configured with the wrong Handler to use for onPostExecute
-         * instead of using main thread as advertised in Javadoc (and its a static field there).
-         *
-         * Our SDK guards against an application that would make a first async task in non UI
-         * thread before SDK is initialized, but we should also avoid corrupting AsyncTask
-         * with our wrong handler to avoid creating bugs in the application code since we are
-         * a library.
-         *
-         * So make sure we execute the async task from UI thread to avoid any issue.
-         */
-        HandlerUtils.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                sendLogs(groupState, stateSnapshot, batch, batchId);
-            }
-        });
+        sendLogs(groupState, stateSnapshot, batch, batchId);
     }
 
     /**


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you ~add~ remove unit tests?
* [ ] ~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

During the testing I found that the line with `sendLogs` call can take up to 300-400ms (!), that unacceptable for UI thread. So, I've marked this issue as a bug.
This happens because of call synchronized method (`sendLogs` and status check).

## Related PRs or issues

#374, #1421
[AB#81136](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81136)
