### PR TITLE
Fix IncorrectContextUsage warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.2.3 (Under development)
 
+### App Center
+
+* **[Fix]** Fix an `IncorrectContextUseViolation` warning when calculating screen size on Android 11.
+
 ___
 
 ## Version 3.2.2

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
@@ -10,9 +10,11 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Point;
+import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
+import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
@@ -67,8 +69,6 @@ public class DeviceInfoHelper {
         /* Carrier info. */
         try {
             TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-
-            @SuppressWarnings("ConstantConditions")
             String networkCountryIso = telephonyManager.getNetworkCountryIso();
             if (!TextUtils.isEmpty(networkCountryIso)) {
                 device.setCarrierCountry(networkCountryIso);
@@ -147,12 +147,23 @@ public class DeviceInfoHelper {
         /* Guess resolution based on the natural device orientation */
         int screenWidth;
         int screenHeight;
-
-        //noinspection ConstantConditions
-        Display defaultDisplay = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE))
-                .getDefaultDisplay();
+        Display defaultDisplay;
         Point size = new Point();
-        defaultDisplay.getSize(size);
+
+        /* Use DeviceManager to avoid android.os.strictmode.IncorrectContextUseViolation when StrictMode is enabled on API 30. */
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+            DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+            defaultDisplay = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+            size.x = displayMetrics.widthPixels;
+            size.y = displayMetrics.heightPixels;
+        } else {
+            //noinspection deprecation
+            defaultDisplay = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE))
+                    .getDefaultDisplay();
+            //noinspection deprecation
+            defaultDisplay.getSize(size);
+        }
         switch (defaultDisplay.getRotation()) {
             case Surface.ROTATION_90:
             case Surface.ROTATION_270:

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/DeviceInfoHelper.java
@@ -152,9 +152,9 @@ public class DeviceInfoHelper {
 
         /* Use DeviceManager to avoid android.os.strictmode.IncorrectContextUseViolation when StrictMode is enabled on API 30. */
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
             DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
             defaultDisplay = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+            DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
             size.x = displayMetrics.widthPixels;
             size.y = displayMetrics.heightPixels;
         } else {

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockito.verification.VerificationMode;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -42,8 +43,10 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -217,6 +220,18 @@ public class DeviceInfoHelperTest {
         /* Remove wrapper SDK information. */
         DeviceInfoHelper.setWrapperSdk(null);
         assertEquals(device, DeviceInfoHelper.getDeviceInfo(contextMock));
+
+        /* Verify the right API was called to get a screen size. */
+        VerificationMode calledIn17Api = osApiLevel >= 17 ? atLeastOnce() : never();
+        VerificationMode calledIn16Api = osApiLevel < 17 ? atLeastOnce() : never();
+        verify(contextMock, calledIn17Api).getSystemService(eq(Context.DISPLAY_SERVICE));
+        verify(contextMock, calledIn17Api).getResources();
+        verify(resourcesMock, calledIn17Api).getDisplayMetrics();
+        //noinspection deprecation
+        verify(displayMock, calledIn16Api).getSize(any(Point.class));
+        verify(contextMock, calledIn16Api).getSystemService(eq(Context.WINDOW_SERVICE));
+        //noinspection deprecation
+        verify(windowManagerMock, calledIn16Api).getDefaultDisplay();
     }
 
     @Test(expected = DeviceInfoHelper.DeviceInfoException.class)

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
@@ -138,10 +138,12 @@ public class DeviceInfoHelperTest {
         when(mWindowManager.getDefaultDisplay()).thenReturn(mDisplay);
         //noinspection deprecation
         doAnswer(new Answer<Void>() {
+
             @Override
             public Void answer(InvocationOnMock invocationOnMock) {
+
+                /* Do not call set method and assign values directly to variables. */
                 Object[] args = invocationOnMock.getArguments();
-                /* DO NOT call set method and assign values directly to variables. */
                 ((Point) args[0]).x = SCREEN_WIDTH;
                 ((Point) args[0]).y = SCREEN_HEIGHT;
                 return null;

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/DeviceInfoHelperTest.java
@@ -8,10 +8,13 @@ package com.microsoft.appcenter.utils;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.graphics.Point;
+import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
+import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
@@ -60,7 +63,16 @@ public class DeviceInfoHelperTest {
     }
 
     @Test
-    public void getDeviceInfo() throws PackageManager.NameNotFoundException, DeviceInfoHelper.DeviceInfoException {
+    public void getDeviceInfoApi17() throws PackageManager.NameNotFoundException, DeviceInfoHelper.DeviceInfoException {
+        getDeviceInfo(17);
+    }
+
+    @Test
+    public void getDeviceInfoApi16() throws PackageManager.NameNotFoundException, DeviceInfoHelper.DeviceInfoException {
+        getDeviceInfo(16);
+    }
+
+    public void getDeviceInfo(Integer osApiLevel) throws PackageManager.NameNotFoundException, DeviceInfoHelper.DeviceInfoException {
 
         /* Mock data. */
         final String appVersion = "1.0";
@@ -71,12 +83,13 @@ public class DeviceInfoHelperTest {
         final Locale locale = Locale.KOREA;
         final String model = "mock-model";
         final String oemName = "mock-manufacture";
-        final Integer osApiLevel = 23;
         final String osName = "Android";
         final String osVersion = "mock-version";
         final String osBuild = "mock-os-build";
         final String screenSizeLandscape = "100x200";
         final String screenSizePortrait = "200x100";
+        final int screenWidth = 100;
+        final int screenHeight = 200;
         final TimeZone timeZone = TimeZone.getTimeZone("KST");
         final Integer timeZoneOffset = timeZone.getOffset(System.currentTimeMillis());
 
@@ -88,8 +101,11 @@ public class DeviceInfoHelperTest {
         PackageManager packageManagerMock = mock(PackageManager.class);
         PackageInfo packageInfoMock = mock(PackageInfo.class);
         WindowManager windowManagerMock = mock(WindowManager.class);
+        DisplayManager displayManagerMock = mock(DisplayManager.class);
+        Resources resourcesMock = mock(Resources.class);
         TelephonyManager telephonyManagerMock = mock(TelephonyManager.class);
         Display displayMock = mock(Display.class);
+        DisplayMetrics displayMetricsMock = mock(DisplayMetrics.class);
 
         /* Delegates to mock instances. */
         when(contextMock.getPackageName()).thenReturn(appNamespace);
@@ -99,18 +115,29 @@ public class DeviceInfoHelperTest {
         //noinspection WrongConstant
         when(contextMock.getSystemService(eq(Context.WINDOW_SERVICE))).thenReturn(windowManagerMock);
         //noinspection WrongConstant
+        when(contextMock.getSystemService(eq(Context.DISPLAY_SERVICE))).thenReturn(displayManagerMock);
+        when(displayManagerMock.getDisplay(anyInt())).thenReturn(displayMock);
+        //noinspection WrongConstant
+        when(contextMock.getResources()).thenReturn(resourcesMock);
+        //noinspection WrongConstant
+        when(resourcesMock.getDisplayMetrics()).thenReturn(displayMetricsMock);
+        displayMetricsMock.widthPixels = screenWidth;
+        displayMetricsMock.heightPixels = screenHeight;
+        //noinspection WrongConstant
         when(packageManagerMock.getPackageInfo(anyString(), eq(0))).thenReturn(packageInfoMock);
         when(telephonyManagerMock.getNetworkCountryIso()).thenReturn(carrierCountry);
         when(telephonyManagerMock.getNetworkOperatorName()).thenReturn(carrierName);
+        //noinspection deprecation
         when(windowManagerMock.getDefaultDisplay()).thenReturn(displayMock);
         when(displayMock.getRotation()).thenReturn(Surface.ROTATION_0, Surface.ROTATION_90, Surface.ROTATION_180, Surface.ROTATION_270);
+        //noinspection deprecation
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocationOnMock) {
                 Object[] args = invocationOnMock.getArguments();
                 /* DO NOT call set method and assign values directly to variables. */
-                ((Point) args[0]).x = 100;
-                ((Point) args[0]).y = 200;
+                ((Point) args[0]).x = screenWidth;
+                ((Point) args[0]).y = screenHeight;
                 return null;
             }
         }).when(displayMock).getSize(any(Point.class));
@@ -222,6 +249,7 @@ public class DeviceInfoHelperTest {
         when(contextMock.getSystemService(Context.WINDOW_SERVICE)).thenReturn(windowManagerMock);
         //noinspection WrongConstant
         when(packageManagerMock.getPackageInfo(anyString(), anyInt())).thenReturn(mock(PackageInfo.class));
+        //noinspection deprecation
         when(windowManagerMock.getDefaultDisplay()).thenReturn(mock(Display.class));
 
         /* Verify. */

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@ ext {
     versionCode = 58
     versionName = '3.2.3'
     minSdkVersion = 16
-    targetSdkVersion = 29
-    compileSdkVersion = 29
+    targetSdkVersion = 30
+    compileSdkVersion = 30
     supportLibVersion = '28.0.0'
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@ ext {
     versionCode = 58
     versionName = '3.2.3'
     minSdkVersion = 16
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 29
+    compileSdkVersion = 29
     supportLibVersion = '28.0.0'
 }


### PR DESCRIPTION
Fix deprecated methods usage, update compile and target sdk versions, update tests.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix an `IncorrectContextUseViolation` warning when accessing a WindowManager from an Application context on Android 11 in StrictMode.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-android/issues/1427/
[AB#81390](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/IvanM-Team/Backlog%20Items/?workitem=81390)
