### PR TITLE
Add a script that uses latest CI NDK version

### DIFF
--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -3,15 +3,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-function get_property() {
-   cat $PROPERTY_FILE | sed 's/ //g' | grep "$1" | cut -d'=' -f2
-}
-
 PROJECT_DIR="$(dirname "$0")/.."
-PROPERTY_FILE="$HOME/Library/Android/sdk/ndk-bundle/source.properties"
+PROPERTY_FILE="$ANDROID_HOME/ndk-bundle/source.properties"
 
 echo "Reading ndk version from source.properties file..."
-VERSION=$(get_property "Pkg.Revision")
+VERSION=$(cat $PROPERTY_FILE | sed 's/ //g' | grep "Pkg.Revision" | cut -d'=' -f2)
 echo $VERSION
 GRADLE_FILE="$PROJECT_DIR/apps/sasquatch/build.gradle"
 

--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -6,6 +6,7 @@ function getProperty {
    PROP_VALUE=`cat $PROPERTY_FILE | sed 's/ //g' | grep "$PROP_KEY" | cut -d'=' -f2`
    echo $PROP_VALUE
 }
+
 PROJECT_DIR="$(dirname "$0")/.."
 PROPERTY_FILE="$HOME/Library/Android/sdk/ndk-bundle/source.properties"
 
@@ -17,7 +18,8 @@ GRADLE_FILE="$PROJECT_DIR/apps/sasquatch/build.gradle"
 if [ -z $VERSION ]; then
   echo "No NDK found in the default location. Proceeding..."
 else
+
+  # Insert ndkVersion = 'x.x.x' in the android section.
   NDK_VERSION_LINE="ndkVersion = '$VERSION'"
-  #sed -a '' 's/\(android { \).*/\1'$NDK_VERSION_LINE'/g' $file
   echo "$(sed "s/android {/android { \\`echo -e '\n\r\t'` $NDK_VERSION_LINE/g" "$GRADLE_FILE")" > $GRADLE_FILE
 fi

--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-function get_property {
-   echo `cat $PROPERTY_FILE | sed 's/ //g' | grep "$1" | cut -d'=' -f2`
+function get_property() {
+   cat $PROPERTY_FILE | sed 's/ //g' | grep "$1" | cut -d'=' -f2
 }
 
 PROJECT_DIR="$(dirname "$0")/.."

--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+function getProperty {
+   PROP_KEY=$1
+   PROP_VALUE=`cat $PROPERTY_FILE | sed 's/ //g' | grep "$PROP_KEY" | cut -d'=' -f2`
+   echo $PROP_VALUE
+}
+PROJECT_DIR="$(dirname "$0")/.."
+PROPERTY_FILE="$HOME/Library/Android/sdk/ndk-bundle/source.properties"
+
+echo "Reading ndk version from source.properties file..."
+VERSION=$(getProperty "Pkg.Revision")
+echo $VERSION
+GRADLE_FILE="$PROJECT_DIR/apps/sasquatch/build.gradle"
+
+if [ -z $VERSION ]; then
+  echo "No NDK found in the default location. Proceeding..."
+else
+  NDK_VERSION_LINE="ndkVersion = '$VERSION'"
+  #sed -a '' 's/\(android { \).*/\1'$NDK_VERSION_LINE'/g' $file
+  echo "$(sed "s/android {/android { \\`echo -e '\n\r\t'` $NDK_VERSION_LINE/g" "$GRADLE_FILE")" > $GRADLE_FILE
+fi

--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -1,17 +1,15 @@
-#!/bin/bash
-set -e
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
-function getProperty {
-   PROP_KEY=$1
-   PROP_VALUE=`cat $PROPERTY_FILE | sed 's/ //g' | grep "$PROP_KEY" | cut -d'=' -f2`
-   echo $PROP_VALUE
+function get_property {
+   echo `cat $PROPERTY_FILE | sed 's/ //g' | grep "$1" | cut -d'=' -f2`
 }
 
 PROJECT_DIR="$(dirname "$0")/.."
 PROPERTY_FILE="$HOME/Library/Android/sdk/ndk-bundle/source.properties"
 
 echo "Reading ndk version from source.properties file..."
-VERSION=$(getProperty "Pkg.Revision")
+VERSION=$(get_property "Pkg.Revision")
 echo $VERSION
 GRADLE_FILE="$PROJECT_DIR/apps/sasquatch/build.gradle"
 

--- a/scripts/set-ndk-version.sh
+++ b/scripts/set-ndk-version.sh
@@ -17,5 +17,5 @@ else
 
   # Insert ndkVersion = 'x.x.x' in the android section.
   NDK_VERSION_LINE="ndkVersion = '$VERSION'"
-  echo "$(sed "s/android {/android { \\`echo -e '\n\r\t'` $NDK_VERSION_LINE/g" "$GRADLE_FILE")" > $GRADLE_FILE
+  echo "$(sed "s/android {/android {\\`echo -e '\n\r    '`$NDK_VERSION_LINE/g" "$GRADLE_FILE")" > $GRADLE_FILE
 fi


### PR DESCRIPTION
~* [ ] Has `CHANGELOG.md` been updated?~
~* [ ] Are tests passing locally?~
~* [ ] Did you add unit tests?~
~* [ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [X] Are the files formatted correctly?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Due to [this gradle update](https://developer.android.com/studio/releases/gradle-plugin#default-ndk-version), in case several NDK versions are installed (like [on our CI](https://docs.microsoft.com/en-us/appcenter/build/macos-10.14-software#android-ndks)), it takes the default, not the latest one, so as a result CI uses 18th NDK which breaks the build.

The solution per the documentation is to set the version in gradle: `ndkVersion = '21.3.6528147'`, which we are doing on CI in order not to break local and future builds.

## Related PRs or issues

[AB#82284](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82284)

**NOTE: Don't forget to enable the corresponding task on CI after merging.**