### PR TITLE
Fix send attachments with null parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.3.1 (Under development)
 
+### App Center Crashes
+
+* **[Fix]** Fix sending attachments with a null text value.
+
 ___
 
 ## Version 3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Crashes
 
-* **[Fix]** Fix sending attachments with a null text value.
+* **[Fix]** Fix sending attachments with a `null` text value.
 
 ___
 

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLog.java
@@ -79,6 +79,9 @@ public class ErrorAttachmentLog extends AbstractLog {
      * @return ErrorAttachmentLog built attachment.
      */
     public static ErrorAttachmentLog attachmentWithText(String text, String fileName) {
+        if (text == null) {
+            text = "";
+        }
         return attachmentWithBinary(text.getBytes(CHARSET), fileName, CONTENT_TYPE_TEXT_PLAIN);
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLogTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/ingestion/models/ErrorAttachmentLogTest.java
@@ -31,6 +31,17 @@ public class ErrorAttachmentLogTest {
     }
 
     @Test
+    public void attachmentWithNullText() {
+        String text = null;
+        String fileName = "1";
+        ErrorAttachmentLog attachment = ErrorAttachmentLog.attachmentWithText(text, fileName);
+        assertNotNull(attachment);
+        assertEquals("", new String(attachment.getData(), CHARSET));
+        assertEquals(fileName, attachment.getFileName());
+        assertEquals(ErrorAttachmentLog.CONTENT_TYPE_TEXT_PLAIN, attachment.getContentType());
+    }
+
+    @Test
     public void attachmentWithBinary() {
         byte[] data = "Hello Binary!".getBytes();
         String fileName = "binary.txt";


### PR DESCRIPTION
Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Repo steps:
Call this method after AppCenter start.
`ErrorAttachmentLog.attachmentWithText(null, "text.txt");`

## Related PRs or issues

[AB#82668](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82668)
