### PR TITLE
Browser doesn't open for private distribution groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for Android Change Log
 
+## Version 4.0.1 (Under development)
+
+### App Center Distribute
+
+* **[Fix]** Fix opening browser when use private distribute group on Android 11.
+
+__
+
 ## Version 4.0.0
 
 ### App Center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix browser opening when using a private distribute group on Android 11.
+* **[Fix]** Fix browser opening when using a private distribution group on Android 11.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix opening browser when use private distribute group on Android 11.
+* **[Fix]** Fix browser opening when using a private distribute group on Android 11.
 
 __
 

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
     <!--
-     In Android 11 there were added a lot of updates that improve privacy. Now the list of installed apps on user devices is hidden by default.
+     Android 11 added a lot of improving privacy updates. The list of installed apps on user devices is hidden by default now.
      These changes make available browsers on user devices visible during checking updates for private distribution groups.
      See more about managing package visibility: https://developer.android.com/training/basics/intents/package-visibility
      -->

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
     <!--
-     Android 11 added a lot of improving privacy updates. The list of installed apps on user devices is hidden by default now.
-     These changes make available browsers on user devices visible during checking updates for private distribution groups.
+     Android 11 brings in a lot of changes regarding privacy. By default, list of installed apps is now hidden.
+     Manifest block below make browsers on user devices acessible in order to let SDK check for updates in private update track.
      See more about managing package visibility: https://developer.android.com/training/basics/intents/package-visibility
      -->
     <queries>

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
+    <!--
+     In Android 11 was added a lot of updates that improve privacy. Now a list of installed apps on user devices is hidden by default.
+     These changes need to make available browsers on user devices visible during checking updates for private distribution groups.
+     See more about managing package visibility: https://developer.android.com/training/basics/intents/package-visibility
+     -->
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
     <!--
-     In Android 11 was added a lot of updates that improve privacy. Now a list of installed apps on user devices is hidden by default.
-     These changes need to make available browsers on user devices visible during checking updates for private distribution groups.
+     In Android 11 there were added a lot of updates that improve privacy. Now the list of installed apps on user devices is hidden by default.
+     These changes make available browsers on user devices visible during checking updates for private distribution groups.
      See more about managing package visibility: https://developer.android.com/training/basics/intents/package-visibility
      -->
     <queries>

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -9,16 +9,12 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
-    <!--
-        Do not add the WRITE_EXTERNAL_STORAGE permission with custom attributes to library's manifest file
-        to avoid manifest merging issues. If an application requires this permission for all versions this
-        will lead to silently removing it for versions bigger than 18.
-        It should be added manually by developers to support old Android devices.
-
-        <uses-permission
-            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-            android:maxSdkVersion="18" />
-    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+    </queries>
 
     <application>
         <activity


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Browser doesn't open for private distribution groups on Android 11.

## Related PRs or issues

[AB#83712](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83712)
