### PR TITLE
Remove throwable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.0.1 (Under development)
 
+### App Center Crashes
+
+* **[Fix]** Fix removing throwable files after rewritten error logs due to small database size.
+
 ### App Center Distribute
 
 * **[Fix]** Fix browser opening when using a private distribution group on Android 11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Crashes
 
-* **[Fix]** Fix removing throwable files after rewritten error logs due to small database size.
+* **[Fix]** Fix removing throwable files after rewriting error logs due to small database size.
 
 ### App Center Distribute
 

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/CrashesAndroidTest.java
@@ -347,7 +347,7 @@ public class CrashesAndroidTest {
         verify(uncaughtExceptionHandler).uncaughtException(thread, exception);
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(1, files.length);
         verifyZeroInteractions(crashesListener);
 
         /* Second process: enqueue log but network is down... */
@@ -380,7 +380,7 @@ public class CrashesAndroidTest {
         verify(mChannel, never()).enqueue(isA(ManagedErrorLog.class), anyString(), anyInt());
         files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(1, files.length);
         verify(crashesListener).shouldProcess(any(ErrorReport.class));
         verify(crashesListener).shouldAwaitUserConfirmation();
         verifyNoMoreInteractions(crashesListener);
@@ -394,7 +394,7 @@ public class CrashesAndroidTest {
         assertEquals(mUserId, log.getValue().getUserId());
         files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(1, files.length);
+        assertEquals(0, files.length);
 
         verify(crashesListener).getErrorAttachments(any(ErrorReport.class));
         verifyNoMoreInteractions(crashesListener);
@@ -474,7 +474,7 @@ public class CrashesAndroidTest {
         verify(mChannel, never()).enqueue(isA(ManagedErrorLog.class), anyString(), anyInt());
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(1, files.length);
         verify(crashesListener).shouldProcess(any(ErrorReport.class));
         verify(crashesListener).shouldAwaitUserConfirmation();
         verifyNoMoreInteractions(crashesListener);
@@ -490,7 +490,7 @@ public class CrashesAndroidTest {
         assertNull(managedErrorLog.getValue().getException().getMinidumpFilePath());
         files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(1, files.length);
+        assertEquals(0, files.length);
         verify(crashesListener).getErrorAttachments(any(ErrorReport.class));
         verifyNoMoreInteractions(crashesListener);
 
@@ -533,7 +533,7 @@ public class CrashesAndroidTest {
         verify(uncaughtExceptionHandler).uncaughtException(thread, exception);
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(1, files.length);
 
         /* Disable, test waiting for disable to finish. */
         Crashes.setEnabled(false).get();
@@ -568,7 +568,7 @@ public class CrashesAndroidTest {
         /* Check there are only 2 files: the throwable and the json one. */
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(1, files.length);
     }
 
     @Test
@@ -617,7 +617,7 @@ public class CrashesAndroidTest {
         verify(mChannel, never()).enqueue(isA(ManagedErrorLog.class), anyString(), anyInt());
         File[] files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(4, files.length);
+        assertEquals(2, files.length);
         verify(crashesListener, times(2)).shouldProcess(any(ErrorReport.class));
         verify(crashesListener).shouldAwaitUserConfirmation();
         verifyNoMoreInteractions(crashesListener);
@@ -633,7 +633,7 @@ public class CrashesAndroidTest {
         assertNull(managedErrorLog.getValue().getException().getMinidumpFilePath());
         files = ErrorLogHelper.getErrorStorageDirectory().listFiles(mMinidumpFilter);
         assertNotNull(files);
-        assertEquals(2, files.length);
+        assertEquals(0, files.length);
         verify(crashesListener, times(2)).getErrorAttachments(any(ErrorReport.class));
         verifyNoMoreInteractions(crashesListener);
 

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -109,7 +109,10 @@ public class WrapperSdkExceptionManagerAndroidTest {
             startFresh();
 
             /* Save crash. */
-            error.id = WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), error.data);
+            Exception exception = new Exception();
+            exception.setType("type");
+            exception.setMessage("message");
+            error.id = WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, exception, error.data);
             String loadedData = WrapperSdkExceptionManager.loadWrapperExceptionData(error.id);
 
             if (error.data == null) {

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -109,10 +109,7 @@ public class WrapperSdkExceptionManagerAndroidTest {
             startFresh();
 
             /* Save crash. */
-            Exception exception = new Exception();
-            exception.setType("type");
-            exception.setMessage("message");
-            error.id = WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, exception, error.data);
+            error.id = WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), error.data);
             String loadedData = WrapperSdkExceptionManager.loadWrapperExceptionData(error.id);
 
             if (error.data == null) {

--- a/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
+++ b/sdk/appcenter-crashes/src/androidTest/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperAndroidTest.java
@@ -118,32 +118,15 @@ public class ErrorLogHelperAndroidTest {
         file = ErrorLogHelper.getStoredErrorLogFile(new UUID(0, 3));
         assertNull(file);
 
-        /* Get a throwable file by UUID. */
-        file = ErrorLogHelper.getStoredThrowableFile(new UUID(0, 3));
-        assertNotNull(file);
-        assertEquals(testFiles[3], file);
-        file = ErrorLogHelper.getStoredThrowableFile(new UUID(0, 0));
-        assertNull(file);
-
         /* Remove an error log file. */
         ErrorLogHelper.removeStoredErrorLogFile(new UUID(0, 2));
         file = ErrorLogHelper.getStoredErrorLogFile(new UUID(0, 2));
         assertNull(file);
 
-        /*Trying to delete an error log file which doesn't exist. */
-        ErrorLogHelper.removeStoredErrorLogFile(new UUID(0, 3));
-        file = ErrorLogHelper.getStoredThrowableFile(new UUID(0, 3));
-        assertNotNull(file);
-
         /* Verify the number of remaining error log files. */
         files = ErrorLogHelper.getStoredErrorLogFiles();
         assertNotNull(files);
         assertEquals(2, files.length);
-
-        /* Remove a throwable file. */
-        ErrorLogHelper.removeStoredThrowableFile(new UUID(0, 3));
-        file = ErrorLogHelper.getStoredThrowableFile(new UUID(0, 3));
-        assertNull(file);
 
         /*Trying to delete a throwable file which doesn't exist. */
         ErrorLogHelper.removeStoredThrowableFile(new UUID(0, 1));

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -516,11 +516,6 @@ public class Crashes extends AbstractAppCenterService {
                             UUID id = errorLog.getId();
                             if (report != null) {
 
-                                /* Clean up before calling callbacks if requested. */
-                                if (callbackProcessor.shouldDeleteThrowable()) {
-                                    removeStoredThrowable(id);
-                                }
-
                                 /* Call back. */
                                 HandlerUtils.runOnUiThread(new Runnable() {
 
@@ -544,11 +539,6 @@ public class Crashes extends AbstractAppCenterService {
                 processCallback(log, new CallbackProcessor() {
 
                     @Override
-                    public boolean shouldDeleteThrowable() {
-                        return false;
-                    }
-
-                    @Override
                     public void onCallBack(ErrorReport report) {
                         mCrashesListener.onBeforeSending(report);
                     }
@@ -560,11 +550,6 @@ public class Crashes extends AbstractAppCenterService {
                 processCallback(log, new CallbackProcessor() {
 
                     @Override
-                    public boolean shouldDeleteThrowable() {
-                        return true;
-                    }
-
-                    @Override
                     public void onCallBack(ErrorReport report) {
                         mCrashesListener.onSendingSucceeded(report);
                     }
@@ -574,11 +559,6 @@ public class Crashes extends AbstractAppCenterService {
             @Override
             public void onFailure(Log log, final java.lang.Exception e) {
                 processCallback(log, new CallbackProcessor() {
-
-                    @Override
-                    public boolean shouldDeleteThrowable() {
-                        return true;
-                    }
 
                     @Override
                     public void onCallBack(ErrorReport report) {
@@ -1144,9 +1124,7 @@ public class Crashes extends AbstractAppCenterService {
         File errorLogFile = new File(errorStorageDirectory, filename + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION);
 
         /* Set stacktrace to error log. */
-        if (errorLog.getException() != null) {
-            errorLog.getException().setStackTrace(getStackTraceString(throwable));
-        }
+        errorLog.getException().setStackTrace(getStackTraceString(throwable));
 
         /* Save stacktrace log to file. */
         String errorLogString = mLogSerializer.serializeLog(errorLog);
@@ -1262,11 +1240,6 @@ public class Crashes extends AbstractAppCenterService {
      * Callback template method.
      */
     private interface CallbackProcessor {
-
-        /**
-         * @return true to delete the stored serialized throwable file.
-         */
-        boolean shouldDeleteThrowable();
 
         /**
          * Execute call back.

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -945,18 +945,18 @@ public class Crashes extends AbstractAppCenterService {
             String stackTrace = null;
 
             /* If exception in the log doesn't have stack trace try get it from the .throwable file. */
-            if (stackTrace == null) {
-                File file = ErrorLogHelper.getStoredThrowableFile(id);
-                if (file != null) {
-                    if (file.length() > 0) {
-                        stackTrace = FileManager.read(file);
-                    }
+            File file = ErrorLogHelper.getStoredThrowableFile(id);
+            if (file != null) {
+                if (file.length() > 0) {
+                    stackTrace = FileManager.read(file);
                 }
             }
-            if (log.getException().getType().equals(MINIDUMP_FILE)) {
-                stackTrace = getStackTraceString(new NativeException());
-            } else {
-                stackTrace = buildStackTrace(log.getException());
+            if (stackTrace == null) {
+                if (MINIDUMP_FILE.equals(log.getException().getType())) {
+                    stackTrace = getStackTraceString(new NativeException());
+                } else {
+                    stackTrace = buildStackTrace(log.getException());
+                }
             }
             ErrorReport report = ErrorLogHelper.getErrorReportFromErrorLog(log, stackTrace);
             mErrorReportCache.put(id, new ErrorLogReport(log, report));

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/Crashes.java
@@ -924,9 +924,6 @@ public class Crashes extends AbstractAppCenterService {
 
     @VisibleForTesting
     String buildStackTrace(Exception exception) {
-        if (exception.getType() == null || exception.getMessage() == null) {
-            return null;
-        }
         String stacktrace = String.format("%s: %s", exception.getType(), exception.getMessage());
         if (exception.getFrames() == null) {
             return stacktrace;

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -447,7 +447,7 @@ public class ErrorLogHelper {
         });
         if (throwableFiles != null && throwableFiles.length > 0) {
             for (File file : throwableFiles) {
-                removeStoredThrowableFile(UUID.fromString(file.getName().replaceFirst("[.][^.]+$", "")));
+                removeStoredThrowableFile(UUID.fromString(file.getName().replaceFirst("\\.[^.]+$", "")));
             }
         }
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -413,13 +413,8 @@ public class ErrorLogHelper {
         });
     }
 
-    @Nullable
-    public static File getStoredThrowableFile(@NonNull UUID id) {
-        return getStoredFile(id, THROWABLE_FILE_EXTENSION);
-    }
-
     public static void removeStoredThrowableFile(@NonNull UUID id) {
-        File file = getStoredThrowableFile(id);
+        File file = getStoredFile(id, THROWABLE_FILE_EXTENSION);
         if (file != null) {
             AppCenterLog.info(Crashes.LOG_TAG, "Deleting throwable file " + file.getName());
             FileManager.delete(file);
@@ -444,6 +439,7 @@ public class ErrorLogHelper {
      */
     public static void removeLostThrowableFiles() {
         File[] throwableFiles = getErrorStorageDirectory().listFiles(new FilenameFilter() {
+
             @Override
             public boolean accept(File dir, String filename) {
                 return filename.endsWith(THROWABLE_FILE_EXTENSION);

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -22,6 +22,7 @@ import com.microsoft.appcenter.crashes.ingestion.models.StackFrame;
 import com.microsoft.appcenter.crashes.ingestion.models.Thread;
 import com.microsoft.appcenter.crashes.model.ErrorReport;
 import com.microsoft.appcenter.ingestion.models.Device;
+import com.microsoft.appcenter.ingestion.models.Log;
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.context.UserIdContext;
@@ -435,6 +436,23 @@ public class ErrorLogHelper {
         if (file != null) {
             AppCenterLog.info(Crashes.LOG_TAG, "Deleting error log file " + file.getName());
             FileManager.delete(file);
+        }
+    }
+
+    /**
+     * Remove throwable files.
+     */
+    public static void removeLostThrowableFiles() {
+        File[] throwableFiles = getErrorStorageDirectory().listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String filename) {
+                return filename.endsWith(THROWABLE_FILE_EXTENSION);
+            }
+        });
+        if (throwableFiles != null && throwableFiles.length > 0) {
+            for (File file : throwableFiles) {
+                removeStoredThrowableFile(UUID.fromString(file.getName().replaceFirst("[.][^.]+$", "")));
+            }
         }
     }
 

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -413,8 +413,13 @@ public class ErrorLogHelper {
         });
     }
 
+    @Nullable
+    public static File getStoredThrowableFile(@NonNull UUID id) {
+        return getStoredFile(id, THROWABLE_FILE_EXTENSION);
+    }
+
     public static void removeStoredThrowableFile(@NonNull UUID id) {
-        File file = getStoredFile(id, THROWABLE_FILE_EXTENSION);
+        File file = getStoredThrowableFile(id);
         if (file != null) {
             AppCenterLog.info(Crashes.LOG_TAG, "Deleting throwable file " + file.getName());
             FileManager.delete(file);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1560,17 +1560,6 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void checkBuildStacktraceWithWrongExceptionModel() {
-        com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = new com.microsoft.appcenter.crashes.ingestion.models.Exception();
-        String stacktrace = Crashes.getInstance().buildStackTrace(mockException);
-        assertNull(stacktrace);
-
-        mockException.setType("type");
-        stacktrace = Crashes.getInstance().buildStackTrace(mockException);
-        assertNull(stacktrace);
-    }
-
-    @Test
     public void checkBuildStacktrace() {
         String expectedStacktrace = "Type of exception: Message exception\n" +
                 " ClassName.MethodName(FileName:1)\n" +

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -299,7 +299,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         CrashesListener mockListener = mock(CrashesListener.class);
@@ -347,7 +346,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
 
@@ -389,7 +387,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(SharedPreferencesManager.getBoolean(eq(Crashes.PREF_KEY_ALWAYS_SEND), anyBoolean())).thenReturn(true);
@@ -519,17 +516,19 @@ public class CrashesTest extends AbstractCrashesTest {
 
     @Test
     public void getChannelListener() throws JSONException {
-        ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE);
 
+        /* Mock and set exception data. */
+        com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
+        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
+        mErrorLog.setException(mockException);
+
+        ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE);
         mockStatic(ErrorLogHelper.class);
         File errorLogFile = mock(File.class);
         when(errorLogFile.length()).thenReturn(1L);
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(errorLogFile);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        File throwableFile = mock(File.class);
-        when(throwableFile.length()).thenReturn(1L);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
         when(ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE)).thenReturn(errorReport);
         when(FileManager.read(any(File.class))).thenReturn("");
         when(FileManager.read(any(File.class))).thenReturn(STACK_TRACE);
@@ -584,7 +583,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(FileManager.read(any(File.class))).thenReturn(null);
 
         CrashesListener mockListener = mock(CrashesListener.class);
@@ -613,7 +611,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
         File pendingFolder = mock(File.class);
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingFolder);
@@ -638,8 +635,6 @@ public class CrashesTest extends AbstractCrashesTest {
         ErrorLogHelper.cleanPendingMinidumps();
         verifyStatic();
         ErrorLogHelper.removeStoredErrorLogFile(mErrorLog.getId());
-        verifyStatic();
-        ErrorLogHelper.removeStoredThrowableFile(mErrorLog.getId());
     }
 
     @Test
@@ -653,7 +648,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(FileManager.read(any(File.class))).thenReturn(null);
 
         CrashesListener mockListener = mock(CrashesListener.class);
@@ -676,13 +670,17 @@ public class CrashesTest extends AbstractCrashesTest {
 
     @Test
     public void buildErrorReport() {
+
+        /* Mock and set exception data. */
+        com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
+        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
+        mErrorLog.setException(mockException);
         mErrorLog.setDevice(mock(Device.class));
         ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE);
 
         mockStatic(ErrorLogHelper.class);
         File throwableFile = mock(File.class);
         when(throwableFile.length()).thenReturn(1L);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile).thenReturn(null);
         when(ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE)).thenReturn(errorReport);
         when(FileManager.read(any(File.class))).thenReturn(STACK_TRACE);
 
@@ -699,7 +697,7 @@ public class CrashesTest extends AbstractCrashesTest {
 
         mErrorLog.setId(UUID.randomUUID());
         report = crashes.buildErrorReport(mErrorLog);
-        assertNull(report);
+        assertNotNull(report);
     }
 
     @Test
@@ -768,9 +766,14 @@ public class CrashesTest extends AbstractCrashesTest {
     @Test
     public void crashInLastSession() throws JSONException, IOException {
 
+        /* Mock and set exception data. */
+        com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
+        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
+
         final ManagedErrorLog errorLog = new ManagedErrorLog();
         errorLog.setId(UUID.randomUUID());
         errorLog.setErrorThreadName(Thread.currentThread().getName());
+        errorLog.setException(mockException);
         Date logTimestamp = new Date(10);
         errorLog.setTimestamp(logTimestamp);
 
@@ -789,7 +792,6 @@ public class CrashesTest extends AbstractCrashesTest {
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(lastErrorLogFile);
         File throwableFile = errorStorageDirectory.newFile();
         new FileWriter(throwableFile).append(STACK_TRACE).close();
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
         when(ErrorLogHelper.getErrorReportFromErrorLog(errorLog, STACK_TRACE)).thenReturn(errorReport);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{lastErrorLogFile});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
@@ -952,7 +954,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(new ErrorReport());
         when(FileManager.read(any(File.class))).thenReturn("");
 
@@ -981,7 +982,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1088,7 +1088,6 @@ public class CrashesTest extends AbstractCrashesTest {
         mockStatic(ErrorLogHelper.class);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report1).thenReturn(report2);
         when(FileManager.read(any(File.class))).thenReturn("");
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1170,7 +1169,6 @@ public class CrashesTest extends AbstractCrashesTest {
         File pendingDir = mock(File.class);
         Whitebox.setInternalState(pendingDir, "path", "");
         when(ErrorLogHelper.getPendingMinidumpDirectory()).thenReturn(pendingDir);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), anyString())).thenReturn(report);
         when(ErrorLogHelper.parseLogFolderUuid(any(File.class))).thenReturn(UUID.randomUUID());
         when(FileManager.read(any(File.class))).thenReturn("");
@@ -1264,7 +1262,6 @@ public class CrashesTest extends AbstractCrashesTest {
         when(exception.getMinidumpFilePath()).thenReturn(null);
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(FileManager.read(any(File.class))).thenReturn("");
         String jsonCrash = "{}";
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1318,7 +1315,6 @@ public class CrashesTest extends AbstractCrashesTest {
         /* This mocks we already processed minidump to convert to pending regular crash report as that would be the case if migrating data from older SDK. */
         when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class)});
         when(ErrorLogHelper.getNewMinidumpFiles()).thenReturn(new File[0]);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
         when(FileManager.read(any(File.class))).thenReturn("");
         String jsonCrash = "{}";
         LogSerializer logSerializer = mock(LogSerializer.class);
@@ -1388,18 +1384,6 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Simulate crash. */
         Crashes.getInstance().saveUncaughtException(Thread.currentThread(), throwable);
-
-        /* Verify we gracefully abort saving throwable (no exception) and we created an empty file instead. */
-        verifyStatic();
-        FileManager.write(throwableFile, STACK_TRACE);
-        assertNotNull(throwableFile);
-        InOrder inOrder = inOrder(throwableFile);
-
-        //noinspection ResultOfMethodCallIgnored
-        inOrder.verify(throwableFile).delete();
-
-        //noinspection ResultOfMethodCallIgnored
-        inOrder.verify(throwableFile).createNewFile();
 
         /* Verify it didn't prevent saving the JSON file. */
         verifyStatic();

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -572,7 +572,7 @@ public class CrashesTest extends AbstractCrashesTest {
         assertErrorEquals(mErrorLog, errorReportCaptor.getValue());
 
         /* onSuccess and onFailure invalidate the cache, so one more call is expected. */
-        verifyStatic(times(2));
+        verifyStatic();
         ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, STACK_TRACE);
     }
 
@@ -1514,20 +1514,11 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void setStacktraceToErrorLogFileWithNullException() throws Exception {
-        setStacktraceToErrorLogFile(null, 0);
-    }
-
-    @Test
-    public void setStacktraceToErrorLogFileWithNCorrectException() throws Exception {
+    public void setStacktraceToErrorLogFile() throws Exception {
 
         /* Mock exception. */
         com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
         when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
-        setStacktraceToErrorLogFile(mockException, 1);
-    }
-
-    private void setStacktraceToErrorLogFile(com.microsoft.appcenter.crashes.ingestion.models.Exception mockException, int times) throws Exception {
 
         /* Mock variables. */
         Context mockContext = mock(Context.class);
@@ -1560,7 +1551,7 @@ public class CrashesTest extends AbstractCrashesTest {
         Crashes.getInstance().saveUncaughtException(mockThread, mockThrowable, mockModelException);
 
         /* Check result. */
-        verifyStatic(times(times));
+        verifyStatic();
         getStackTraceString(any(Throwable.class));
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -524,7 +524,6 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Mock and set exception data. */
         com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
-        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
         when(mockException.getType()).thenReturn("type");
         when(mockException.getMessage()).thenReturn("message");
         mErrorLog.setException(mockException);
@@ -682,7 +681,6 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Mock and set exception data. */
         com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
-        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
         when(mockException.getType()).thenReturn("type");
         when(mockException.getMessage()).thenReturn("message");
         mErrorLog.setException(mockException);
@@ -779,7 +777,6 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Mock and set exception data. */
         com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
-        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
         when(mockException.getType()).thenReturn("type");
         when(mockException.getMessage()).thenReturn("message");
 
@@ -1524,6 +1521,8 @@ public class CrashesTest extends AbstractCrashesTest {
 
     @Test
     public void checkStacktraceWhenThrowableFileIsNull() throws Exception {
+        String expectedStacktrace = "type: message\n" +
+                " ClassName.MethodName(FileName:1)";
 
         /* Mock file. */
         File mockFile = mock(File.class);
@@ -1534,11 +1533,18 @@ public class CrashesTest extends AbstractCrashesTest {
         when(mockDir.listFiles(any(FilenameFilter.class))).thenReturn(new File[] {mockFile});
         whenNew(File.class).withAnyArguments().thenReturn(mockDir);
 
+        /* Prepare first frame. */
+        final StackFrame stackFrame1 = new StackFrame();
+        stackFrame1.setClassName("ClassName");
+        stackFrame1.setMethodName("MethodName");
+        stackFrame1.setFileName("FileName");
+        stackFrame1.setLineNumber(1);
+
         /* Mock exception value. */
         com.microsoft.appcenter.crashes.ingestion.models.Exception mockException = mock(com.microsoft.appcenter.crashes.ingestion.models.Exception.class);
-        when(mockException.getStackTrace()).thenReturn(STACK_TRACE);
         when(mockException.getType()).thenReturn("type");
         when(mockException.getMessage()).thenReturn("message");
+        when(mockException.getFrames()).thenReturn(Arrays.asList(stackFrame1));
 
         /* Mock log. */
         ManagedErrorLog mockLog = new ManagedErrorLog();
@@ -1554,7 +1560,7 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Verify that stacktrace is null. */
         ErrorReport report = crashes.buildErrorReport(mockLog);
-        assertEquals(STACK_TRACE, report.getStackTrace());
+        assertEquals(expectedStacktrace, report.getStackTrace());
         verifyStatic(never());
         FileManager.read(any(File.class));
     }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/UncaughtExceptionHandlerTest.java
@@ -109,6 +109,7 @@ public class UncaughtExceptionHandlerTest {
                 .thenReturn(errorLogMock);
 
         when(errorLogMock.getId()).thenReturn(UUID.randomUUID());
+        when(errorLogMock.getException()).thenReturn(new com.microsoft.appcenter.crashes.ingestion.models.Exception());
 
         mDefaultExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
         Thread.setDefaultUncaughtExceptionHandler(mDefaultExceptionHandler);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -88,6 +88,7 @@ public class WrapperSdkExceptionManagerTest {
         when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(errorStorageDirectory.getRoot());
         ManagedErrorLog errorLogMock = mock(ManagedErrorLog.class);
         when(errorLogMock.getId()).thenReturn(UUID.randomUUID());
+        when(errorLogMock.getException()).thenReturn(new com.microsoft.appcenter.crashes.ingestion.models.Exception());
         when(ErrorLogHelper.createErrorLog(any(Context.class), any(Thread.class), any(Exception.class), Matchers.<Map<Thread, StackTraceElement[]>>any(), anyLong(), anyBoolean()))
                 .thenReturn(errorLogMock);
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/WrapperSdkExceptionManagerTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
@@ -183,8 +184,9 @@ public class WrapperSdkExceptionManagerTest {
     @Test
     @PrepareForTest(android.util.Log.class)
     public void saveWrapperSdkCrashWithJavaThrowable() throws JSONException, IOException {
+        String mockData = "mock";
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
-        when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
+        when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn(mockData);
         Crashes.getInstance().setLogSerializer(logSerializer);
         String data = "d";
         Throwable throwable = new Throwable();
@@ -194,7 +196,7 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic();
         FileManager.write(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(STACK_TRACE));
+        FileManager.write(any(File.class), eq(mockData));
 
         /* We can't do it twice in the same process. */
         data = "e";
@@ -202,14 +204,15 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.write(any(File.class), eq(data));
         verifyStatic();
-        FileManager.write(any(File.class), eq(STACK_TRACE));
+        FileManager.write(any(File.class), eq(mockData));
     }
 
     @Test
     @PrepareForTest({android.util.Log.class})
     public void saveWrapperSdkCrashWithOnlyJavaThrowable() throws JSONException, IOException {
+        String mockData = "mock";
         LogSerializer logSerializer = Mockito.mock(LogSerializer.class);
-        when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn("mock");
+        when(logSerializer.serializeLog(any(ManagedErrorLog.class))).thenReturn(mockData);
         Crashes.getInstance().setLogSerializer(logSerializer);
         Throwable throwable = new Throwable();
         mockStatic(android.util.Log.class);
@@ -218,12 +221,12 @@ public class WrapperSdkExceptionManagerTest {
         verifyStatic(never());
         FileManager.write(any(File.class), isNull(String.class));
         verifyStatic();
-        FileManager.write(any(File.class), eq(STACK_TRACE));
+        FileManager.write(any(File.class), eq(mockData));
 
         /* We can't do it twice in the same process. */
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), throwable, new Exception(), null);
         verifyStatic();
-        FileManager.write(any(File.class), eq(STACK_TRACE));
+        FileManager.write(any(File.class), eq(mockData));
     }
 
     @Test
@@ -242,28 +245,16 @@ public class WrapperSdkExceptionManagerTest {
         when(throwableFile.createNewFile()).thenReturn(false);
         String data = "d";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
-        verifyStatic();
-        AppCenterLog.error(anyString(), anyString(), argThat(new ArgumentMatcher<Throwable>() {
-
-            @Override
-            public boolean matches(Object argument) {
-                return argument instanceof IOException;
-            }
-        }));
+        verifyStatic(times(3));
+        AppCenterLog.debug(anyString(), anyString());
 
         /* Second call is ignored. */
         data = "e";
         WrapperSdkExceptionManager.saveWrapperException(Thread.currentThread(), null, new Exception(), data);
 
         /* No more error. */
-        verifyStatic();
-        AppCenterLog.error(anyString(), anyString(), argThat(new ArgumentMatcher<Throwable>() {
-
-            @Override
-            public boolean matches(Object argument) {
-                return argument instanceof IOException;
-            }
-        }));
+        verifyStatic(times(3));
+        AppCenterLog.debug(anyString(), anyString());
     }
 
     @Test

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -530,8 +530,8 @@ public class ErrorLogHelperTest {
         /* Mock files. */
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
-        when(mockFile1.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120002");
-        when(mockFile2.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120003");
+        when(mockFile1.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120002" + ErrorLogHelper.THROWABLE_FILE_EXTENSION );
+        when(mockFile2.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120003" + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
 
         /* Mock getting storage directory. */
         File mockDir = mock(File.class);

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -61,6 +61,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -517,5 +519,54 @@ public class ErrorLogHelperTest {
         File logFolder = mTemporaryFolder.newFolder("new", originalFolderName + ".dmp");
         UUID uuid = ErrorLogHelper.parseLogFolderUuid(logFolder);
         assertNotEquals(uuid.toString(), originalFolderName);
+    }
+
+    @Test
+    public void removeLostThrowableFiles() {
+
+        /* Mock FileManager class. */
+        mockStatic(FileManager.class);
+
+        /* Mock files. */
+        File mockFile1 = mock(File.class);
+        File mockFile2 = mock(File.class);
+        when(mockFile1.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120002");
+        when(mockFile2.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120003");
+
+        /* Mock getting storage directory. */
+        File mockDir = mock(File.class);
+        File[] mockFiles = new File[] {mockFile1, mockFile2};
+        when(mockDir.listFiles(any(FilenameFilter.class))).thenReturn(mockFiles);
+        ErrorLogHelper.setErrorLogDirectory(mockDir);
+
+        /* Verify removing files when getErrorStorageDirectory return some files. */
+        ErrorLogHelper.removeLostThrowableFiles();
+        verifyStatic(times(2));
+        FileManager.delete(any(File.class));
+    }
+
+
+    @Test
+    public void removeLostThrowableFilesWhenListOfFilesIsEmpty() throws java.lang.Exception {
+
+        /* Mock FileManager class. */
+        mockStatic(FileManager.class);
+
+        /* Mock getting storage directory. */
+        File mockDir = mock(File.class);
+        when(mockDir.listFiles(any(FilenameFilter.class)))
+                .thenReturn(null)
+                .thenReturn(new File[0]);
+        ErrorLogHelper.setErrorLogDirectory(mockDir);
+
+        /* Verify removing files when getErrorStorageDirectory return null. */
+        ErrorLogHelper.removeLostThrowableFiles();
+        verifyStatic(never());
+        FileManager.delete(any(File.class));
+
+        /* Verify removing files when getErrorStorageDirectory return 0. */
+        ErrorLogHelper.removeLostThrowableFiles();
+        verifyStatic(never());
+        FileManager.delete(any(File.class));
     }
 }

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -545,7 +545,6 @@ public class ErrorLogHelperTest {
         FileManager.delete(any(File.class));
     }
 
-
     @Test
     public void removeLostThrowableFilesWhenListOfFilesIsEmpty() throws java.lang.Exception {
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Repro steps:

- Build and run the Sasquatch app in debug mode from Android Studio.
- Set the storage size to 32768 (32kb).
- Turn off Wi-Fi and LTE, so there's no network on the device/emulator.
- Crash the app several times (7-10 times).
- Turn on Wi-Fi/LTE.
- Run the Sasquatch app in debug mode from Android Studio, open Device File Explorer in the IDE and see extra throwable files.

**Actual:**
There are several .throwable files that are not cleaned up even after restart.

**Expected:**
After network turned on .throwable files should be cleaned up.

## Related PRs or issues

[AB#83943](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83943)
