### PR TITLE
Add onNoReleaseAvailable callback feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### App Center Distribute
 
+* **[Feature]** Add `onNoReleaseAvailable` callback to DistributeListener.
 * **[Fix]** Fix a crash when the app is trying to open the system settings screen from the background.
 * **[Fix]** Fix browser opening when using a private distribution group on Android 11.
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchDistributeListener.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/listeners/SasquatchDistributeListener.java
@@ -8,6 +8,7 @@ package com.microsoft.appcenter.sasquatch.listeners;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.support.v7.app.AlertDialog;
+import android.widget.Toast;
 
 import com.microsoft.appcenter.distribute.Distribute;
 import com.microsoft.appcenter.distribute.DistributeListener;
@@ -45,5 +46,16 @@ public class SasquatchDistributeListener implements DistributeListener {
             dialogBuilder.create().show();
         }
         return custom;
+    }
+
+    /*
+     * TODO: uncomment the annotation after release.
+     *  The annotation conflicts with `gradlew assemble` command, because gradle runs through
+     *  all build variants including jcenter ones.
+     *
+     * @Override
+     */
+    public void onNoReleaseAvailable(Activity activity) {
+        Toast.makeText(activity, activity.getString(R.string.no_updates_available), Toast.LENGTH_LONG).show();
     }
 }

--- a/apps/sasquatch/src/main/res/values/strings.xml
+++ b/apps/sasquatch/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
         <item>Date/Time</item>
         <item>Clear</item>
     </string-array>
+    <string name="no_updates_available" tools:ignore="MissingTranslation">No updates available</string>
     <string name="version_x_available" tools:ignore="MissingTranslation">Version %1$s available!</string>
     <string name="transmission_enabled" tools:ignore="MissingTranslation">Transmission target is enabled.</string>
     <string name="transmission_disabled" tools:ignore="MissingTranslation">Transmission target is disabled.</string>

--- a/sdk/appcenter-distribute-play/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
+++ b/sdk/appcenter-distribute-play/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
@@ -27,4 +27,17 @@ public interface DistributeListener {
      * @return the custom dialog whose visibility will be managed for you if not null.
      */
     boolean onReleaseAvailable(Activity activity, ReleaseDetails releaseDetails);
+
+    /**
+     * Called when no updates are available for the application.
+     * <p>
+     * This callback will repeat for every foreground/background state change if there are no updates.
+     * <p>
+     * It's easier to use Toast or Snackbar here, but if you prefer a dialog and you use custom
+     * dialogs for {@link DistributeListener#onReleaseAvailable(Activity, ReleaseDetails)},
+     * make sure to dismiss the previous onReleaseAvailable dialog if it is still showing.
+     *
+     * @param activity current activity.
+     */
+    boolean onNoReleaseAvailable(Activity activity);
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1172,8 +1172,12 @@ public class Distribute extends AbstractAppCenterService {
                     } catch (JSONException je) {
                         AppCenterLog.verbose(LOG_TAG, "Cannot read the error as JSON", je);
                     }
-                    if (ErrorDetails.NO_RELEASES_FOR_USER_CODE.equals(code)) {
+                    if (ErrorDetails.NO_RELEASES_FOR_USER_CODE.equals(code) || ErrorDetails.NO_RELEASES_FOUND.equals(code)) {
                         AppCenterLog.info(LOG_TAG, "No release available to the current user.");
+                        if (mListener != null && mForegroundActivity != null) {
+                            AppCenterLog.debug(LOG_TAG, "Calling listener.onNoReleaseAvailable.");
+                            mListener.onNoReleaseAvailable(mForegroundActivity);
+                        }
                     } else {
                         AppCenterLog.error(LOG_TAG, "Failed to check latest release (delete setup state)", e);
                         SharedPreferencesManager.remove(PREFERENCE_KEY_DISTRIBUTION_GROUP_ID);
@@ -1225,7 +1229,13 @@ public class Distribute extends AbstractAppCenterService {
 
                 /* Check version code is equals or higher and hash is different. */
                 AppCenterLog.debug(LOG_TAG, "Check if latest release is more recent.");
-                if (isMoreRecent(releaseDetails) && canUpdateNow(releaseDetails)) {
+                boolean moreRecent = isMoreRecent(releaseDetails);
+                if (!moreRecent) {
+                    if (mListener != null && mForegroundActivity != null) {
+                        AppCenterLog.debug(LOG_TAG, "Calling listener.onNoReleaseAvailable.");
+                        mListener.onNoReleaseAvailable(mForegroundActivity);
+                    }
+                } else if (canUpdateNow(releaseDetails)) {
 
                     /* Load last known release to see if we need to prepare a cleanup. */
                     if (mReleaseDetails == null) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeListener.java
@@ -27,4 +27,17 @@ public interface DistributeListener {
      * @return the custom dialog whose visibility will be managed for you if not null.
      */
     boolean onReleaseAvailable(Activity activity, ReleaseDetails releaseDetails);
+
+    /**
+     * Called when no updates are available for the application.
+     * <p>
+     * This callback will repeat for every foreground/background state change if there are no updates.
+     * <p>
+     * It's easier to use Toast or Snackbar here, but if you prefer a dialog and you use custom
+     * dialogs for {@link DistributeListener#onReleaseAvailable(Activity, ReleaseDetails)},
+     * make sure to dismiss the previous onReleaseAvailable dialog if it is still showing.
+     *
+     * @param activity current activity.
+     */
+    void onNoReleaseAvailable(Activity activity);
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ErrorDetails.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ErrorDetails.java
@@ -19,6 +19,11 @@ class ErrorDetails {
     static final String NO_RELEASES_FOR_USER_CODE = "no_releases_for_user";
 
     /**
+     * Error code when no releases were found for the application.
+     */
+    static final String NO_RELEASES_FOUND = "not_found";
+
+    /**
      * Code property.
      */
     private static final String CODE = "code";


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [X] Did you check UI tests on the sample app? They are not executed on CI.

## Description

This PR adds a new callback `onNoReleaseAvailable` to DistributeListener.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-android/issues/1215
[AB#84053](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=84053)

## Misc

Note: assemble docs task is failing on CI because it uses jcenter dependency, not project one.
