### PR TITLE
Fix coverageReport gradle task

### DIFF
--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -469,7 +469,6 @@ public class ErrorLogHelper {
         return report;
     }
 
-    @VisibleForTesting
     public static void setErrorLogDirectory(File file) {
         sErrorLogDirectory = file;
     }

--- a/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
+++ b/sdk/appcenter-crashes/src/main/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelper.java
@@ -470,7 +470,7 @@ public class ErrorLogHelper {
     }
 
     @VisibleForTesting
-    static void setErrorLogDirectory(File file) {
+    public static void setErrorLogDirectory(File file) {
         sErrorLogDirectory = file;
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -55,7 +55,6 @@ import org.powermock.reflect.Whitebox;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1521,18 +1520,17 @@ public class CrashesTest extends AbstractCrashesTest {
     }
 
     @Test
-    public void checkStacktraceWhenThrowableFileIsNull() throws Exception {
+    public void checkStacktraceWhenThrowableFileIsEmpty() throws Exception {
         String expectedStacktrace = "type: message\n" +
                 " ClassName.MethodName(FileName:1)";
 
-        /* Mock file. */
-        File mockFile = mock(File.class);
-        when(mockFile.length()).thenReturn(0L);
-
-        /* Mock files. */
-        File mockDir = mock(File.class);
-        when(mockDir.listFiles(any(FilenameFilter.class))).thenReturn(new File[]{mockFile});
-        whenNew(File.class).withAnyArguments().thenReturn(mockDir);
+        /* Create empty throwable file. */
+        UUID logId = UUID.randomUUID();
+        String throwableFileName = logId + ErrorLogHelper.THROWABLE_FILE_EXTENSION;
+        File errorStorageDirectory = mTemporaryFolder.newFolder("error");
+        ErrorLogHelper.setErrorLogDirectory(errorStorageDirectory);
+        File throwableFile = new File(errorStorageDirectory, throwableFileName);
+        assertTrue(throwableFile.createNewFile());
 
         /* Prepare first frame. */
         final StackFrame stackFrame1 = new StackFrame();
@@ -1549,7 +1547,7 @@ public class CrashesTest extends AbstractCrashesTest {
 
         /* Mock log. */
         ManagedErrorLog mockLog = new ManagedErrorLog();
-        mockLog.setId(UUID.randomUUID());
+        mockLog.setId(logId);
         mockLog.setErrorThreadName("Thread name");
         mockLog.setAppLaunchTimestamp(new Date());
         mockLog.setTimestamp(new Date());

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/CrashesTest.java
@@ -1600,7 +1600,7 @@ public class CrashesTest extends AbstractCrashesTest {
         /* Verify. */
         assertEquals(expectedStacktrace, report.getStackTrace());
         verify(crashes, never()).buildStackTrace(any(com.microsoft.appcenter.crashes.ingestion.models.Exception.class));
-        verifyStatic(times(1));
+        verifyStatic();
         FileManager.read(any(File.class));
     }
 

--- a/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
+++ b/sdk/appcenter-crashes/src/test/java/com/microsoft/appcenter/crashes/utils/ErrorLogHelperTest.java
@@ -530,12 +530,12 @@ public class ErrorLogHelperTest {
         /* Mock files. */
         File mockFile1 = mock(File.class);
         File mockFile2 = mock(File.class);
-        when(mockFile1.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120002" + ErrorLogHelper.THROWABLE_FILE_EXTENSION );
+        when(mockFile1.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120002" + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
         when(mockFile2.getName()).thenReturn("74aa0682-3478-11eb-adc1-0242ac120003" + ErrorLogHelper.THROWABLE_FILE_EXTENSION);
 
         /* Mock getting storage directory. */
         File mockDir = mock(File.class);
-        File[] mockFiles = new File[] {mockFile1, mockFile2};
+        File[] mockFiles = new File[]{mockFile1, mockFile2};
         when(mockDir.listFiles(any(FilenameFilter.class))).thenReturn(mockFiles);
         ErrorLogHelper.setErrorLogDirectory(mockDir);
 
@@ -567,5 +567,27 @@ public class ErrorLogHelperTest {
         ErrorLogHelper.removeLostThrowableFiles();
         verifyStatic(never());
         FileManager.delete(any(File.class));
+    }
+
+    @Test
+    public void removeStoredErrorLogFile() throws java.lang.Exception {
+
+        /* Create file. */
+        UUID logId = UUID.randomUUID();
+        String throwableFileName = logId + ErrorLogHelper.ERROR_LOG_FILE_EXTENSION;
+        File errorStorageDirectory = mTemporaryFolder.newFolder("error");
+        ErrorLogHelper.setErrorLogDirectory(errorStorageDirectory);
+        File errorLogFile = new File(errorStorageDirectory, throwableFileName);
+        assertTrue(errorLogFile.createNewFile());
+        assertTrue(errorLogFile.exists());
+
+        /* Remove stored log file. */
+        ErrorLogHelper.removeStoredErrorLogFile(logId);
+
+        /* Verify. */
+        assertFalse(errorLogFile.exists());
+
+        /* Coverage check. */
+        ErrorLogHelper.removeStoredErrorLogFile(UUID.randomUUID());
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
@@ -23,8 +23,8 @@ import com.microsoft.appcenter.utils.DeviceInfoHelper;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -183,31 +183,86 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         /* Verify the right listener gets called again. */
         verify(listener, times(1)).onNoReleaseAvailable(mActivity);
         verify(listener, never()).onReleaseAvailable(any(Activity.class), any(ReleaseDetails.class));
-
     }
 
     @Test
-    public void distributeNoListener() throws Exception {
-        System.out.println("2");
+    public void distributeNotRecentNoListener() throws Exception {
+        DistributeListener listener = mock(DistributeListener.class);
+        distributeNotRecentCoverage(null, listener, false);
+    }
+
+    @Test
+    public void distributeNotRecentNoActivity() throws Exception {
+        DistributeListener listener = mock(DistributeListener.class);
+        distributeNotRecentCoverage(listener, listener, true);
+    }
+
+    @Test
+    public void distributeNotRecentNoListenerNoActivity() throws Exception {
+        DistributeListener listener = mock(DistributeListener.class);
+        distributeNotRecentCoverage(null, listener, true);
+    }
+
+    private void distributeNotRecentCoverage(DistributeListener actualListener, DistributeListener verificationListener, boolean onPause) throws Exception {
+
+        /* Set the package version higher than the portal's one. */
+        mockStatic(DeviceInfoHelper.class);
+        when(DeviceInfoHelper.getVersionCode(any(PackageInfo.class))).thenReturn(11);
+
+        /* Mock http call. */
+        ArgumentCaptor<ServiceCallback> httpCallback = ArgumentCaptor.forClass(ServiceCallback.class);
+        when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), httpCallback.capture())).thenReturn(mock(ServiceCall.class));
+
+        /* Mock data model. */
+        mockStatic(ReleaseDetails.class);
+        ReleaseDetails details = mock(ReleaseDetails.class);
+        when(details.getId()).thenReturn(1);
+        when(details.getVersion()).thenReturn(10);
+        when(details.getShortVersion()).thenReturn("2.3.4");
+        when(details.isMandatoryUpdate()).thenReturn(false);
+        when(details.getReleaseHash()).thenReturn("some_hash");
+        when(ReleaseDetails.parse(anyString())).thenReturn(details);
+
+        /* Mock update token. */
+        when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_TOKEN)).thenReturn("some token");
+
+        /* Start Distribute service. */
+        restartProcessAndSdk();
+
+        /* Set Distribute listener and customize it. */
+        Distribute.setListener(actualListener);
+
+        /* Resume activity. */
+        Distribute.getInstance().onActivityResumed(mActivity);
+        if (onPause) {
+            Distribute.getInstance().onActivityPaused(mActivity);
+        }
+
+        /* Simulate network latency. */
+        httpCallback.getValue().onCallSucceeded(new HttpResponse(200, "mock"));
+
+        /* Verify the right listener gets called. */
+        verify(verificationListener, never()).onNoReleaseAvailable(any(Activity.class));
+        verify(verificationListener, never()).onReleaseAvailable(any(Activity.class), any(ReleaseDetails.class));
+    }
+
+    @Test
+    public void distributeNotFoundAvailableNoListener() throws Exception {
         DistributeListener listener = mock(DistributeListener.class);
         distributeNoReleaseAvailableCoverage(null, listener, false);
     }
 
     @Test
-    public void distributeNoActivity() throws Exception {
-        System.out.println("3");
+    public void distributeNotFoundNoActivity() throws Exception {
         DistributeListener listener = mock(DistributeListener.class);
         distributeNoReleaseAvailableCoverage(listener, listener, true);
     }
 
     @Test
-    public void distributeNoListenerNoActivity() throws Exception {
-        System.out.println("4");
+    public void distributeNotFoundNoListenerNoActivity() throws Exception {
         DistributeListener listener = mock(DistributeListener.class);
         distributeNoReleaseAvailableCoverage(null, listener, true);
     }
-
-    ServiceCallback callback = null;
 
     private void distributeNoReleaseAvailableCoverage(DistributeListener actualListener, DistributeListener verificationListener, boolean onPause) throws Exception {
 
@@ -221,14 +276,8 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         final HttpException httpException = new HttpException(new HttpResponse(404, "{code:'not_found'}"));
 
         /* Mock http call. */
-        when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), any(ServiceCallback.class))).thenAnswer(new Answer<ServiceCall>() {
-
-            @Override
-            public ServiceCall answer(InvocationOnMock invocation) {
-                callback = (ServiceCallback) invocation.getArguments()[4];
-                return mock(ServiceCall.class);
-            }
-        });
+        ArgumentCaptor<ServiceCallback> httpCallback = ArgumentCaptor.forClass(ServiceCallback.class);
+        when(mHttpClient.callAsync(anyString(), anyString(), anyMapOf(String.class, String.class), any(HttpClient.CallTemplate.class), httpCallback.capture())).thenReturn(mock(ServiceCall.class));
 
         /* Start Distribute service. */
         restartProcessAndSdk();
@@ -238,11 +287,12 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
 
         /* Resume activity. */
         Distribute.getInstance().onActivityResumed(mActivity);
-        if (onPause){
+        if (onPause) {
             Distribute.getInstance().onActivityPaused(mActivity);
         }
 
-        callback.onCallFailed(httpException);
+        /* Simulate network latency. */
+        httpCallback.getValue().onCallFailed(httpException);
 
         /* Verify the right listener gets called. */
         verify(verificationListener, never()).onNoReleaseAvailable(any(Activity.class));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeCustomizationTest.java
@@ -174,14 +174,14 @@ public class DistributeCustomizationTest extends AbstractDistributeTest {
         Distribute.getInstance().onActivityResumed(mActivity);
 
         /* Verify the right listener gets called. */
-        verify(listener, times(1)).onNoReleaseAvailable(mActivity);
+        verify(listener).onNoReleaseAvailable(mActivity);
         verify(listener, never()).onReleaseAvailable(any(Activity.class), any(ReleaseDetails.class));
 
         /* Resume activity again to invoke update request. */
         Distribute.getInstance().onActivityResumed(mActivity);
 
         /* Verify the right listener gets called again. */
-        verify(listener, times(1)).onNoReleaseAvailable(mActivity);
+        verify(listener).onNoReleaseAvailable(mActivity);
         verify(listener, never()).onReleaseAvailable(any(Activity.class), any(ReleaseDetails.class));
     }
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeWarnUnknownSourcesTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeWarnUnknownSourcesTest.java
@@ -127,6 +127,23 @@ public class DistributeWarnUnknownSourcesTest extends AbstractDistributeTest {
         verify(mUnknownSourcesDialog).show();
     }
 
+    @Test
+    public void clickSettingsNotActivity() throws Exception {
+
+        /* Click settings. */
+        Intent intent = mock(Intent.class);
+        whenNew(Intent.class).withArguments(Settings.ACTION_SECURITY_SETTINGS).thenReturn(intent);
+        ArgumentCaptor<DialogInterface.OnClickListener> clickListener = ArgumentCaptor.forClass(DialogInterface.OnClickListener.class);
+        verify(mDialogBuilder).setPositiveButton(eq(R.string.appcenter_distribute_unknown_sources_dialog_settings), clickListener.capture());
+
+        /* Go to unknown sources without any activity in foreground. */
+        Distribute.getInstance().onActivityPaused(mock(Activity.class));
+        clickListener.getValue().onClick(mUnknownSourcesDialog, DialogInterface.BUTTON_POSITIVE);
+
+        /* Verify no navigation attempts. */
+        verify(mFirstActivity, never()).startActivity(intent);
+    }
+
     @After
     public void tearDown() throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 0);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AbstractAppCenterService.java
@@ -14,7 +14,6 @@ import android.support.annotation.WorkerThread;
 import com.microsoft.appcenter.channel.Channel;
 import com.microsoft.appcenter.ingestion.models.json.LogFactory;
 import com.microsoft.appcenter.utils.AppCenterLog;
-import com.microsoft.appcenter.utils.HandlerUtils;
 import com.microsoft.appcenter.utils.async.AppCenterFuture;
 import com.microsoft.appcenter.utils.async.DefaultAppCenterFuture;
 import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
@@ -353,58 +352,6 @@ public abstract class AbstractAppCenterService implements AppCenterService {
 
             /* App Center is not configured if we reach this. */
             disabledOrNotStartedRunnable.run();
-        }
-    }
-
-    /**
-     * Like {{@link #post(Runnable)}} but also post back in U.I. thread.
-     * Use this for example to manage life cycle callbacks to make sure SDK is started and that
-     * every operation runs in order.
-     * <p>
-     * This method will not run the command if the SDK is disabled, the purpose is for internal commands, not APIs.
-     *
-     * @param runnable command to run.
-     */
-    protected synchronized void postOnUiThread(final Runnable runnable) {
-
-        /*
-         * We don't try to optimize with if channel if not null as there could be race conditions:
-         * If onResume was queued, then onStarted called, onResume will be next in queue and thus
-         * onPause could be called between the queued onStarted and the queued onResume.
-         */
-        post(new Runnable() {
-
-            @Override
-            public void run() {
-
-                /* And make sure we run the original command on U.I. thread. */
-                HandlerUtils.runOnUiThread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        runIfEnabled(runnable);
-                    }
-                });
-            }
-        }, new Runnable() {
-
-            @Override
-            public void run() {
-
-                /* Avoid logging SDK disabled by providing an empty command. */
-            }
-        }, null);
-    }
-
-    /**
-     * Run the command only if service is enabled.
-     * The method is top level just because code coverage when using synchronized.
-     *
-     * @param runnable command to run.
-     */
-    private synchronized void runIfEnabled(Runnable runnable) {
-        if (isInstanceEnabled()) {
-            runnable.run();
         }
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -105,8 +105,7 @@ subprojects {
         def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
         sourceDirectories.from = files(["$projectDir/src/main/java"])
         classDirectories.from = files([
-                fileTree(dir: "$buildDir/intermediates/classes/debug", excludes: fileFilter),
-                fileTree(dir: "$buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+                fileTree(dir: "$buildDir/intermediates/javac/debug/classes", excludes: fileFilter)
         ])
         executionData.from = fileTree(dir: buildDir, includes: [
                 'jacoco/testDebugUnitTest.exec',


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] ~~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~~
* [ ] ~~Did you check UI tests on the sample app? They are not executed on CI.~~

## Description

The code coverage has been broken on Android since we bumped up the Gradle plugin version. 
This PR:
- Fixes the code coverage task
- Adds and changes tests to reach 100% coverage
- Removes unused methods (postOnUiThread & runIfEnabled)

## Related PRs or issues

[AB#84105](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=84105)
