### PR TITLE
Fix show title in the push notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for Android Change Log
 
+## Version 4.1.1 (Under development)
+
+### App Center Distribute
+
+* **[Fix]** Fix show title in the push notification during downloading a new release.
+
 ## Version 4.1.0
 
 ### App Center Crashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix show title in the push notification during downloading a new release.
+* **[Fix]** Fix showing the title in the push notification while downloading a new release.
 
 ## Version 4.1.0
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -15,6 +15,7 @@ import android.support.annotation.AnyThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
+import com.microsoft.appcenter.distribute.R;
 import com.microsoft.appcenter.distribute.ReleaseDetails;
 import com.microsoft.appcenter.distribute.download.AbstractReleaseDownloader;
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -117,7 +118,7 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
             AppCenterLog.debug(LOG_TAG, "Downloading is already in progress.");
             return;
         }
-        mRequestTask = AsyncTaskUtils.execute(LOG_TAG, new DownloadManagerRequestTask(this));
+        mRequestTask = AsyncTaskUtils.execute(LOG_TAG, new DownloadManagerRequestTask(this, mContext.getString(R.string.appcenter_distribute_downloading_version)));
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
@@ -37,7 +37,7 @@ class DownloadManagerRequestTask extends AsyncTask<Void, Void, Void> {
         AppCenterLog.debug(LOG_TAG, "Start downloading new release from " + downloadUrl);
         DownloadManager downloadManager = mDownloader.getDownloadManager();
         DownloadManager.Request request = createRequest(downloadUrl);
-        request.setTitle(String.format("%s %s (%s)", mTitle, releaseDetails.getShortVersion(), releaseDetails.getVersion()));
+        request.setTitle(String.format(mTitle, releaseDetails.getShortVersion(), releaseDetails.getVersion()));
 
         /* Hide mandatory download to prevent canceling via notification cancel or download UI delete. */
         if (releaseDetails.isMandatoryUpdate()) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
@@ -35,6 +35,7 @@ class DownloadManagerRequestTask extends AsyncTask<Void, Void, Void> {
         AppCenterLog.debug(LOG_TAG, "Start downloading new release from " + downloadUrl);
         DownloadManager downloadManager = mDownloader.getDownloadManager();
         DownloadManager.Request request = createRequest(downloadUrl);
+        request.setTitle(String.format("Downloading version %s (%s)", releaseDetails.getShortVersion(), releaseDetails.getVersion()));
 
         /* Hide mandatory download to prevent canceling via notification cancel or download UI delete. */
         if (releaseDetails.isMandatoryUpdate()) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
@@ -21,9 +21,11 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
 class DownloadManagerRequestTask extends AsyncTask<Void, Void, Void> {
 
     private final DownloadManagerReleaseDownloader mDownloader;
+    private String mTitle;
 
-    DownloadManagerRequestTask(DownloadManagerReleaseDownloader downloader) {
+    DownloadManagerRequestTask(DownloadManagerReleaseDownloader downloader, String title) {
         mDownloader = downloader;
+        mTitle = title;
     }
 
     @Override
@@ -35,7 +37,7 @@ class DownloadManagerRequestTask extends AsyncTask<Void, Void, Void> {
         AppCenterLog.debug(LOG_TAG, "Start downloading new release from " + downloadUrl);
         DownloadManager downloadManager = mDownloader.getDownloadManager();
         DownloadManager.Request request = createRequest(downloadUrl);
-        request.setTitle(String.format("Downloading version %s (%s)", releaseDetails.getShortVersion(), releaseDetails.getVersion()));
+        request.setTitle(String.format("%s %s (%s)", mTitle, releaseDetails.getShortVersion(), releaseDetails.getVersion()));
 
         /* Hide mandatory download to prevent canceling via notification cancel or download UI delete. */
         if (releaseDetails.isMandatoryUpdate()) {

--- a/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
+++ b/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
@@ -17,6 +17,7 @@
     <!-- TODO: Deprecated. Remove this key and move the translated strings to appcenter_distribute_downloading_update. -->
     <string name="appcenter_distribute_downloading_mandatory_update">Downloading update</string>
     <!-- TODO: Add translations. -->
+    <string name="appcenter_distribute_downloading_version" tools:ignore="MissingTranslation">Downloading version</string>
     <string name="appcenter_distribute_downloading_error" tools:ignore="MissingTranslation">Failed to download app update</string>
     <string name="appcenter_distribute_download_progress_number_format">%1$d MB of %2$d MB</string>
     <string name="appcenter_distribute_install_ready_title">App update downloaded</string>

--- a/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
+++ b/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
@@ -17,7 +17,7 @@
     <!-- TODO: Deprecated. Remove this key and move the translated strings to appcenter_distribute_downloading_update. -->
     <string name="appcenter_distribute_downloading_mandatory_update">Downloading update</string>
     <!-- TODO: Add translations. -->
-    <string name="appcenter_distribute_downloading_version" tools:ignore="MissingTranslation">Downloading version</string>
+    <string name="appcenter_distribute_downloading_version" tools:ignore="MissingTranslation">Downloading version %s (%s)</string>
     <string name="appcenter_distribute_downloading_error" tools:ignore="MissingTranslation">Failed to download app update</string>
     <string name="appcenter_distribute_download_progress_number_format">%1$d MB of %2$d MB</string>
     <string name="appcenter_distribute_install_ready_title">App update downloaded</string>

--- a/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
+++ b/sdk/appcenter-distribute/src/main/res/values/appcenter_distribute.xml
@@ -17,7 +17,7 @@
     <!-- TODO: Deprecated. Remove this key and move the translated strings to appcenter_distribute_downloading_update. -->
     <string name="appcenter_distribute_downloading_mandatory_update">Downloading update</string>
     <!-- TODO: Add translations. -->
-    <string name="appcenter_distribute_downloading_version" tools:ignore="MissingTranslation">Downloading version %s (%s)</string>
+    <string name="appcenter_distribute_downloading_version" tools:ignore="MissingTranslation">Downloading version %1$s (%2$d)</string>
     <string name="appcenter_distribute_downloading_error" tools:ignore="MissingTranslation">Failed to download app update</string>
     <string name="appcenter_distribute_download_progress_number_format">%1$d MB of %2$d MB</string>
     <string name="appcenter_distribute_install_ready_title">App update downloaded</string>

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
@@ -61,24 +61,33 @@ public class DownloadManagerRequestTaskTest {
 
     @Test
     public void downloadStarted() {
+        when(mReleaseDetails.getVersion()).thenReturn(1);
+        when(mReleaseDetails.getShortVersion()).thenReturn("1");
         when(mReleaseDetails.isMandatoryUpdate()).thenReturn(false);
 
         /* Perform background task. */
         mRequestTask.doInBackground();
 
         /* Verify. */
+        String expectedTitle = "Downloading version 1 (1)";
+        verify(mDownloadManagerRequest).setTitle(eq(expectedTitle));
         verifyZeroInteractions(mDownloadManagerRequest);
         verify(mDownloader).onDownloadStarted(eq(DOWNLOAD_ID), anyLong());
     }
 
     @Test
     public void hideNotificationOnMandatoryUpdate() {
+        when(mReleaseDetails.getVersion()).thenReturn(1);
+        when(mReleaseDetails.getShortVersion()).thenReturn("1");
+        when(mReleaseDetails.isMandatoryUpdate()).thenReturn(false);
         when(mReleaseDetails.isMandatoryUpdate()).thenReturn(true);
 
         /* Perform background task. */
         mRequestTask.doInBackground();
 
         /* Verify. */
+        String expectedTitle = "Downloading version 1 (1)";
+        verify(mDownloadManagerRequest).setTitle(eq(expectedTitle));
         verify(mDownloadManagerRequest).setNotificationVisibility(DownloadManager.Request.VISIBILITY_HIDDEN);
         verify(mDownloadManagerRequest).setVisibleInDownloadsUi(false);
         verify(mDownloader).onDownloadStarted(eq(DOWNLOAD_ID), anyLong());

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
@@ -55,7 +55,7 @@ public class DownloadManagerRequestTaskTest {
         when(mDownloader.getDownloadManager()).thenReturn(mDownloadManager);
 
         /* Create RequestTask. */
-        mRequestTask = spy(new DownloadManagerRequestTask(mDownloader));
+        mRequestTask = spy(new DownloadManagerRequestTask(mDownloader, "title"));
         when(mRequestTask.createRequest(any(Uri.class))).thenReturn(mDownloadManagerRequest);
     }
 
@@ -69,7 +69,7 @@ public class DownloadManagerRequestTaskTest {
         mRequestTask.doInBackground();
 
         /* Verify. */
-        String expectedTitle = "Downloading version 1 (1)";
+        String expectedTitle = "title 1 (1)";
         verify(mDownloadManagerRequest).setTitle(eq(expectedTitle));
         verifyZeroInteractions(mDownloadManagerRequest);
         verify(mDownloader).onDownloadStarted(eq(DOWNLOAD_ID), anyLong());
@@ -86,7 +86,7 @@ public class DownloadManagerRequestTaskTest {
         mRequestTask.doInBackground();
 
         /* Verify. */
-        String expectedTitle = "Downloading version 1 (1)";
+        String expectedTitle = "title 1 (1)";
         verify(mDownloadManagerRequest).setTitle(eq(expectedTitle));
         verify(mDownloadManagerRequest).setNotificationVisibility(DownloadManager.Request.VISIBILITY_HIDDEN);
         verify(mDownloadManagerRequest).setVisibleInDownloadsUi(false);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTaskTest.java
@@ -55,7 +55,7 @@ public class DownloadManagerRequestTaskTest {
         when(mDownloader.getDownloadManager()).thenReturn(mDownloadManager);
 
         /* Create RequestTask. */
-        mRequestTask = spy(new DownloadManagerRequestTask(mDownloader, "title"));
+        mRequestTask = spy(new DownloadManagerRequestTask(mDownloader, "title %1$s (%2$d)"));
         when(mRequestTask.createRequest(any(Uri.class))).thenReturn(mDownloadManagerRequest);
     }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

The title has not clear information on the push notification during downloading new release.

**Expected behavior**
Title should contains information about downloading release (version and short version)

**Actual behavior**
Title contains `<Untitled>` string instead.

## Related PRs or issues

[AB#84082](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/84082)
