### PR TITLE
Fix crash on disabled download manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### App Center Distribute
 
+* **[Fix]** Fix a crash when download manager application was disabled.
 * **[Fix]** Fix showing the title in the push notification while downloading a new release.
 
 ### App Center Crashes

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerRequestTask.java
@@ -45,11 +45,14 @@ class DownloadManagerRequestTask extends AsyncTask<Void, Void, Void> {
             request.setVisibleInDownloadsUi(false);
         }
         long enqueueTime = System.currentTimeMillis();
-        long downloadId = downloadManager.enqueue(request);
-        if (isCancelled()) {
-            return null;
+        try {
+            long downloadId = downloadManager.enqueue(request);
+            if (!isCancelled()) {
+                mDownloader.onDownloadStarted(downloadId, enqueueTime);
+            }
+        } catch (IllegalArgumentException e) {
+            AppCenterLog.error(LOG_TAG, "Failed to download: download manager app is disabled.");
         }
-        mDownloader.onDownloadStarted(downloadId, enqueueTime);
         return null;
     }
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

This PR addresses a case when android download manager app was disabled in settings, which in turn led to crash when SDK tried to download new apk.

## Related PRs or issues

AB#85360
#1477