### PR TITLE
Issue #1506. Declared android:exported explicitly for components with intent-filter. Android 12 requirement

### DIFF
--- a/apps/sasquatch/src/main/AndroidManifest.xml
+++ b/apps/sasquatch/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         tools:targetApi="n">
         <activity
             android:name=".activities.MainActivity"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sdk/appcenter-distribute/src/main/AndroidManifest.xml
+++ b/sdk/appcenter-distribute/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
     <application>
         <activity
             android:name="com.microsoft.appcenter.distribute.DeepLinkActivity"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@android:style/Theme.NoDisplay"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -38,7 +39,9 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name="com.microsoft.appcenter.distribute.DownloadManagerReceiver">
+        <receiver 
+            android:name="com.microsoft.appcenter.distribute.DownloadManagerReceiver"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
                 <action android:name="android.intent.action.DOWNLOAD_NOTIFICATION_CLICKED" />


### PR DESCRIPTION
## Description

Android 12 requires to declare the`android:exported` attribute explicitly for components with `intent-filter`
Documentation link: https://developer.android.com/about/versions/12/behavior-changes-12#exported

## Related PRs or issues

Issue: https://github.com/microsoft/appcenter-sdk-android/issues/1506
