### PR TITLE
Fix Distribute module ANR issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.2.1 (Under active development)
 
+### App Center Distribute
+
+* **[Fix]** Fix a rare deadlock case when a new version starts downloading and at the same moment the download status is checked.
+
 ___
 
 ## Version 4.2.0

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1753,6 +1753,7 @@ public class Distribute extends AbstractAppCenterService {
      * @param intent         prepared install intent.
      * @return false if install U.I should be shown now, true if a notification was posted or if the task was canceled.
      */
+    @UiThread
     synchronized boolean notifyDownload(ReleaseDetails releaseDetails, Intent intent) {
 
         /* Check state. */
@@ -1903,7 +1904,7 @@ public class Distribute extends AbstractAppCenterService {
      * @param releaseDetails to check state change.
      * @param enqueueTime    timestamp in milliseconds just before enqueuing download.
      */
-    @WorkerThread
+    @UiThread
     synchronized void setDownloading(@NonNull ReleaseDetails releaseDetails, long enqueueTime) {
         if (releaseDetails != mReleaseDetails) {
             return;
@@ -1917,7 +1918,7 @@ public class Distribute extends AbstractAppCenterService {
      *
      * @param releaseDetails to check state change.
      */
-    @WorkerThread
+    @UiThread
     synchronized void setInstalling(@NonNull ReleaseDetails releaseDetails) {
         if (releaseDetails != mReleaseDetails) {
             return;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
@@ -79,8 +79,6 @@ class ReleaseDownloadListener implements ReleaseDownloader.Listener {
         AppCenterLog.verbose(LOG_TAG, String.format(Locale.ENGLISH, "Downloading %s (%d) update: %d KiB / %d KiB",
                 mReleaseDetails.getShortVersion(), mReleaseDetails.getVersion(),
                 currentSize / KIBIBYTE_IN_BYTES, totalSize / KIBIBYTE_IN_BYTES));
-
-        // Run on the UI thread to prevent deadlock.
         HandlerUtils.runOnUiThread(new Runnable() {
 
             @Override

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerDistributeDeadlockTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerDistributeDeadlockTest.java
@@ -1,0 +1,285 @@
+package com.microsoft.appcenter.distribute.download.manager;
+
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import com.microsoft.appcenter.AppCenterHandler;
+import com.microsoft.appcenter.channel.Channel;
+import com.microsoft.appcenter.distribute.Distribute;
+import com.microsoft.appcenter.distribute.R;
+import com.microsoft.appcenter.distribute.ReleaseDetails;
+import com.microsoft.appcenter.distribute.download.ReleaseDownloader;
+import com.microsoft.appcenter.utils.AppCenterLog;
+import com.microsoft.appcenter.utils.AppNameHelper;
+import com.microsoft.appcenter.utils.HandlerUtils;
+import com.microsoft.appcenter.utils.storage.SharedPreferencesManager;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.runners.statements.FailOnTimeout;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.microsoft.appcenter.distribute.DistributeConstants.INVALID_DOWNLOAD_IDENTIFIER;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
+import static com.microsoft.appcenter.utils.PrefStorageConstants.ALLOWED_NETWORK_REQUEST;
+import static com.microsoft.appcenter.utils.PrefStorageConstants.KEY_ENABLED;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+
+@PrepareForTest({
+        SharedPreferencesManager.class,
+        AppCenterLog.class,
+        AppNameHelper.class,
+        Distribute.class,
+        HandlerUtils.class
+})
+public class DownloadManagerDistributeDeadlockTest {
+
+    private static final long DOWNLOAD_ID = 42;
+
+    private static final String DISTRIBUTE_ENABLED_KEY = KEY_ENABLED + "_Distribute";
+
+    private static final int MIN_TIMEOUT = 5000;
+
+    @Rule
+    public Timeout mTimeout = new Timeout(MIN_TIMEOUT, TimeUnit.MILLISECONDS) {
+        public Statement apply(Statement base, final Description description) {
+
+            /* We use the constructor because we can't use the builder and override evaluate method at the same time. */
+            return new FailOnTimeout(base, MIN_TIMEOUT) {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        super.evaluate();
+                    } catch (Throwable e) {
+                        System.out.println("Caught timeout exception in: " + description.getMethodName());
+                        if (description.getAnnotation(TimeoutExpected.class) != null) {
+                            System.out.println("Ignore, timeout expected");
+                            return;
+                        }
+                        System.out.println("Throw timeout exception");
+                        throw new TimeoutException();
+                    }
+                }
+            };
+        }
+    };
+
+    @Rule
+    public PowerMockRule mPowerMockRule = new PowerMockRule();
+
+    @Mock
+    Context mContext;
+
+    @Mock
+    Activity mActivity;
+
+    @Mock
+    AlertDialog mDialog;
+
+    @Mock
+    PackageManager mPackageManager;
+
+    @Mock
+    ApplicationInfo mApplicationInfo;
+
+    @Mock
+    AppCenterHandler mAppCenterHandler;
+
+    @Mock
+    ReleaseDetails mReleaseDetails;
+
+    @Mock
+    Channel mChannel;
+
+    @Before
+    public void initDownloader() throws Exception {
+
+        /* 'unsetInstance' has package-private visibility. We don't need to break it for the test. */
+        Method unsetInstanceMethod = Distribute.class.getDeclaredMethod("unsetInstance");
+        unsetInstanceMethod.setAccessible(true);
+        unsetInstanceMethod.invoke(null);
+
+        /* First call to com.microsoft.appcenter.AppCenter.isEnabled shall return true, initial state. */
+        mockStatic(SharedPreferencesManager.class);
+        when(SharedPreferencesManager.getBoolean(DISTRIBUTE_ENABLED_KEY, true)).thenReturn(true);
+        when(SharedPreferencesManager.getBoolean(ALLOWED_NETWORK_REQUEST, true)).thenReturn(true);
+
+        /* Default download id when not found. */
+        when(SharedPreferencesManager.getLong(PREFERENCE_KEY_DOWNLOAD_ID, INVALID_DOWNLOAD_IDENTIFIER)).thenReturn(INVALID_DOWNLOAD_IDENTIFIER);
+
+        /* Mock package manager. */
+        when(mContext.getApplicationContext()).thenReturn(mContext);
+        when(mContext.getPackageName()).thenReturn("com.contoso");
+        when(mActivity.getPackageName()).thenReturn("com.contoso");
+        when(mContext.getApplicationInfo()).thenReturn(mApplicationInfo);
+        when(mActivity.getApplicationInfo()).thenReturn(mApplicationInfo);
+        when(mContext.getPackageManager()).thenReturn(mPackageManager);
+        when(mActivity.getPackageManager()).thenReturn(mPackageManager);
+        PackageInfo packageInfo = mock(PackageInfo.class);
+        when(mPackageManager.getPackageInfo("com.contoso", 0)).thenReturn(packageInfo);
+        Whitebox.setInternalState(packageInfo, "packageName", "com.contoso");
+        Whitebox.setInternalState(packageInfo, "versionName", "1.2.3");
+        Whitebox.setInternalState(packageInfo, "versionCode", 6);
+        Whitebox.setInternalState(packageInfo, "lastUpdateTime", 2);
+
+        /* Mock app name and other string resources. */
+        mockStatic(AppNameHelper.class);
+        when(AppNameHelper.getAppName(mContext)).thenReturn("unit-test-app");
+        when(mContext.getString(R.string.appcenter_distribute_update_dialog_message_optional)).thenReturn("%s%s%d");
+        when(mContext.getString(R.string.appcenter_distribute_update_dialog_message_mandatory)).thenReturn("%s%s%d");
+        when(mContext.getString(R.string.appcenter_distribute_install_ready_message)).thenReturn("%s%s%d");
+    }
+
+    @Test
+    @TimeoutExpected
+    public void deadlockExpected() throws Exception {
+        testDeadlock(false);
+    }
+
+    @Test
+    public void deadlockFixed() throws Exception {
+        testDeadlock(true);
+    }
+
+    public void testDeadlock(final boolean handlerOn) throws Exception {
+
+        /* Init release downloader listener. The implementation is package private, therefore we use reflection here. */
+        Class<?> downloadListenerClass = Class.forName("com.microsoft.appcenter.distribute.ReleaseDownloadListener");
+        Constructor<?> downloadListenerDeclaredConstructor = downloadListenerClass.getDeclaredConstructor(Context.class, ReleaseDetails.class);
+        downloadListenerDeclaredConstructor.setAccessible(true);
+        ReleaseDownloader.Listener releaseDownloadListener = (ReleaseDownloader.Listener) downloadListenerDeclaredConstructor.newInstance(mContext, mReleaseDetails);
+
+        /* Init release downloader. */
+        final DownloadManagerReleaseDownloader mReleaseDownloader = new DownloadManagerReleaseDownloader(mContext, mReleaseDetails, releaseDownloadListener);
+
+        /* Mock release details. */
+        when(mReleaseDetails.getVersion()).thenReturn(1);
+        when(mReleaseDetails.isMandatoryUpdate()).thenReturn(false);
+
+        /* If we don't stub this method, the onActivityResumed thread will try to display the dialog. */
+        Distribute distribute = spy(Distribute.getInstance());
+        PowerMockito.when(distribute, "shouldRefreshDialog", mDialog).thenReturn(false);
+
+        /* Simulate we already have release details initialized, otherwise we would have to implement it naturally and the test would become unnecessarily large. */
+        Field privateStringField = Distribute.getInstance().getClass().getDeclaredField("mReleaseDetails");
+        privateStringField.setAccessible(true);
+        privateStringField.set(Distribute.getInstance(), mReleaseDetails);
+        Field privateStringField2 = Distribute.getInstance().getClass().getDeclaredField("mReleaseDownloader");
+        privateStringField2.setAccessible(true);
+        privateStringField2.set(Distribute.getInstance(), mReleaseDownloader);
+
+        /* Init the barrier in order to align concurrent threads execution. */
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final int cycles = 50;
+
+        /* We use executor service for the following Android Handler simulation. */
+        final ExecutorService uiThreadExecutor = Executors.newSingleThreadExecutor();
+
+        /* Handler Utils. */
+        Answer<Void> runNow = new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                Runnable runnable = (Runnable) invocation.getArguments()[0];
+                if (handlerOn) {
+
+                    /* Submit the runnable to the ui thread executor, mimics HandlerUtils.runOnUiThread behavior. */
+                    uiThreadExecutor.submit(runnable);
+                } else {
+
+                    /* Run immediately on the same thread. */
+                    runnable.run();
+                }
+                return null;
+            }
+        };
+        mockStatic(HandlerUtils.class);
+        doAnswer(runNow).when(HandlerUtils.class);
+        HandlerUtils.runOnUiThread(any(Runnable.class));
+
+        /* UI thread scenario. */
+        Callable<Object> onActivityResumedCallable = new Callable<Object>() {
+
+            @Override
+            public Object call() {
+
+                /* Prepare distribute setup. */
+                Distribute.getInstance().onStarting(mAppCenterHandler);
+                Distribute.getInstance().onStarted(mContext, mChannel, "a", null, true);
+                waitAnotherThreadAndStartExecution(barrier);
+                for (int i = 0; i < cycles; i++) {
+
+                    /* The enter point of the deadlock case. */
+                    Distribute.getInstance().onActivityResumed(mActivity);
+                }
+                return null;
+            }
+        };
+
+        /* Worker thread scenario. */
+        Runnable downloadRunnable = new Runnable() {
+
+            @Override
+            public void run() {
+                waitAnotherThreadAndStartExecution(barrier);
+                for (int i = 0; i < cycles; i++) {
+
+                    /* The enter point of the deadlock case. */
+                    mReleaseDownloader.onDownloadStarted(DOWNLOAD_ID, 0);
+                }
+            }
+        };
+        final Thread backgroundThread = new Thread(downloadRunnable, "background-thread");
+
+        /* Start execution. */
+        Future<Object> submit = uiThreadExecutor.submit(onActivityResumedCallable);
+        backgroundThread.start();
+
+        /* Wait for the execution to complete. */
+        submit.get();
+        backgroundThread.join();
+    }
+
+    private void waitAnotherThreadAndStartExecution(CyclicBarrier barrier) {
+        try {
+
+            /* Wait for another thread to reach this point, to simulate deadlock timing. */
+            barrier.await();
+        } catch (BrokenBarrierException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerDistributeDeadlockTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerDistributeDeadlockTest.java
@@ -227,6 +227,7 @@ public class DownloadManagerDistributeDeadlockTest {
     @Test
     public void onDownloadStartedTest() throws Exception {
         testDeadlock(true, new Runnable() {
+
             @Override
             public void run() {
                 mReleaseDownloader.onDownloadStarted(DOWNLOAD_ID, 0);
@@ -240,6 +241,7 @@ public class DownloadManagerDistributeDeadlockTest {
 
         /* Deadlock simulation. The same can be used for other callbacks of ReleaseDownloadListener. */
         testDeadlock(false, new Runnable() {
+
             @Override
             public void run() {
                 mReleaseDownloader.onDownloadStarted(DOWNLOAD_ID, 0);
@@ -250,6 +252,7 @@ public class DownloadManagerDistributeDeadlockTest {
     @Test
     public void onDownloadCompleteTest() throws Exception {
         testDeadlock(true, new Runnable() {
+
             @Override
             public void run() {
                 mReleaseDownloader.onDownloadComplete(mCursor);
@@ -260,6 +263,7 @@ public class DownloadManagerDistributeDeadlockTest {
     @Test
     public void onDownloadErrorTest() throws Exception {
         testDeadlock(true, new Runnable() {
+
             @Override
             public void run() {
                 mReleaseDownloader.onDownloadError(new RuntimeException("test"));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/TimeoutExpected.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/TimeoutExpected.java
@@ -1,0 +1,11 @@
+package com.microsoft.appcenter.distribute.download.manager;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface TimeoutExpected {
+}


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

This PR fixes the rare deadlock case when a new version starts downloading and at the same moment the download status is checked (along with a few other cases). The approach is the following: ease up the locking on one side of communication between the downloader and the main module by posting calls to the main module on the UI thread.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-android/issues/1533
[AB#86784](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Mobile%20SDK/Backlog%20Items/?workitem=86784)

## Misc

Deadlock stacktraces:
https://github.com/microsoft/appcenter-sdk-android/issues/1533#issuecomment-854288307
![1](https://user-images.githubusercontent.com/13853815/120732004-39d34980-c517-11eb-9547-ff19efaa1b21.png)
![2](https://user-images.githubusercontent.com/13853815/120731786-e660fb80-c516-11eb-8c7c-fcb3e095c259.png)