### PR TITLE
Fix intent flag for android apps lower 23 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### App Center Distribute
 
 * **[Fix]** Fix a rare deadlock case when a new version starts downloading and at the same moment the download status is checked.
+* **[Fix]** Fix passing pending intent flag for a completed download notification on Android lower then 23 API.
 
 ___
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1798,7 +1798,6 @@ public class Distribute extends AbstractAppCenterService {
                 .setContentText(getInstallReadyMessage())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
                 .setContentIntent(PendingIntent.getActivities(mContext, 0, new Intent[]{intent}, pendingIntentFlag));
-
         builder.setStyle(new Notification.BigTextStyle().bigText(getInstallReadyMessage()));
         Notification notification = builder.build();
         notification.flags |= Notification.FLAG_AUTO_CANCEL;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1789,11 +1789,16 @@ public class Distribute extends AbstractAppCenterService {
         } else {
             builder = getOldNotificationBuilder();
         }
+        int pendingIntentFlag = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingIntentFlag = PendingIntent.FLAG_IMMUTABLE;
+        }
         builder.setTicker(mContext.getString(R.string.appcenter_distribute_install_ready_title))
                 .setContentTitle(mContext.getString(R.string.appcenter_distribute_install_ready_title))
                 .setContentText(getInstallReadyMessage())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
-                .setContentIntent(PendingIntent.getActivities(mContext, 0, new Intent[]{intent}, PendingIntent.FLAG_IMMUTABLE));
+                .setContentIntent(PendingIntent.getActivities(mContext, 0, new Intent[]{intent}, pendingIntentFlag));
+
         builder.setStyle(new Notification.BigTextStyle().bigText(getInstallReadyMessage()));
         Notification notification = builder.build();
         notification.flags |= Notification.FLAG_AUTO_CANCEL;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Fix intent flag for android apps lower 23 API.

## Related PRs or issues
[AB#87052](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/87052)