### PR TITLE
Add a new property isOneCollectorEnabled to startService log

### DIFF
--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/AppCenter.java
@@ -1024,6 +1024,7 @@ public class AppCenter {
             mStartedServicesNamesToLog.clear();
             StartServiceLog startServiceLog = new StartServiceLog();
             startServiceLog.setServices(allServiceNamesToStart);
+            startServiceLog.oneCollectorEnabled(mTransmissionTargetToken != null);
             mChannel.enqueue(startServiceLog, CORE_GROUP, Flags.DEFAULTS);
         }
     }

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/StartServiceLog.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/ingestion/models/StartServiceLog.java
@@ -26,6 +26,13 @@ public class StartServiceLog extends AbstractLog {
 
     private static final String SERVICES = "services";
 
+    private static final String IS_ONE_COLLECTOR_ENABLED = "isOneCollectorEnabled";
+
+    /**
+     * OneCollector usage status.
+     */
+    private boolean isOneCollectorEnabled = false;
+
     /**
      * The list of services of the AppCenter start call.
      */
@@ -54,16 +61,26 @@ public class StartServiceLog extends AbstractLog {
         this.services = services;
     }
 
+    public void oneCollectorEnabled(boolean isEnabled) {
+        isOneCollectorEnabled = isEnabled;
+    }
+
+    public boolean isOneCollectorEnabled() {
+        return isOneCollectorEnabled;
+    }
+
     @Override
     public void read(JSONObject object) throws JSONException {
         super.read(object);
         setServices(JSONUtils.readStringArray(object, SERVICES));
+        oneCollectorEnabled(JSONUtils.readBoolean(object, IS_ONE_COLLECTOR_ENABLED));
     }
 
     @Override
     public void write(JSONStringer writer) throws JSONException {
         super.write(writer);
         JSONUtils.writeStringArray(writer, SERVICES, getServices());
+        JSONUtils.write(writer, IS_ONE_COLLECTOR_ENABLED, isOneCollectorEnabled());
     }
 
     @Override

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/AppCenterTest.java
@@ -109,6 +109,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(false));
     }
 
     @Test
@@ -140,6 +141,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         services.add(service.getServiceName());
         services.add(anotherService.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(false));
     }
 
     @Test
@@ -160,6 +162,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(false));
     }
 
     @Test
@@ -179,6 +182,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(false));
     }
 
     @Test
@@ -198,6 +202,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(true));
     }
 
     @Test
@@ -217,6 +222,7 @@ public class AppCenterTest extends AbstractAppCenterTest {
         List<String> services = new ArrayList<>();
         services.add(service.getServiceName());
         verify(mStartServiceLog).setServices(eq(services));
+        verify(mStartServiceLog).oneCollectorEnabled(eq(false));
     }
 
     @Test

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/StartServiceLogTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/ingestion/models/StartServiceLogTest.java
@@ -45,11 +45,13 @@ public class StartServiceLogTest {
         services.add("FIRST");
         services.add("SECOND");
         a.setServices(services);
+        a.oneCollectorEnabled(true);
         checkEquals(a.getServices(), services);
         checkNotEquals(a, b);
         b.setServices(new ArrayList<String>());
         checkNotEquals(a, b);
         b.setServices(services);
+        b.oneCollectorEnabled(true);
         checkEquals(a, b);
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Add a new property to startService log.

## Related PRs or issues

[AB#89379](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89379)