### PR TITLE
Patch with fixes after testing release 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * **[Feature]** Remove the download manager task if the download doesn't start within 10 seconds.
 * **[Feature]** Replace installing a new release using the deprecated intent action [ACTION_INSTALL_PACKAGE](https://developer.android.com/reference/android/content/Intent#ACTION_INSTALL_PACKAGE) with the `PackageInstaller` API.
 * **[Feature]** Add sumcheck on the downloaded file before starting the install process.
+* **[Fix]** Fix a crash after discarding the installation if the download of a new release was interrupted in the previous application start and resumed in the current one.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Center SDK for Android Change Log
 
-## Version 4.4.0
+## Version 4.4.1
 
 ### App Center
 

--- a/apps/sasquatch/build.gradle
+++ b/apps/sasquatch/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     projectDependencyImplementation project(':sdk:appcenter-analytics')
     projectDependencyImplementation project(':sdk:appcenter-crashes')
 
-    def appCenterSdkVersion = "4.4.1"
+    def appCenterSdkVersion = "4.4.0"
     mavenCentralDependencyImplementation "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"
     mavenCentralDependencyImplementation "com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}"
 

--- a/apps/sasquatch/build.gradle
+++ b/apps/sasquatch/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     projectDependencyImplementation project(':sdk:appcenter-analytics')
     projectDependencyImplementation project(':sdk:appcenter-crashes')
 
-    def appCenterSdkVersion = "4.4.0"
+    def appCenterSdkVersion = "4.4.1"
     mavenCentralDependencyImplementation "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"
     mavenCentralDependencyImplementation "com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}"
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ActivityConstants.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/ActivityConstants.java
@@ -20,5 +20,5 @@ final class ActivityConstants {
     /**
      * Default Analytics transmission interval in seconds.
      */
-    static final int DEFAULT_TRANSMISSION_INTERVAL_IN_SECONDS = 3;
+    static final int DEFAULT_TRANSMISSION_INTERVAL_IN_SECONDS = 6;
 }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1952,6 +1952,10 @@ public class Distribute extends AbstractAppCenterService {
      * @param totalSize total size of downloaded file.
      */
     synchronized void showSystemSettingsDialogOrStartInstalling(long downloadId, long totalSize) {
+        if (mReleaseInstallerListener == null) {
+            AppCenterLog.debug(LOG_TAG, "Installing couldn't start due to the release installer wasn't initialized.");
+            return;
+        }
         mReleaseInstallerListener.setDownloadId(downloadId);
         mReleaseInstallerListener.setTotalSize(totalSize);
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1540,7 +1540,7 @@ public class Distribute extends AbstractAppCenterService {
             }
             mUsingDefaultUpdateDialog = !customized;
         }
-        if (mUsingDefaultUpdateDialog) {
+        if (mUsingDefaultUpdateDialog != null && mUsingDefaultUpdateDialog) {
             if (!shouldRefreshDialog(mUpdateDialog)) {
                 return;
             }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -996,6 +996,17 @@ public class DistributeTest extends AbstractDistributeTest {
         verify(mReleaseInstallerListener, times(2)).hideInstallProgressDialog();
     }
 
+    @Test
+    public void showSystemSettingsDialogWhenPackageInstallerNull() {
+
+        /* Try to show dialog. */
+        Distribute.getInstance().showSystemSettingsDialogOrStartInstalling(1L, 1L);
+
+        /* Verify that log was called. */
+        verifyStatic();
+        AppCenterLog.debug(eq(LOG_TAG), eq("Installing couldn't start due to the release installer wasn't initialized."));
+    }
+
     private void firstDownloadNotification(int apiLevel) throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", apiLevel);
         mockStatic(DistributeUtils.class);

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 ext {
     versionCode = 65
-    versionName = '4.4.0'
+    versionName = '4.4.1'
     minSdkVersion = 21
     compileSdkVersion = 30
     targetSdkVersion = 30


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

1) Add null check before showing settings dialog
2) Fix UI for transmission interval

3) Fix crash. Repro steps:
- Launch app - see in-app update dialog
- Disable network connection and press on download button
- Close application
- Start the application again and enable network connection.
- Wait when downloading new release was completed and see confirmation dialog about installing a new release
- Discard installing the new release
- See crash:
```
Crashes.getLastSessionCrashReport().getStackTrace()=java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
        at com.microsoft.appcenter.distribute.Distribute.showUpdateDialog(Distribute.java:1543)
        at com.microsoft.appcenter.distribute.Distribute.handleApiCallSuccess(Distribute.java:1334)
        at com.microsoft.appcenter.distribute.Distribute.access$600(Distribute.java:109)
        at com.microsoft.appcenter.distribute.Distribute$4.onCallSucceeded(Distribute.java:1201)
        at com.microsoft.appcenter.http.HttpClientCallDecorator.onCallSucceeded(HttpClientCallDecorator.java:59)
        at com.microsoft.appcenter.http.HttpClientCallDecorator.onCallSucceeded(HttpClientCallDecorator.java:59)
        at com.microsoft.appcenter.http.DefaultHttpClientCallTask.onPostExecute(DefaultHttpClientCallTask.java:299)
```

[AB#89327](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89327)