### PR TITLE
Fix checking a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.4.3 (Under active development)
 
+### App Center Distribute
+
+* **[Fix]** Fix checking a new release if the application was already updated before.
+
 ___
 
 ## Version 4.4.2

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/InstallerUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/InstallerUtils.java
@@ -88,7 +88,7 @@ public class InstallerUtils {
         if (sInstalledFromAppStore == null) {
             String installer = context.getPackageManager().getInstallerPackageName(context.getPackageName());
             AppCenterLog.debug(logTag, "InstallerPackageName=" + installer);
-            sInstalledFromAppStore = installer != null && !LOCAL_STORES.contains(installer);
+            sInstalledFromAppStore = installer != null && !LOCAL_STORES.contains(installer) && !installer.equals(context.getPackageName());
         }
         return sInstalledFromAppStore;
     }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AppStoreDetectionTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/AppStoreDetectionTest.java
@@ -20,6 +20,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -80,6 +81,23 @@ public class AppStoreDetectionTest {
     @Test
     public void adbIsNotStore() {
         setInstallerPackageName("adb");
+
+        /* Check cache. */
+        verifyNotFromAppStore();
+    }
+
+    @Test
+    public void applicationInstallerIsNotStore() {
+        String mockPackage = "mock.package.name";
+
+        /* Mock context. */
+        Context mockContext = mock(Context.class);
+        when(mockContext.getPackageName()).thenReturn(mockPackage);
+        when(mockContext.getPackageManager()).thenReturn(mPackageManager);
+        mContext = mockContext;
+
+        /* Mock installer package name. */
+        setInstallerPackageName(mockPackage);
 
         /* Check cache. */
         verifyNotFromAppStore();


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

**Repro steps:**
1. Build the current app (v1.0) and distribute it from within the App Center
2. Download the app from the App Center (v1.0), then install it
3. Build and distribute another update (v1.1)
4. Open the app (v1.0), it would detect the update, then install it, this process will work fine
5. Build and distribute another update (v1.2)
6. Open the app(v1.1), the app won't detect the update, at this point any other updates won't be detected by the app. However, if I uninstall the currently installed app, then redownload the app (v1.1) from within the App Center, the app would detect the update (v1.2) with no issues.

**Expected**
A new release should be detected and SDK should show an in-app update dialog.

**Actual**
A new release isn't detected and SDK doesn't show an in-app update dialog.

## Related PRs or issues

[AB#89876](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89876)
#1594
