### PR TITLE
Fix clicks on the download notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.4.4 (Under active development)
 
+### App Center Distribute
+
+* **[Fix]** Fix clicks on the download notification.
+
  ___
 
 ## Version 4.4.3

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -13,6 +13,7 @@ import android.app.DownloadManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -1999,22 +2000,26 @@ public class Distribute extends AbstractAppCenterService {
             NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
                     mContext.getString(R.string.appcenter_distribute_notification_category),
                     NotificationManager.IMPORTANCE_DEFAULT);
-
-            //noinspection ConstantConditions
             notificationManager.createNotificationChannel(channel);
             builder = new Notification.Builder(mContext, NOTIFICATION_CHANNEL_ID);
         } else {
             builder = getOldNotificationBuilder();
         }
+
+        // TODO: Combine this and code from resumeApp.
+        Intent intent = new Intent(mContext, DeepLinkActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                mContext, 0, intent, 0);
+
         builder.setTicker(mContext.getString(R.string.appcenter_distribute_install_ready_title))
                 .setContentTitle(mContext.getString(R.string.appcenter_distribute_install_ready_title))
                 .setContentText(getInstallReadyMessage())
-                .setSmallIcon(mContext.getApplicationInfo().icon);
-        builder.setStyle(new Notification.BigTextStyle().bigText(getInstallReadyMessage()));
+                .setSmallIcon(mContext.getApplicationInfo().icon)
+                .setStyle(new Notification.BigTextStyle().bigText(getInstallReadyMessage()))
+                .setContentIntent(pendingIntent);
         Notification notification = builder.build();
         notification.flags |= Notification.FLAG_AUTO_CANCEL;
-
-        //noinspection ConstantConditions
         notificationManager.notify(DistributeUtils.getNotificationId(), notification);
         SharedPreferencesManager.putInt(PREFERENCE_KEY_DOWNLOAD_STATE, DOWNLOAD_STATE_NOTIFIED);
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1883,13 +1883,7 @@ public class Distribute extends AbstractAppCenterService {
 
         /* Nothing to do if already in foreground. */
         if (mForegroundActivity == null) {
-
-            /*
-             * Use our deep link activity with no parameter just to resume app correctly
-             * without duplicating activities or clearing task.
-             */
-            Intent intent = new Intent(context, DeepLinkActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            Intent intent = DistributeUtils.getResumeAppIntent(context);
             context.startActivity(intent);
         }
     }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -201,11 +201,6 @@ public final class DistributeConstants {
     static final long POSTPONE_TIME_THRESHOLD = 24 * 60 * 60 * 1000;
 
     /**
-     * Notification channel identifier.
-     */
-    static final String NOTIFICATION_CHANNEL_ID = "appcenter.distribute";
-
-    /**
      * Base key for stored preferences.
      */
     private static final String PREFERENCE_PREFIX = SERVICE_NAME + ".";

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -118,6 +118,17 @@ class DistributeUtils {
         return SharedPreferencesManager.getInt(PREFERENCE_KEY_DOWNLOAD_STATE, DOWNLOAD_STATE_COMPLETED);
     }
 
+    static Intent getResumeAppIntent(@NonNull Context context) {
+
+        /*
+         * Use our deep link activity with no parameter just to resume app correctly
+         * without duplicating activities or clearing task.
+         */
+        Intent intent = new Intent(context, DeepLinkActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return intent;
+    }
+
     @NonNull
     static String computeReleaseHash(@NonNull PackageInfo packageInfo) {
         return HashUtils.sha256(packageInfo.packageName + ":" + packageInfo.versionName + ":" + DeviceInfoHelper.getVersionCode(packageInfo));

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -17,6 +17,7 @@ import android.net.Uri;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.appcenter.utils.AppCenterLog;
 import com.microsoft.appcenter.utils.DeviceInfoHelper;
@@ -64,7 +65,8 @@ class DistributeUtils {
      *
      * @return notification identifier for downloads.
      */
-    private static int getNotificationId() {
+    @VisibleForTesting
+    static int getNotificationId() {
         return Distribute.class.getName().hashCode();
     }
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeUtils.java
@@ -6,9 +6,16 @@
 package com.microsoft.appcenter.distribute;
 
 import android.app.Activity;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.net.Uri;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 
 import com.microsoft.appcenter.utils.AppCenterLog;
@@ -48,12 +55,58 @@ class DistributeUtils {
     static final String TESTER_APP_PACKAGE_NAME = "com.microsoft.hockeyapp.testerapp";
 
     /**
+     * Notification channel identifier.
+     */
+    static final String NOTIFICATION_CHANNEL_ID = "appcenter.distribute";
+
+    /**
      * Get the notification identifier for downloads.
      *
      * @return notification identifier for downloads.
      */
-    static int getNotificationId() {
+    private static int getNotificationId() {
         return Distribute.class.getName().hashCode();
+    }
+
+    static void postDownloadNotification(@NonNull Context context, String message, Intent intent) {
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        Notification.Builder builder;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+            /* Create or update notification channel (mandatory on Android 8 target). */
+            NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
+                    context.getString(R.string.appcenter_distribute_notification_category),
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            notificationManager.createNotificationChannel(channel);
+            builder = new Notification.Builder(context, NOTIFICATION_CHANNEL_ID);
+        } else {
+            builder = getOldNotificationBuilder(context);
+        }
+        int pendingIntentFlag = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingIntentFlag = PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, pendingIntentFlag);
+        builder.setTicker(context.getString(R.string.appcenter_distribute_install_ready_title))
+                .setContentTitle(context.getString(R.string.appcenter_distribute_install_ready_title))
+                .setContentText(message)
+                .setSmallIcon(context.getApplicationInfo().icon)
+                .setStyle(new Notification.BigTextStyle().bigText(message))
+                .setContentIntent(pendingIntent);
+        Notification notification = builder.build();
+        notification.flags |= Notification.FLAG_AUTO_CANCEL;
+        notificationManager.notify(DistributeUtils.getNotificationId(), notification);
+    }
+
+    static void cancelDownloadNotification(@NonNull Context context) {
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.cancel(DistributeUtils.getNotificationId());
+    }
+
+    @NonNull
+    @SuppressWarnings({"deprecation", "RedundantSuppression"})
+    private static Notification.Builder getOldNotificationBuilder(@NonNull Context context) {
+        return new Notification.Builder(context);
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
@@ -13,6 +13,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.WorkerThread;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.widget.Toast;
 
 import com.microsoft.appcenter.distribute.download.ReleaseDownloader;
@@ -96,8 +98,13 @@ class ReleaseDownloadListener implements ReleaseDownloader.Listener {
             @Override
             public void run() {
 
+                /* Use intent to just resume app instead on install intent. */
+                // TODO: Combine with Distribute.resumeApp()
+                Intent intent = new Intent(mContext, DeepLinkActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
                 /* Check if app should install now. */
-                if (!Distribute.getInstance().notifyDownload(mReleaseDetails)) {
+                if (!Distribute.getInstance().notifyDownload(mReleaseDetails, intent)) {
                     AppCenterLog.info(LOG_TAG, "Release is downloaded. Starting to install it.");
                     Distribute.getInstance().setInstalling(mReleaseDetails);
                     Distribute.getInstance().showSystemSettingsDialogOrStartInstalling(downloadId, totalSize);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDownloadListener.java
@@ -99,9 +99,7 @@ class ReleaseDownloadListener implements ReleaseDownloader.Listener {
             public void run() {
 
                 /* Use intent to just resume app instead on install intent. */
-                // TODO: Combine with Distribute.resumeApp()
-                Intent intent = new Intent(mContext, DeepLinkActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                Intent intent = DistributeUtils.getResumeAppIntent(mContext);
 
                 /* Check if app should install now. */
                 if (!Distribute.getInstance().notifyDownload(mReleaseDetails, intent)) {

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -75,6 +76,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.reflect.Whitebox;
 
@@ -322,9 +324,11 @@ public class DistributeTest extends AbstractDistributeTest {
 
     @Test
     public void cancelingNotification() {
-        mockStatic(DistributeUtils.class);
-        when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_NOTIFIED);
-        when(DistributeUtils.getNotificationId()).thenReturn(2);
+        spy(DistributeUtils.class);
+        PowerMockito.doReturn(DOWNLOAD_STATE_NOTIFIED).when(DistributeUtils.class);
+        DistributeUtils.getStoredDownloadState();
+        PowerMockito.doReturn(0).when(DistributeUtils.class);
+        DistributeUtils.getNotificationId();
         NotificationManager manager = mock(NotificationManager.class);
         when(mContext.getSystemService(NOTIFICATION_SERVICE)).thenReturn(manager);
         Distribute.getInstance().onStarted(mContext, mChannel, "a", null, true);
@@ -355,7 +359,7 @@ public class DistributeTest extends AbstractDistributeTest {
         ReleaseDetails mockReleaseDetails = mock(ReleaseDetails.class);
 
         /* Call notify download. */
-        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mockReleaseDetails);
+        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mockReleaseDetails, null);
 
         /* Verify. */
         assertTrue(notifyDownloadResult);
@@ -375,7 +379,7 @@ public class DistributeTest extends AbstractDistributeTest {
         when(DistributeUtils.getStoredDownloadState()).thenReturn(DOWNLOAD_STATE_NOTIFIED);
 
         /* Call notify download. */
-        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mReleaseDetails);
+        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mReleaseDetails, null);
 
         /* Verify. */
         assertFalse(notifyDownloadResult);
@@ -395,7 +399,7 @@ public class DistributeTest extends AbstractDistributeTest {
         Distribute.getInstance().onActivityResumed(mock(Activity.class));
 
         /* Call notify download. */
-        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mReleaseDetails);
+        boolean notifyDownloadResult = Distribute.getInstance().notifyDownload(mReleaseDetails, null);
 
         /* Verify. */
         assertFalse(notifyDownloadResult);
@@ -407,7 +411,7 @@ public class DistributeTest extends AbstractDistributeTest {
         mockStatic(DistributeUtils.class);
         when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(mReleaseDetails);
         Distribute.getInstance().startFromBackground(mContext);
-        assertTrue(Distribute.getInstance().notifyDownload(mock(ReleaseDetails.class)));
+        assertTrue(Distribute.getInstance().notifyDownload(mock(ReleaseDetails.class), null));
     }
 
     @Test
@@ -1035,16 +1039,18 @@ public class DistributeTest extends AbstractDistributeTest {
 
     private void firstDownloadNotification(int apiLevel) throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", apiLevel);
-        mockStatic(DistributeUtils.class);
+        spy(DistributeUtils.class);
         NotificationManager manager = mock(NotificationManager.class);
         whenNew(Notification.Builder.class).withAnyArguments()
                 .thenReturn(mock(Notification.Builder.class, RETURNS_MOCKS));
-        when(DistributeUtils.loadCachedReleaseDetails()).thenReturn(mReleaseDetails);
-        when(DistributeUtils.getNotificationId()).thenReturn(0);
+        PowerMockito.doReturn(mReleaseDetails).when(DistributeUtils.class);
+        DistributeUtils.loadCachedReleaseDetails();
+        PowerMockito.doReturn(0).when(DistributeUtils.class);
+        DistributeUtils.getNotificationId();
         when(mContext.getSystemService(NOTIFICATION_SERVICE)).thenReturn(manager);
         Distribute.getInstance().startFromBackground(mContext);
-        Distribute.getInstance().onStarted(mContext, mChannel, "0", "Anna", false);
-        Distribute.getInstance().notifyDownload(mReleaseDetails);
+        Distribute.getInstance().onStarted(mContext, mChannel, "0", "test", false);
+        Distribute.getInstance().notifyDownload(mReleaseDetails, null);
         verify(manager).notify(eq(DistributeUtils.getNotificationId()), any(Notification.class));
     }
 }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUtilsTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUtilsTest.java
@@ -50,14 +50,6 @@ public class DistributeUtilsTest {
     }
 
     @Test
-    public void getNotificationId() {
-
-        /* Coverage fix. */
-        int notificationId = DistributeUtils.getNotificationId();
-        Assert.assertNotEquals(0, notificationId);
-    }
-
-    @Test
     public void loadCachedReleaseDetails() throws JSONException {
         ReleaseDetails mock = mock(ReleaseDetails.class);
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_RELEASE_DETAILS)).thenReturn("test");

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUtilsTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeUtilsTest.java
@@ -17,6 +17,7 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import static com.microsoft.appcenter.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,6 +48,11 @@ public class DistributeUtilsTest {
     public void init() {
         new DistributeUtils();
         new DistributeConstants();
+    }
+
+    @Test
+    public void notificationId() {
+        assertNotEquals(0, DistributeUtils.getNotificationId());
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/ReleaseDownloadListenerTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/ReleaseDownloadListenerTest.java
@@ -57,6 +57,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
         AppCenter.class,
         AppCenterLog.class,
         Distribute.class,
+        DistributeUtils.class,
         HandlerUtils.class,
         InstallerUtils.class,
         ProgressDialog.class,
@@ -196,7 +197,7 @@ public class ReleaseDownloadListenerTest {
 
             @Override
             public Void answer(InvocationOnMock invocation) {
-                ((Runnable) invocation.getArguments()[0]).run();
+                invocation.<Runnable>getArgument(0).run();
                 return null;
             }
         }).when(HandlerUtils.class);
@@ -372,10 +373,12 @@ public class ReleaseDownloadListenerTest {
 
     @Test
     public void onComplete() throws Exception {
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.getResumeAppIntent(eq(mContext))).thenReturn(mock(Intent.class));
         ReleaseDetails mockReleaseDetails = mockReleaseDetails(true);
 
         /* Do not notify the download. */
-        when(mDistribute.notifyDownload(mockReleaseDetails)).thenReturn(false);
+        when(mDistribute.notifyDownload(eq(mockReleaseDetails), any(Intent.class))).thenReturn(false);
         ReleaseDownloadListener releaseDownloadListener = new ReleaseDownloadListener(mContext, mockReleaseDetails);
         releaseDownloadListener.onComplete(1L, 1L);
 
@@ -386,10 +389,12 @@ public class ReleaseDownloadListenerTest {
 
     @Test
     public void onCompleteNotify() throws Exception {
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.getResumeAppIntent(eq(mContext))).thenReturn(mock(Intent.class));
         ReleaseDetails mockReleaseDetails = mockReleaseDetails(false);
 
         /* Notify the download. */
-        when(mDistribute.notifyDownload(mockReleaseDetails)).thenReturn(true);
+        when(mDistribute.notifyDownload(eq(mockReleaseDetails), any(Intent.class))).thenReturn(true);
         ReleaseDownloadListener releaseDownloadListener = new ReleaseDownloadListener(mContext, mockReleaseDetails);
         releaseDownloadListener.onComplete(1L, 1L);
 
@@ -400,9 +405,11 @@ public class ReleaseDownloadListenerTest {
 
     @Test
     public void onCompleteActivityNotResolved() throws Exception {
+        mockStatic(DistributeUtils.class);
+        when(DistributeUtils.getResumeAppIntent(eq(mContext))).thenReturn(mock(Intent.class));
 
         /* Mock notify download result. */
-        when(mDistribute.notifyDownload(any(ReleaseDetails.class))).thenReturn(true);
+        when(mDistribute.notifyDownload(any(ReleaseDetails.class), any(Intent.class))).thenReturn(true);
 
         /* Mock resolving to null activity. */
         when(mInstallIntent.resolveActivity(any(PackageManager.class))).thenReturn(null);


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

App doesn't resume when the user clicks on the download notification.

## Related PRs or issues

#1613
[AB#91962](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/91962)
