### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,123 +1,124 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "gradle",
-                    "groupId": "com.android.tools.build",
-                    "version": "3.3.2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "gradle-bintray-plugin",
-                    "groupId": "com.jfrog.bintray.gradle",
-                    "version": "1.8.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "android-maven-gradle-plugin",
-                    "groupId": "com.github.dcendents",
-                    "version": "2.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "coveralls-gradle-plugin",
-                    "groupId": "org.kt3k.gradle.plugin",
-                    "version": "2.8.2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "espresso-core",
-                    "groupId": "com.androidx.test.espresso",
-                    "version": "3.0.2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "espresso-idling-resource",
-                    "groupId": "com.androidx.test.espresso",
-                    "version": "3.0.2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "rules",
-                    "groupId": "com.androidx.test",
-                    "version": "1.2.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "appcompat",
-                    "groupId": "com.androidx.appcompat",
-                    "version": "1.0.2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "browser",
-                    "groupId": "androidx.browser",
-                    "version": "1.0.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "Maven",
-                "maven": {
-                    "artifactId": "recyclerview",
-                    "groupId": "com.androidx.recyclerview",
-                    "version": "1.1.0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://android.googlesource.com/platform/frameworks/support",
-                    "commitHash": "cb7620b6f66a6e33fb9882bbca995a45c64f3c3e"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/microsoft/appcenter-sdk-android-breakpad.git",
-                    "commitHash": "0d8e4133e2b9caadb012d438c4c12cf6daff2a40"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "gradle",
+          "groupId": "com.android.tools.build",
+          "version": "3.3.2"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "gradle-bintray-plugin",
+          "groupId": "com.jfrog.bintray.gradle",
+          "version": "1.8.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "android-maven-gradle-plugin",
+          "groupId": "com.github.dcendents",
+          "version": "2.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "coveralls-gradle-plugin",
+          "groupId": "org.kt3k.gradle.plugin",
+          "version": "2.8.2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "espresso-core",
+          "groupId": "com.androidx.test.espresso",
+          "version": "3.0.2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "espresso-idling-resource",
+          "groupId": "com.androidx.test.espresso",
+          "version": "3.0.2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "rules",
+          "groupId": "com.androidx.test",
+          "version": "1.2.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "appcompat",
+          "groupId": "com.androidx.appcompat",
+          "version": "1.0.2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "browser",
+          "groupId": "androidx.browser",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "Maven",
+        "maven": {
+          "artifactId": "recyclerview",
+          "groupId": "com.androidx.recyclerview",
+          "version": "1.1.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://android.googlesource.com/platform/frameworks/support",
+          "commitHash": "cb7620b6f66a6e33fb9882bbca995a45c64f3c3e"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/appcenter-sdk-android-breakpad.git",
+          "commitHash": "0d8e4133e2b9caadb012d438c4c12cf6daff2a40"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.