### PR TITLE
Decouple versioning of sasquatch app from SDK

### DIFF
--- a/apps/sasquatch/build.gradle
+++ b/apps/sasquatch/build.gradle
@@ -14,6 +14,8 @@ android {
     flavorDimensions "dependency", "distribute"
 
     defaultConfig {
+        versionCode 300
+        versionName "5.0.0"
         externalNativeBuild {
             ndkBuild {
                 arguments "NDK_APPLICATION_MK=Application.mk", "V=1"


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Currently the Sasquatch App version is coupled with the AppCenter Android SDK version due to the unity of the versioning in the versions.gradle file.

This coupling will raise an issue when trying to test the distribute feature with the latest SDK module, here's an example scenario:
I want to verify that the distribute feature works as expected for the new app center sdk version (5.0.0)
If I downgrade the version from the versions.gradle file (let's say to 4.0.0) for the sake of downgrading the Sasquatch application to test the distribute behaviour, the sdk's version is thus downgraded as well (which is not what we want because we want to actually test the behaviour of the sdk against version 5.0.0 😊) 

Therefore, it makes sense for the Sasquatch app to have its own versioning criteria that does not get affected by the SDK. One of the solutions can be overriding the global (versions.gradle) versioning in the Sasquatch's build.gradle. 


## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
