### PR TITLE
Fix NPE in Distribute module on resume workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix NPE in Distribute SDK on resume of distribute work flow when showing update setup failed dialog.
+* **[Fix]** Fix NPE in Distribute module on resume distribute workflow when showing update setup failed dialog.
  ___
 
 ## Version 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # App Center SDK for Android Change Log
 
+## Version 5.0.1
+
+### App Center Distribute
+
+* **[Fix]** Fix NPE in Distribute SDK on resume of distribute work flow when showing update setup failed dialog.
+ ___
+
 ## Version 5.0.0
 
 ### AppCenter

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1580,35 +1580,38 @@ public class Distribute extends AbstractAppCenterService {
         if (!shouldRefreshDialog(mUpdateSetupFailedDialog)) {
             return;
         }
-        if(mForegroundActivity!=null) {
-            AppCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
-            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
-            dialogBuilder.setCancelable(false);
-            dialogBuilder.setTitle(R.string.appcenter_distribute_update_failed_dialog_title);
-            dialogBuilder.setMessage(R.string.appcenter_distribute_update_failed_dialog_message);
-            dialogBuilder.setPositiveButton(R.string.appcenter_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
 
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    storeUpdateSetupFailedPackageHash(dialog);
-                }
-            });
-            dialogBuilder.setNegativeButton(R.string.appcenter_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
-
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    handleUpdateFailedDialogReinstallAction(dialog);
-                }
-            });
-            mUpdateSetupFailedDialog = dialogBuilder.create();
-            showAndRememberDialogActivity(mUpdateSetupFailedDialog);
-
-            /* Don't show this dialog again. */
-            SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-        }else
-        {
+        /* Check if foreground activity is null, if null we return, if not we proceed to show the setup failed dialog */
+        if (mForegroundActivity == null) {
             AppCenterLog.debug(LOG_TAG, "Failed to show the update setup failed dialog. The foreground activity is null");
+            return;
         }
+
+        AppCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
+        dialogBuilder.setCancelable(false);
+        dialogBuilder.setTitle(R.string.appcenter_distribute_update_failed_dialog_title);
+        dialogBuilder.setMessage(R.string.appcenter_distribute_update_failed_dialog_message);
+        dialogBuilder.setPositiveButton(R.string.appcenter_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                    storeUpdateSetupFailedPackageHash(dialog);
+            }
+        });
+        dialogBuilder.setNegativeButton(R.string.appcenter_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                handleUpdateFailedDialogReinstallAction(dialog);
+            }
+        });
+        mUpdateSetupFailedDialog = dialogBuilder.create();
+        showAndRememberDialogActivity(mUpdateSetupFailedDialog);
+
+        /* Don't show this dialog again. */
+        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1581,7 +1581,6 @@ public class Distribute extends AbstractAppCenterService {
             return;
         }
 
-        /* Check if foreground activity is null, if null we return, if not we proceed to show the setup failed dialog */
         if (mForegroundActivity == null) {
             AppCenterLog.debug(LOG_TAG, "Failed to show the update setup failed dialog. The foreground activity is null");
             return;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1574,7 +1574,8 @@ public class Distribute extends AbstractAppCenterService {
      * Show update setup failed dialog.
      */
     @UiThread
-    private synchronized void showUpdateSetupFailedDialog() {
+    @VisibleForTesting
+    protected synchronized void showUpdateSetupFailedDialog() {
 
         /* Check if we need to replace the dialog. */
         if (!shouldRefreshDialog(mUpdateSetupFailedDialog)) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1580,30 +1580,35 @@ public class Distribute extends AbstractAppCenterService {
         if (!shouldRefreshDialog(mUpdateSetupFailedDialog)) {
             return;
         }
-        AppCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
-        dialogBuilder.setCancelable(false);
-        dialogBuilder.setTitle(R.string.appcenter_distribute_update_failed_dialog_title);
-        dialogBuilder.setMessage(R.string.appcenter_distribute_update_failed_dialog_message);
-        dialogBuilder.setPositiveButton(R.string.appcenter_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
+        if(mForegroundActivity!=null) {
+            AppCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
+            dialogBuilder.setCancelable(false);
+            dialogBuilder.setTitle(R.string.appcenter_distribute_update_failed_dialog_title);
+            dialogBuilder.setMessage(R.string.appcenter_distribute_update_failed_dialog_message);
+            dialogBuilder.setPositiveButton(R.string.appcenter_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
 
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                storeUpdateSetupFailedPackageHash(dialog);
-            }
-        });
-        dialogBuilder.setNegativeButton(R.string.appcenter_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    storeUpdateSetupFailedPackageHash(dialog);
+                }
+            });
+            dialogBuilder.setNegativeButton(R.string.appcenter_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
 
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                handleUpdateFailedDialogReinstallAction(dialog);
-            }
-        });
-        mUpdateSetupFailedDialog = dialogBuilder.create();
-        showAndRememberDialogActivity(mUpdateSetupFailedDialog);
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    handleUpdateFailedDialogReinstallAction(dialog);
+                }
+            });
+            mUpdateSetupFailedDialog = dialogBuilder.create();
+            showAndRememberDialogActivity(mUpdateSetupFailedDialog);
 
-        /* Don't show this dialog again. */
-        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+            /* Don't show this dialog again. */
+            SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+        }else
+        {
+            AppCenterLog.debug(LOG_TAG, "Failed to show the update setup failed dialog. The foreground activity is null");
+        }
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -1596,7 +1596,7 @@ public class Distribute extends AbstractAppCenterService {
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                    storeUpdateSetupFailedPackageHash(dialog);
+                storeUpdateSetupFailedPackageHash(dialog);
             }
         });
         dialogBuilder.setNegativeButton(R.string.appcenter_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
@@ -1611,7 +1611,6 @@ public class Distribute extends AbstractAppCenterService {
 
         /* Don't show this dialog again. */
         SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-
     }
 
     /**

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -449,6 +449,20 @@ public class DistributeTest extends AbstractDistributeTest {
     }
 
     @Test
+    public void doNotShowUpdateSetupFailedDialogInNullForegroundActivity() {
+        when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("failed_message");
+
+        /* Trigger call. */
+        Distribute.getInstance().onActivityResumed(null);
+        start();
+
+        /* Verify dialog. */
+        verify(mDialogBuilder, never()).create();
+        verifyStatic(SharedPreferencesManager.class, never());
+        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+    }
+
+    @Test
     public void showUpdateSetupFailedDialogInForeground() {
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("failed_message");
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -453,7 +453,8 @@ public class DistributeTest extends AbstractDistributeTest {
         when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("failed_message");
 
         /* Trigger call. */
-        Distribute.getInstance().onActivityResumed(null);
+        Distribute.getInstance().showUpdateSetupFailedDialog();
+        mActivity = null;
         start();
 
         /* Verify dialog. */

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -451,9 +451,7 @@ public class DistributeTest extends AbstractDistributeTest {
     @Test
     public void doNotShowUpdateSetupFailedDialogInNullForegroundActivity() {
         /* Trigger call. */
-        Distribute.getInstance().onActivityResumed(null);
         Distribute.getInstance().showUpdateSetupFailedDialog();
-        start();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -452,6 +452,7 @@ public class DistributeTest extends AbstractDistributeTest {
     public void doNotShowUpdateSetupFailedDialogInNullForegroundActivity() {
         /* Trigger call. */
         Distribute.getInstance().showUpdateSetupFailedDialog();
+        start();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -453,7 +453,6 @@ public class DistributeTest extends AbstractDistributeTest {
         /* Trigger call. */
         Distribute.getInstance().onActivityResumed(null);
         Distribute.getInstance().showUpdateSetupFailedDialog();
-        start();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -453,6 +453,7 @@ public class DistributeTest extends AbstractDistributeTest {
         /* Trigger call. */
         Distribute.getInstance().onActivityResumed(null);
         Distribute.getInstance().showUpdateSetupFailedDialog();
+        start();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -450,17 +450,13 @@ public class DistributeTest extends AbstractDistributeTest {
 
     @Test
     public void doNotShowUpdateSetupFailedDialogInNullForegroundActivity() {
-        when(SharedPreferencesManager.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY)).thenReturn("failed_message");
-
         /* Trigger call. */
+        Distribute.getInstance().onActivityResumed(null);
         Distribute.getInstance().showUpdateSetupFailedDialog();
-        mActivity = null;
         start();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();
-        verifyStatic(SharedPreferencesManager.class, never());
-        SharedPreferencesManager.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -451,8 +451,8 @@ public class DistributeTest extends AbstractDistributeTest {
     @Test
     public void doNotShowUpdateSetupFailedDialogInNullForegroundActivity() {
         /* Trigger call. */
-        Distribute.getInstance().showUpdateSetupFailedDialog();
         start();
+        Distribute.getInstance().showUpdateSetupFailedDialog();
 
         /* Verify dialog. */
         verify(mDialogBuilder, never()).create();


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

My initial thoughts around this issue:
The issue is happening under the scenario of which the distribute SDK needs to show the "Update Setup Failed" dialog. 
When the "showUpdateSetupFailedDialog" method is called, the alert dialog uses the global variable activity instance mForegroundActivity.
The mForegroundActivity in the above scenario is null. Thus the crash.
How could this variable be null? Let's observe the workflow:
In our Distribute.java class, mForegroundActivity is a global private variable used in the scope of this class.
The value of the mForegroundActivity is set under the following two cases:
onActivityResumed => The value of mForegroundActivity is set to the value of the activity being resumed. 
onActivityPaused => The value of mForegroundActivity is explicitly set to null.
The call for "showUpdateSetupFailedDialog" occurs inside the "resumeDistributeWorkflow" function which is called by the onActivityResumed method. 
The "resumeDistributeWorkflow" has a condition on its very first line which checks if our mForegroundActivity is null, and apparently, this check passes before reaching the line of code that should show the "update failed" alert dialog where our code is crashing.
Therefore, the value of mForegroundActivity has been tampered with along the way before reaching the "show update failed" dialog. Weird right? We are within the same block of code, under the same method, and between few lines of code that do not explicitly change the value of our mForegroundActivity, the value has actually changed. 
This issue is most probably a "thread shared memory issue". I am assuming that one of the running threads have executed the onActivityPause function which updates the value of the mForegroundActivity to null, while on onActivityResume code is being executed. Thus failing to show the alert dialog and producing the above null pointer exception.
I will be investigating further and trying to create a small test with multithreads trying to access and update global variables, and look into possible solutions. 

Note that the user which this issue is occurring with, might be stuck in the loop of crashes every time he/she opens their app because of having the values with the running threads continually stored in memory - I will reply on the GitHub conversation thread for this issue asking if they can try to clear app cache and data for their app from the device's settings and try again to see if the issue continuous. 


## Related PRs or issues

https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/95531

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
