### PR TITLE
Fix Concurrent Modification Exception in DefaultChannel on setNetwork…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Version 5.0.1 (Under development)
 
+### AppCenter
+
+* **[Fix]** Fix Concurrent Modification Exception in DefaultChannel on setNetworkRequestsAllowed.
+
 ### App Center Distribute
 
 * **[Fix]** Fix NPE in Distribute module on resume distribute workflow when showing update setup failed dialog.
-* **[Fix]** Fix Concurrent Modification Exception in DefaultChannel on setNetworkRequestsAllowed.
  ___
 
 ## Version 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Distribute
 
 * **[Fix]** Fix NPE in Distribute module on resume distribute workflow when showing update setup failed dialog.
+* **[Fix]** Fix Concurrent Modification Exception in DefaultChannel on setNetworkRequestsAllowed.
  ___
 
 ## Version 5.0.0

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -789,6 +789,11 @@ public class DefaultChannel implements Channel {
         return mGroupStates.get(groupName);
     }
 
+    @VisibleForTesting
+    Map<String, GroupState> getGroupStates() {
+        return mGroupStates;
+    }
+
     @Override
     public void addListener(Listener listener) {
         mListeners.add(listener);

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/channel/DefaultChannel.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
@@ -160,7 +161,7 @@ public class DefaultChannel implements Channel {
         mContext = context;
         mAppSecret = appSecret;
         mInstallId = IdHelper.getInstallId();
-        mGroupStates = new HashMap<>();
+        mGroupStates = new ConcurrentHashMap<>();
         mListeners = new LinkedHashSet<>();
         mPersistence = persistence;
         mIngestion = ingestion;

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
@@ -49,6 +49,8 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 public class AbstractDefaultChannelTest {
 
     static final String TEST_GROUP = "group_test";
+    static final String TEST_GROUP_TWO = "group_test_2";
+    static final String TEST_GROUP_THREE = "group_test_3";
 
     static final long BATCH_TIME_INTERVAL = 500;
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/AbstractDefaultChannelTest.java
@@ -48,9 +48,10 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 })
 public class AbstractDefaultChannelTest {
 
-    static final String TEST_GROUP = "group_test";
-    static final String TEST_GROUP_TWO = "group_test_2";
-    static final String TEST_GROUP_THREE = "group_test_3";
+    static final String TEST_GROUP = "group1";
+    static final String TEST_GROUP_TWO = "group2";
+    static final String TEST_GROUP_THREE = "group3";
+    static final String TEST_GROUP_FOUR = "group4";
 
     static final long BATCH_TIME_INTERVAL = 500;
 

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1213,12 +1213,12 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
             Iterator it1 = myMap.keySet().iterator();
             while (it1.hasNext()) {
                 String key = it1.next().toString();
-                if(key.equals(TEST_GROUP_TWO)) {
+                if (key.equals(TEST_GROUP_TWO)) {
                     channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                     channel.addGroup(TEST_GROUP_FOUR, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                 }
             }
-        }catch (ConcurrentModificationException e) {
+        } catch (ConcurrentModificationException e) {
             fail("This code should not have thrown an Exception " + e.getMessage());
         }
     }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1199,10 +1199,8 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
     }
 
     @Test
-    public void testConcurrentIterableDataStructureUpdatesSuccess()
-    {
-        try
-        {
+    public void testConcurrentIterableDataStructureUpdatesSuccess() {
+        try {
             Persistence mockPersistence = mock(Persistence.class);
             AppCenterIngestion mockIngestion = mock(AppCenterIngestion.class);
             Channel.GroupListener mockListener = mock(Channel.GroupListener.class);
@@ -1218,39 +1216,14 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
             Iterator it1 = myMap.keySet().iterator();
             while (it1.hasNext()) {
                 String key = it1.next().toString();
-                if(key.equals(TEST_GROUP_TWO))
-                {
+                if(key.equals(TEST_GROUP_TWO)) {
                     channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                     channel.addGroup(TEST_GROUP_FOUR, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                 }
 
             }
-        }catch (ConcurrentModificationException e)
-        {
+        }catch (ConcurrentModificationException e) {
             fail("This code should not have thrown an Exception " + e.getMessage());
-        }
-
-    }
-
-
-    @Test(expected = ConcurrentModificationException.class)
-    public void testConcurrentIterableDataStructureUpdatesFail()
-    {
-        //Create a hashmap that is sensitive to concurrent modifications by definition
-        HashMap<String,String> myMap = new HashMap<>();
-        myMap.put("1", "1");
-        myMap.put("2", "1");
-        myMap.put("3", "1");
-
-        //Iterate and modify twice. A Concurrent modification exception is expected.
-        Iterator it1 = myMap.keySet().iterator();
-        while (it1.hasNext()) {
-            String key = it1.next().toString();
-            System.out.println("Map Value:" + myMap.get(key));
-            if (key.equals("2")) {
-                myMap.put("1", "1");
-                myMap.put("4", "1");
-            }
         }
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -1210,9 +1210,9 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
             channel.addGroup(TEST_GROUP_THREE, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
 
             //Iterate over the map and modify twice
-            Iterator it1 = myMap.keySet().iterator();
-            while (it1.hasNext()) {
-                String key = it1.next().toString();
+            Iterator iterator = myMap.keySet().iterator();
+            while (iterator.hasNext()) {
+                String key = iterator.next().toString();
                 if (key.equals(TEST_GROUP_TWO)) {
                     channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                     channel.addGroup(TEST_GROUP_FOUR, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/channel/DefaultChannelTest.java
@@ -29,7 +29,6 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import android.content.Context;
 
 import com.microsoft.appcenter.CancellationException;
-import com.microsoft.appcenter.Constants;
 import com.microsoft.appcenter.Flags;
 import com.microsoft.appcenter.http.HttpException;
 import com.microsoft.appcenter.http.HttpResponse;
@@ -53,12 +52,10 @@ import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultChannelTest extends AbstractDefaultChannelTest {
 
@@ -1220,7 +1217,6 @@ public class DefaultChannelTest extends AbstractDefaultChannelTest {
                     channel.addGroup(TEST_GROUP, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                     channel.addGroup(TEST_GROUP_FOUR, 50, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, null, mockListener);
                 }
-
             }
         }catch (ConcurrentModificationException e) {
             fail("This code should not have thrown an Exception " + e.getMessage());


### PR DESCRIPTION
…RequestsAllowed

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

This issue is occuring because we are iterating on a hashMap that at some point can be modified by other running threads. This will cause a concurrent modification exception which is very common in data structures with iterators. One solution is to use the [ConcurrentHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html) instead of HashMap given that our map is exposed to multiple modifications in our code.

## Related PRs or issues

[AB#96392](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/96392)
https://github.com/microsoft/appcenter-sdk-android/issues/1666/

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
