### PR TITLE
Add catching RuntimeException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for Android Change Log
 
+## Version 5.0.2 (In development)
+
+### AppCenter
+
+* **[Fix]** Fix SDK crash if the underlying Android call throws an exception. 
+
 ## Version 5.0.1
 
 ### AppCenter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### AppCenter
 
-* **[Fix]** Fix SDK crash if the underlying Android call throws an exception. 
+* **[Fix]** Fix SDK crash if the `ConnectivityManager.getNetworkInfo` method call throws an exception.
 
 ## Version 5.0.1
 

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -149,7 +149,7 @@ public class NetworkStateHelper implements Closeable {
                     return true;
                 }
             } catch (RuntimeException e) {
-                AppCenterLog.error(LOG_TAG, network.toString());
+                AppCenterLog.warn(LOG_TAG, "Failed to get network info", e);
             }
         }
         return false;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -23,8 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static android.content.Context.CONNECTIVITY_SERVICE;
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
-import com.microsoft.appcenter.ingestion.models.Log;
-
 /**
  * Network state helper.
  */

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static android.content.Context.CONNECTIVITY_SERVICE;
 import static com.microsoft.appcenter.AppCenter.LOG_TAG;
 
+import com.microsoft.appcenter.ingestion.models.Log;
+
 /**
  * Network state helper.
  */
@@ -143,9 +145,13 @@ public class NetworkStateHelper implements Closeable {
             return false;
         }
         for (Network network : networks) {
-            NetworkInfo info = mConnectivityManager.getNetworkInfo(network);
-            if (info != null && info.isConnected()) {
-                return true;
+            try {
+                NetworkInfo info = mConnectivityManager.getNetworkInfo(network);
+                if (info != null && info.isConnected()) {
+                    return true;
+                }
+            } catch (NullPointerException e) {
+                AppCenterLog.debug(LOG_TAG, network.toString());
             }
         }
         return false;

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/utils/NetworkStateHelper.java
@@ -148,8 +148,8 @@ public class NetworkStateHelper implements Closeable {
                 if (info != null && info.isConnected()) {
                     return true;
                 }
-            } catch (NullPointerException e) {
-                AppCenterLog.debug(LOG_TAG, network.toString());
+            } catch (RuntimeException e) {
+                AppCenterLog.error(LOG_TAG, network.toString());
             }
         }
         return false;

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -196,6 +195,6 @@ public class NetworkStateHelperTestFromLollipop extends AbstractNetworkStateHelp
         when(mConnectivityManager.getNetworkInfo(any())).thenThrow(new NullPointerException());
         assertFalse(helper.isNetworkConnected());
         verifyStatic(AppCenterLog.class);
-        AppCenterLog.warn(eq(AppCenter.LOG_TAG), anyString());
+        AppCenterLog.warn(eq(AppCenter.LOG_TAG), anyString(), any(RuntimeException.class));
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
@@ -196,6 +196,6 @@ public class NetworkStateHelperTestFromLollipop extends AbstractNetworkStateHelp
         when(mConnectivityManager.getNetworkInfo(any())).thenThrow(new NullPointerException());
         assertFalse(helper.isNetworkConnected());
         verifyStatic(AppCenterLog.class);
-        AppCenterLog.error(eq(AppCenter.LOG_TAG), anyString());
+        AppCenterLog.warn(eq(AppCenter.LOG_TAG), anyString());
     }
 }

--- a/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
+++ b/sdk/appcenter/src/test/java/com/microsoft/appcenter/utils/NetworkStateHelperTestFromLollipop.java
@@ -14,6 +14,7 @@ import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
 
+import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.test.TestUtils;
 
 import org.junit.After;
@@ -26,22 +27,30 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-@PrepareForTest(NetworkStateHelper.class)
+@PrepareForTest({NetworkStateHelper.class, AppCenterLog.class})
 public class NetworkStateHelperTestFromLollipop extends AbstractNetworkStateHelperTest {
 
     @Before
     public void setUp() throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.LOLLIPOP);
+
+        /* Mock static classes. */
+        mockStatic(AppCenterLog.class);
     }
 
     @After
@@ -177,5 +186,16 @@ public class NetworkStateHelperTestFromLollipop extends AbstractNetworkStateHelp
         new NetworkStateHelper(mContext);
         verify(builder).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
         verify(builder, never()).addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+    }
+      
+    @Test
+    public void verifyNullPointerExceptionCatch() {
+        NetworkStateHelper helper = new NetworkStateHelper(mContext);
+        Network network = mock(Network.class);
+        when(mConnectivityManager.getAllNetworks()).thenReturn(new Network[] { network });
+        when(mConnectivityManager.getNetworkInfo(any())).thenThrow(new NullPointerException());
+        assertFalse(helper.isNetworkConnected());
+        verifyStatic(AppCenterLog.class);
+        AppCenterLog.error(eq(AppCenter.LOG_TAG), anyString());
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Please have a look at our [guidelines for contributions](https://github.com/microsoft/appcenter-sdk-android/blob/develop/CONTRIBUTING.md) and consider the following before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~

## Description

Add try/catch for capture NullPointerException in NetworkStateHelper.isAnyNetworkConnected

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-android/issues/1679
[AB#100301](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/100301)


