### PR TITLE
Ignore file size check if original update file has AAB extension format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### AppCenter
 
+* **[Improvement]** Support updates using AAB file uploaded to the portal.
 * **[Fix]** Fix SDK crash if the `ConnectivityManager.getNetworkInfo` method call throws an exception.
 
 ## Version 5.0.1

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
@@ -47,6 +47,7 @@ public class ReleaseDetailsTest {
         assertFalse(releaseDetails.isMandatoryUpdate());
         assertEquals("9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60", releaseDetails.getReleaseHash());
         assertEquals("fd37a4b1-4937-45ef-97fb-b864154371f0", releaseDetails.getDistributionGroupId());
+        assertEquals(FileExtension.apk, releaseDetails.getFileExtension());
     }
 
     @Test(expected = JSONException.class)

--- a/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
+++ b/sdk/appcenter-distribute/src/androidTest/java/com/microsoft/appcenter/distribute/ReleaseDetailsTest.java
@@ -31,6 +31,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -59,6 +60,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -76,6 +78,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -93,6 +96,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -119,6 +123,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -136,6 +141,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -152,6 +158,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -168,6 +175,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -195,6 +203,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -224,6 +233,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -250,6 +260,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -267,6 +278,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -294,6 +306,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -310,6 +323,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -327,6 +341,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -344,6 +359,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -360,6 +376,7 @@ public class ReleaseDetailsTest {
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "mandatory_update: false," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -377,6 +394,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: true," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);
@@ -403,6 +421,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -436,6 +455,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: []," +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -453,6 +473,7 @@ public class ReleaseDetailsTest {
                 "size: 4242," +
                 "mandatory_update: false," +
                 "package_hashes: '9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60'" +
+                "fileExtension: 'apk'," +
                 "distribution_group_id: 'fd37a4b1-4937-45ef-97fb-b864154371f0'" +
                 "}";
         ReleaseDetails.parse(json);
@@ -470,6 +491,7 @@ public class ReleaseDetailsTest {
                 "download_url: 'http://download.thinkbroadband.com/1GB.zip'," +
                 "size: 4242," +
                 "mandatory_update: false," +
+                "fileExtension: 'apk'," +
                 "package_hashes: ['9f52199c986d9210842824df695900e1656180946212bd5e8978501a5b732e60']" +
                 "}";
         ReleaseDetails releaseDetails = ReleaseDetails.parse(json);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -19,7 +19,6 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.HEADER_API_
 import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_INSTALL_ID;
-import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_IS_INSTALL_PAGE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_RELEASE_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_UPDATE_SETUP_FAILED;
 import static com.microsoft.appcenter.distribute.DistributeConstants.POSTPONE_TIME_THRESHOLD;
@@ -1065,7 +1064,6 @@ public class Distribute extends AbstractAppCenterService {
         } else {
             url += String.format(GET_LATEST_PRIVATE_RELEASE_PATH_FORMAT, mAppSecret, releaseHash, getReportingParametersForUpdatedRelease(false, distributionGroupId));
         }
-        url += "&" + PARAMETER_IS_INSTALL_PAGE + "=" + "true";
         Map<String, String> headers = new HashMap<>();
         if (updateToken != null) {
             headers.put(HEADER_API_TOKEN, updateToken);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -19,6 +19,7 @@ import static com.microsoft.appcenter.distribute.DistributeConstants.HEADER_API_
 import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_INSTALL_ID;
+import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_IS_INSTALL_PAGE;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_RELEASE_ID;
 import static com.microsoft.appcenter.distribute.DistributeConstants.PARAMETER_UPDATE_SETUP_FAILED;
 import static com.microsoft.appcenter.distribute.DistributeConstants.POSTPONE_TIME_THRESHOLD;
@@ -1064,6 +1065,7 @@ public class Distribute extends AbstractAppCenterService {
         } else {
             url += String.format(GET_LATEST_PRIVATE_RELEASE_PATH_FORMAT, mAppSecret, releaseHash, getReportingParametersForUpdatedRelease(false, distributionGroupId));
         }
+        url += "&" + PARAMETER_IS_INSTALL_PAGE + "=" + "true";
         Map<String, String> headers = new HashMap<>();
         if (updateToken != null) {
             headers.put(HEADER_API_TOKEN, updateToken);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -137,6 +137,11 @@ public final class DistributeConstants {
     static final String PARAMETER_INSTALL_ID = "install_id";
 
     /**
+     * API parameter for downloading the update apk file, even if an aab file was uploaded.
+     */
+    static final String PARAMETER_IS_INSTALL_PAGE = "is_install_page";
+
+    /**
      * Invalid download identifier.
      */
     public static final long INVALID_DOWNLOAD_IDENTIFIER = -1;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/DistributeConstants.java
@@ -77,14 +77,16 @@ public final class DistributeConstants {
     static final String PRIVATE_UPDATE_SETUP_PATH_FORMAT = "/apps/%s/private-update-setup/";
 
     /**
-     * Check latest private release API URL path. Contains variables: appSecret, release_hash, extra query string parameters.
+     * Check latest private release API URL path. Contains variables: is_install_page, appSecret, release_hash, extra query string parameters.
+     * is_install_page - API parameter for downloading the update apk file, even if an aab file was uploaded.
      */
-    static final String GET_LATEST_PRIVATE_RELEASE_PATH_FORMAT = "/sdk/apps/%s/releases/private/latest?release_hash=%s%s";
+    static final String GET_LATEST_PRIVATE_RELEASE_PATH_FORMAT = "/sdk/apps/%s/releases/private/latest?is_install_page=true&release_hash=%s%s";
 
     /**
-     * Check latest public release API URL path. Contains variables: appSecret, release_hash, extra query string parameters.
+     * Check latest public release API URL path. Contains variables: is_install_page, appSecret, release_hash, extra query string parameters.
+     * is_install_page - API parameter for downloading the update apk file, even if an aab file was uploaded.
      */
-    static final String GET_LATEST_PUBLIC_RELEASE_PATH_FORMAT = "/public/sdk/apps/%s/releases/latest?release_hash=%s%s";
+    static final String GET_LATEST_PUBLIC_RELEASE_PATH_FORMAT = "/public/sdk/apps/%s/releases/latest?is_install_page=true&release_hash=%s%s";
 
     /**
      * API parameter for release hash.
@@ -135,11 +137,6 @@ public final class DistributeConstants {
      * API parameter for install identifier.
      */
     static final String PARAMETER_INSTALL_ID = "install_id";
-
-    /**
-     * API parameter for downloading the update apk file, even if an aab file was uploaded.
-     */
-    static final String PARAMETER_IS_INSTALL_PAGE = "is_install_page";
 
     /**
      * Invalid download identifier.

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/FileExtension.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/FileExtension.java
@@ -1,0 +1,6 @@
+package com.microsoft.appcenter.distribute;
+
+public enum FileExtension {
+    aab,
+    apk
+}

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/ReleaseDetails.java
@@ -32,6 +32,8 @@ public class ReleaseDetails {
 
     private static final String MIN_API_LEVEL = "android_min_api_level";
 
+    private static final String FILE_EXTENSION = "fileExtension";
+
     private static final String DOWNLOAD_URL = "download_url";
 
     private static final String MANDATORY_UPDATE = "mandatory_update";
@@ -80,6 +82,11 @@ public class ReleaseDetails {
     private int minApiLevel;
 
     /**
+     * The original update file extension.
+     */
+    private FileExtension fileExtension;
+
+    /**
      * The URL that hosts the binary for this release.
      */
     private Uri downloadUrl;
@@ -117,6 +124,7 @@ public class ReleaseDetails {
         releaseDetails.releaseNotes = object.isNull(RELEASE_NOTES) ? null : object.getString(RELEASE_NOTES);
         releaseDetails.releaseNotesUrl = object.isNull(RELEASE_NOTES_URL) ? null : Uri.parse(object.getString(RELEASE_NOTES_URL));
         releaseDetails.minApiLevel = object.getInt(MIN_API_LEVEL);
+        releaseDetails.fileExtension = FileExtension.valueOf(object.getString(FILE_EXTENSION));
         releaseDetails.downloadUrl = Uri.parse(object.getString(DOWNLOAD_URL));
         String scheme = releaseDetails.downloadUrl.getScheme();
         if (scheme == null || !scheme.startsWith("http")) {
@@ -193,6 +201,15 @@ public class ReleaseDetails {
      */
     int getMinApiLevel() {
         return minApiLevel;
+    }
+
+    /**
+     * Get The original update file extension value.
+     *
+     * @return the fileExtension value
+     */
+    public FileExtension getFileExtension() {
+        return fileExtension;
     }
 
     /**

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -251,11 +251,12 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
 
     private boolean isDownloadedFileValid() {
         try {
-            ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId);
             if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
-                return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
+                ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId);
+                boolean isValid = fileDescriptor.getStatSize() == mReleaseDetails.getSize();
+                fileDescriptor.close();
+                return isValid;
             }
-            fileDescriptor.close();
             return true;
         } catch (IOException e) {
             AppCenterLog.error(LOG_TAG, "Cannot open downloaded file for id=" + mDownloadId, e);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -250,6 +250,8 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
     }
 
     private boolean isDownloadedFileValid() {
+        // As per the current system design, only the files with APK
+        // extension have their size correctly indicated in the release details.
         if (mReleaseDetails.getFileExtension() != FileExtension.apk) {
             return true;
         }

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -23,6 +23,7 @@ import androidx.annotation.AnyThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import com.microsoft.appcenter.distribute.FileExtension;
 import com.microsoft.appcenter.distribute.R;
 import com.microsoft.appcenter.distribute.ReleaseDetails;
 import com.microsoft.appcenter.distribute.download.AbstractReleaseDownloader;
@@ -250,7 +251,10 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
 
     private boolean isDownloadedFileValid() {
         try (ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId)) {
-            return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
+            if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
+                return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
+            }
+            return true;
         } catch (IOException e) {
             AppCenterLog.error(LOG_TAG, "Cannot open downloaded file for id=" + mDownloadId, e);
             return false;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -250,12 +250,9 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
     }
 
     private boolean isDownloadedFileValid() {
-        try {
+        try (ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId)) {
             if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
-                ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId);
-                boolean isValid = fileDescriptor.getStatSize() == mReleaseDetails.getSize();
-                fileDescriptor.close();
-                return isValid;
+                return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
             }
             return true;
         } catch (IOException e) {

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -250,10 +250,12 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
     }
 
     private boolean isDownloadedFileValid() {
-        try (ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId)) {
+        try {
+            ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId);
             if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
                 return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
             }
+            fileDescriptor.close();
             return true;
         } catch (IOException e) {
             AppCenterLog.error(LOG_TAG, "Cannot open downloaded file for id=" + mDownloadId, e);

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -250,12 +250,11 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
     }
 
     private boolean isDownloadedFileValid() {
+        if (mReleaseDetails.getFileExtension() != FileExtension.apk) {
+            return true;
+        }
         try (ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId)) {
-            if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
-                return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
-            } else {
-                return true;
-            }
+            return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
         } catch (IOException e) {
             AppCenterLog.error(LOG_TAG, "Cannot open downloaded file for id=" + mDownloadId, e);
             return false;

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloader.java
@@ -253,8 +253,9 @@ public class DownloadManagerReleaseDownloader extends AbstractReleaseDownloader 
         try (ParcelFileDescriptor fileDescriptor = getDownloadManager().openDownloadedFile(mDownloadId)) {
             if (mReleaseDetails.getFileExtension() == FileExtension.apk) {
                 return fileDescriptor.getStatSize() == mReleaseDetails.getSize();
+            } else {
+                return true;
             }
-            return true;
         } catch (IOException e) {
             AppCenterLog.error(LOG_TAG, "Cannot open downloaded file for id=" + mDownloadId, e);
             return false;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeApiSuccessTest.java
@@ -1284,7 +1284,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?release_hash=" + TEST_HASH + "$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?is_install_page=true&release_hash=" + TEST_HASH + "$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -1301,7 +1301,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?release_hash=" + TEST_HASH + "$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?is_install_page=true&release_hash=" + TEST_HASH + "$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -1320,7 +1320,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         Distribute.setUpdateTrack(UpdateTrack.PRIVATE);
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?release_hash=" + TEST_HASH + "&distribution_group_id=" + distributionGroupId + "&downloaded_release_id=4$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        verify(mHttpClient).callAsync(matches("^https://.*?/sdk/apps/a/releases/private/latest\\?is_install_page=true&release_hash=" + TEST_HASH + "&distribution_group_id=" + distributionGroupId + "&downloaded_release_id=4$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
 
     @Test
@@ -1337,7 +1337,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         /* Primary storage will be missing data. */
         start();
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mHttpClient).callAsync(matches("^https://.*?/public/sdk/apps/a/releases/latest\\?release_hash=" + TEST_HASH + "&install_id=" + mInstallId + "&distribution_group_id=" + distributionGroupId + "&downloaded_release_id=4$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
+        verify(mHttpClient).callAsync(matches("^https://.*?/public/sdk/apps/a/releases/latest\\?is_install_page=true&release_hash=" + TEST_HASH + "&install_id=" + mInstallId + "&distribution_group_id=" + distributionGroupId + "&downloaded_release_id=4$"), eq("GET"), eq(headers), any(HttpClient.CallTemplate.class), any(ServiceCallback.class));
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -455,6 +455,21 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
+    public void errorOnCloseFileDescriptor() throws IOException {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
+
+        /* Throw exception. */
+        doThrow(new IOException()).when(mFileDescriptor).close();
+
+        /* Complete download. */
+        mReleaseDownloader.onDownloadComplete();
+
+        /* Verify. */
+        verify(mListener).onError(anyString());
+    }
+
+    @Test
     public void errorOnInvalidFile() throws IOException {
 
         /* If size is different. */
@@ -513,22 +528,6 @@ public class DownloadManagerReleaseDownloaderTest {
 
         /* Verify. */
         verify(mFileDescriptor).close();
-        verify(mListener).onError(anyString());
-    }
-
-    @Test
-    public void iOExceptionOnGetStatSizeFileDescriptor() throws IOException {
-        /* Define file extension. */
-        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
-
-        /* Throw exception in invalid size callback. */
-        when(mDownloadManager.openDownloadedFile(anyLong())).thenThrow(new FileNotFoundException());
-
-        /* Complete download. */
-        mReleaseDownloader.onDownloadComplete();
-
-        /* Verify. */
-        verify(mListener, never()).onComplete(any(Uri.class));
         verify(mListener).onError(anyString());
     }
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -34,6 +34,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.ParcelFileDescriptor;
 
+import com.microsoft.appcenter.distribute.FileExtension;
 import com.microsoft.appcenter.distribute.ReleaseDetails;
 import com.microsoft.appcenter.distribute.download.ReleaseDownloader;
 import com.microsoft.appcenter.utils.AsyncTaskUtils;
@@ -455,12 +456,31 @@ public class DownloadManagerReleaseDownloaderTest {
         /* If size is different. */
         when(mReleaseDetails.getSize()).thenReturn(142 * 1024L);
 
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
+
         /* Complete download. */
         mReleaseDownloader.onDownloadComplete();
 
         /* Verify. */
         verify(mFileDescriptor).close();
         verify(mListener).onError(anyString());
+    }
+
+    @Test
+    public void ignoreFileSizeComparisonForApkTransformedFromAab() {
+        /* If size is different. */
+        when(mReleaseDetails.getSize()).thenReturn(142 * 1024L);
+
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.aab);
+
+        /* Complete download. */
+        mReleaseDownloader.onDownloadComplete();
+
+        /* Verify. */
+        verify(mFileDescriptor, times(0)).getStatSize();
+        verify(mListener, times(0)).onError(anyString());
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -522,13 +522,12 @@ public class DownloadManagerReleaseDownloaderTest {
         when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
 
         /* Throw exception in invalid size callback. */
-        doThrow(new IOException()).when(mFileDescriptor).close();
+        when(mDownloadManager.openDownloadedFile(anyLong())).thenThrow(new FileNotFoundException());
 
         /* Complete download. */
         mReleaseDownloader.onDownloadComplete();
 
         /* Verify. */
-        verify(mFileDescriptor).close();
         verify(mListener, never()).onComplete(any(Uri.class));
         verify(mListener).onError(anyString());
     }

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -468,6 +468,19 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
+    public void sizeOfApkIsCorrect() {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
+
+        /* Complete download. */
+        mReleaseDownloader.onDownloadComplete();
+
+        /* Verify. */
+        verify(mFileDescriptor).getStatSize();
+        verify(mListener, times(0)).onError(anyString());
+    }
+
+    @Test
     public void ignoreFileSizeComparisonForApkTransformedFromAab() {
         /* If size is different. */
         when(mReleaseDetails.getSize()).thenReturn(142 * 1024L);

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -526,25 +526,6 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
-    public void runtimeExceptionOnGetStatSizeFileDescriptor() throws IOException {
-
-        /* Throw exception in invalid size callback. */
-        String exceptionMessage = "Test FileNotFoundException";
-        doThrow(new FileNotFoundException(exceptionMessage)).when(mDownloadManager).openDownloadedFile(anyLong());
-
-        /* Complete download. */
-
-        try {
-            mReleaseDownloader.onDownloadComplete();
-        } catch (Exception e) {
-            assertEquals(exceptionMessage, e.getMessage());
-        }
-
-        /* Verify. */
-        verify(mListener, never()).onComplete(any(Uri.class));
-    }
-
-    @Test
     public void errorDownloadDoesNothingAfterCancellation() {
         mReleaseDownloader.cancel();
         mReleaseDownloader.onDownloadError(new RuntimeException("Test"));

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -511,7 +511,7 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
-    public void exceptionOnClosingFileDescriptor() throws IOException {
+    public void iOExceptionOnClosingFileDescriptor() throws IOException {
 
         /* Throw exception in invalid size callback. */
         doThrow(new IOException()).when(mFileDescriptor).close();
@@ -523,6 +523,26 @@ public class DownloadManagerReleaseDownloaderTest {
         verify(mFileDescriptor).close();
         verify(mListener, never()).onComplete(any(Uri.class));
         verify(mListener).onError(anyString());
+    }
+
+    @Test
+    public void notIoExceptionOnClosingFileDescriptor() throws IOException {
+
+        /* Throw exception in invalid size callback. */
+        String exceptionMessage = "Test RuntimeException";
+        doThrow(new RuntimeException(exceptionMessage)).when(mFileDescriptor).close();
+
+        /* Complete download. */
+
+        try {
+            mReleaseDownloader.onDownloadComplete();
+        } catch (Exception e) {
+            assertEquals(exceptionMessage, e.getMessage());
+        }
+
+        /* Verify. */
+        verify(mFileDescriptor).close();
+        verify(mListener, never()).onComplete(any(Uri.class));
     }
 
     @Test

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -511,7 +511,7 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
-    public void iOExceptionOnClosingFileDescriptor() throws IOException {
+    public void iOExceptionOnGetStatSizeFileDescriptor() throws IOException {
 
         /* Throw exception in invalid size callback. */
         doThrow(new IOException()).when(mFileDescriptor).close();
@@ -526,11 +526,11 @@ public class DownloadManagerReleaseDownloaderTest {
     }
 
     @Test
-    public void notIoExceptionOnClosingFileDescriptor() throws IOException {
+    public void runtimeExceptionOnGetStatSizeFileDescriptor() throws IOException {
 
         /* Throw exception in invalid size callback. */
-        String exceptionMessage = "Test RuntimeException";
-        doThrow(new RuntimeException(exceptionMessage)).when(mFileDescriptor).close();
+        String exceptionMessage = "Test FileNotFoundException";
+        doThrow(new FileNotFoundException(exceptionMessage)).when(mDownloadManager).openDownloadedFile(anyLong());
 
         /* Complete download. */
 
@@ -541,7 +541,6 @@ public class DownloadManagerReleaseDownloaderTest {
         }
 
         /* Verify. */
-        verify(mFileDescriptor).close();
         verify(mListener, never()).onComplete(any(Uri.class));
     }
 

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/download/manager/DownloadManagerReleaseDownloaderTest.java
@@ -406,6 +406,8 @@ public class DownloadManagerReleaseDownloaderTest {
 
     @Test
     public void completeDownload() throws IOException {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
 
         /* Complete download. */
         mReleaseDownloader.onDownloadComplete();
@@ -439,6 +441,8 @@ public class DownloadManagerReleaseDownloaderTest {
 
     @Test
     public void errorOnOpenDownloadedFile() throws IOException {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
 
         /* Throw exception. */
         when(mDownloadManager.openDownloadedFile(anyLong())).thenThrow(new FileNotFoundException());
@@ -498,6 +502,8 @@ public class DownloadManagerReleaseDownloaderTest {
 
     @Test
     public void errorDownloadFileNotFound() throws IOException {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
 
         /* DownloadManager returns null. */
         when(mDownloadManager.getUriForDownloadedFile(anyLong())).thenReturn(null);
@@ -512,6 +518,8 @@ public class DownloadManagerReleaseDownloaderTest {
 
     @Test
     public void iOExceptionOnGetStatSizeFileDescriptor() throws IOException {
+        /* Define file extension. */
+        when(mReleaseDetails.getFileExtension()).thenReturn(FileExtension.apk);
 
         /* Throw exception in invalid size callback. */
         doThrow(new IOException()).when(mFileDescriptor).close();


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Added the `is_install_page=true` parameter to the URL for the release details request in order to receive a link to download the APK file even if an ABB file has been uploaded to the portal. Also, due to the fact that when uploading an AAB file to the portal, the release details indicate the size of the AAB file, even if we download the APK file, we ignore the check of the size of the uploaded file in this case.
