### PR TITLE
Version 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 5.0.3 (In development)
 
+### App Center Distribute
+
+* **[Fix]** Add RECEIVER_EXPORTED flag for install receiver.
+* **[Fix]** Add FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT flag for broadcast pending intent.
+
 ## Version 5.0.2
 
 ### AppCenter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # App Center SDK for Android Change Log
 
-## Version 5.0.3 (In development)
+## Version 5.0.4
 
 ### App Center Distribute
 
 * **[Fix]** Add RECEIVER_EXPORTED flag for install receiver.
 * **[Fix]** Add FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT flag for broadcast pending intent.
+
+## Version 5.0.3
+
+### AppCenter
+
+* **[Internal]** Add `dataResidencyRegion` option.
+
 
 ## Version 5.0.2
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Microsoft/AppCenter-SDK-Android/badge.svg?branch=develop)](https://coveralls.io/github/Microsoft/AppCenter-SDK-Android?branch=develop)
 [![GitHub Release](https://img.shields.io/github/release/microsoft/appcenter-sdk-android.svg)](https://github.com/microsoft/appcenter-sdk-android/releases/latest)
-[![Bintray](https://api.bintray.com/packages/vsappcenter/appcenter/appcenter/images/download.svg)](https://bintray.com/vsappcenter/appcenter)
 [![license](https://img.shields.io/badge/license-MIT%20License-00AAAA.svg)](https://github.com/microsoft/appcenter-sdk-android/blob/master/license.txt)
+[![Project Map](https://img.shields.io/badge/SourceSpy-Project_Map-blue.svg)](https://sourcespy.com/github/microsoftappcentersdkandroid/)
 
 # Visual Studio App Center SDK for Android
 

--- a/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/appcenter/sasquatch/activities/SettingsActivity.java
@@ -13,6 +13,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.FileObserver;
 import android.preference.CheckBoxPreference;
@@ -738,7 +739,7 @@ public class SettingsActivity extends AppCompatActivity {
             if (requestCode == FILE_ATTACHMENT_DIALOG_ID) {
                 Uri fileAttachment = resultCode == RESULT_OK && data != null ? data.getData() : null;
                 if (fileAttachment != null) {
-                    getActivity().getContentResolver().takePersistableUriPermission(fileAttachment, data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    getActivity().getContentResolver().takePersistableUriPermission(fileAttachment, Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 }
                 MainActivity.setFileAttachment(fileAttachment);
                 Preference preference = getPreferenceManager().findPreference(getString(R.string.appcenter_crashes_file_attachment_key));

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/install/session/InstallStatusReceiver.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/install/session/InstallStatusReceiver.java
@@ -7,6 +7,7 @@ package com.microsoft.appcenter.distribute.install.session;
 
 import static com.microsoft.appcenter.distribute.DistributeConstants.LOG_TAG;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -32,6 +33,15 @@ class InstallStatusReceiver extends BroadcastReceiver {
     @VisibleForTesting
     static final String INSTALL_STATUS_ACTION = "com.microsoft.appcenter.action.INSTALL_STATUS";
 
+    /**
+     * Raw value of PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT.
+     * https://developer.android.com/reference/android/app/PendingIntent#FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT
+     * This flag will appear only in Android target SDK 34.
+     */
+    @VisibleForTesting
+    private static final int FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT_VALUE = 16777216;
+
+
     static IntentFilter getInstallerReceiverFilter() {
         IntentFilter installerReceiverFilter = new IntentFilter();
         installerReceiverFilter.addAction(INSTALL_STATUS_ACTION);
@@ -49,8 +59,12 @@ class InstallStatusReceiver extends BroadcastReceiver {
         int broadcastFlags = 0;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             broadcastFlags = PendingIntent.FLAG_MUTABLE;
+            if (Build.VERSION.SDK_INT >= 34) {
+                broadcastFlags |= FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT_VALUE;
+            }
         }
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(
+        // Suppress the warning as the flag PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT is unavailable on Android SDK < 34.
+        @SuppressLint("WrongConstant") PendingIntent pendingIntent = PendingIntent.getBroadcast(
                 context,
                 requestCode,
                 new Intent(INSTALL_STATUS_ACTION),

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/install/session/SessionReleaseInstaller.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/install/session/SessionReleaseInstaller.java
@@ -14,6 +14,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageInstaller;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.os.ParcelFileDescriptor;
 
@@ -233,7 +234,11 @@ public class SessionReleaseInstaller extends AbstractReleaseInstaller {
         if (mInstallStatusReceiver == null) {
             AppCenterLog.debug(LOG_TAG, "Register receiver for installing a new release.");
             mInstallStatusReceiver = new InstallStatusReceiver(this);
-            mContext.registerReceiver(mInstallStatusReceiver, InstallStatusReceiver.getInstallerReceiverFilter());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                mContext.registerReceiver(mInstallStatusReceiver, InstallStatusReceiver.getInstallerReceiverFilter(), Context.RECEIVER_EXPORTED);
+            } else {
+                mContext.registerReceiver(mInstallStatusReceiver, InstallStatusReceiver.getInstallerReceiverFilter());
+            }
         }
         if (mSessionCallback == null) {
             PackageInstaller packageInstaller = getPackageInstaller();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/install/session/InstallStatusReceiverTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/install/session/InstallStatusReceiverTest.java
@@ -53,6 +53,7 @@ import java.util.Set;
 public class InstallStatusReceiverTest {
 
     private static final int SESSION_ID = 42;
+    private static final int FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT_VALUE = 16777216;
 
     @Rule
     public PowerMockRule mRule = new PowerMockRule();
@@ -214,6 +215,14 @@ public class InstallStatusReceiverTest {
         /* Verify that we add install status to filter. */
         assertEquals(filter, InstallStatusReceiver.getInstallerReceiverFilter());
         verify(filter).addAction(INSTALL_STATUS_ACTION);
+    }
+
+    @Test
+    public void createIntentSenderOnAndroid34() {
+
+        /* Mock SDK_INT to 34 target SDK. */
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", 34);
+        createIntentSender(PendingIntent.FLAG_MUTABLE | FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT_VALUE);
     }
 
     @Test

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,8 +6,8 @@
 // Version constants
 
 ext {
-    versionCode = 72
-    versionName = '5.0.3'
+    versionCode = 73
+    versionName = '5.0.4'
     minSdkVersion = 21
     compileSdkVersion = 33
     targetSdkVersion = 33


### PR DESCRIPTION
- Add FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT flag for broadcast pending intent and RECEIVER_EXPORTED flag for install receiver. https://github.com/microsoft/appcenter-sdk-android/pull/1713