### PR TITLE
Migrate to java.security.Random instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 5.0.5 (Under development)
 
+### AppCenter
+
+* **[Improvement]** Use java.security.Random instead of java.util.Random.
+
 ### App Center Crashes
 
 * **[Fix]** Synchronize the timestamp used for minidump attachments with the crash log's timestamp.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
@@ -14,7 +14,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 
 import java.net.UnknownHostException;
 import java.util.Map;
-import java.security.Random;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.appcenter.http.DefaultHttpClient.X_MS_RETRY_AFTER_MS_HEADER;
@@ -42,7 +42,7 @@ public class HttpClientRetryer extends HttpClientDecorator {
     /**
      * Random object for interval randomness.
      */
-    private final Random mRandom = new Random();
+    private final SecureRandom mRandom = new SecureRandom();
 
     /**
      * Init with default retry policy.

--- a/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
+++ b/sdk/appcenter/src/main/java/com/microsoft/appcenter/http/HttpClientRetryer.java
@@ -14,7 +14,7 @@ import com.microsoft.appcenter.utils.AppCenterLog;
 
 import java.net.UnknownHostException;
 import java.util.Map;
-import java.util.Random;
+import java.security.Random;
 import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.appcenter.http.DefaultHttpClient.X_MS_RETRY_AFTER_MS_HEADER;


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

The "Insufficiently Random Values" alert references the `HttpClientRetryer` file, which uses random values in a non-security context, specifically for creating timeouts for retries. But to avoid this warning, we migrate to `java.security.Random` package.

## Related PRs or issues

Issue: [#1032](https://github.com/microsoft/appcenter-sdk-react-native/issues/1032/)
[AB#107228](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/107228)

[Build succeed
](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1535175&view=results)