### PR TITLE
[CI] Add publishing to Azure Maven Artifacts

### DIFF
--- a/.azurepipelines/azure-maven-template.yml
+++ b/.azurepipelines/azure-maven-template.yml
@@ -1,0 +1,102 @@
+stages:
+- stage: PublishAzureMaven
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  displayName: Publish Azure Maven
+  dependsOn: stage
+  jobs:
+  - job: UploadArtifacts
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Build Artifacts
+      inputs:
+        artifactName: Release
+        targetPath: '$(Agent.BuildDirectory)/Release'
+    - task: MavenAuthenticate@0
+      displayName: 'Maven Authenticate'
+      inputs:
+        artifactsFeeds: AppCenter
+    - task: Bash@3
+      displayName: Publish appcenter To AzureArtifacts
+      inputs:
+        targetType: 'inline'
+        script: |
+          VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/appcenter/*/)
+          ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/appcenter/$VERSION"
+          ARTIFACT_ID="appcenter"
+          ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
+
+          mvn deploy:deploy-file -DgeneratePom=false \
+              -Durl=$(AZURE_REPO) \
+              -Dfile=$ARTIFACT_FILE_BASE.aar \
+              -Dfiles=$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-javadoc.jar \
+              -Dtypes=pom,jar,jar \
+              -Dclassifiers=pom,sources,javadoc \
+              -DgroupId=com.microsoft.appcenter \
+              -DartifactId=$ARTIFACT_ID \
+              -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \
+              -DrepositoryId=AppCenter \
+              -e
+    - task: Bash@3
+      displayName: Publish appcenter-analytics To AzureArtifacts
+      inputs:
+        targetType: 'inline'
+        script: |
+          VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/appcenter-analytics/*/)
+          ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/appcenter-analytics/$VERSION"
+          ARTIFACT_ID="appcenter-analytics"
+          ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
+
+          mvn deploy:deploy-file -DgeneratePom=false \
+              -Durl=$(AZURE_REPO) \
+              -Dfile=$ARTIFACT_FILE_BASE.aar \
+              -Dfiles=$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-javadoc.jar \
+              -Dtypes=pom,jar,jar \
+              -Dclassifiers=pom,sources,javadoc \
+              -DgroupId=com.microsoft.appcenter \
+              -DartifactId=$ARTIFACT_ID \
+              -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \
+              -DrepositoryId=AppCenter \
+              -e
+    - task: Bash@3
+      displayName: Publish appcenter-crashes To AzureArtifacts
+      inputs:
+        targetType: 'inline'
+        script: |
+          VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/appcenter-crashes/*/)
+          ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/appcenter-crashes/$VERSION"
+          ARTIFACT_ID="appcenter-crashes"
+          ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
+
+          mvn deploy:deploy-file -DgeneratePom=false \
+              -Durl=$(AZURE_REPO) \
+              -Dfile=$ARTIFACT_FILE_BASE.aar \
+              -Dfiles=$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-javadoc.jar \
+              -Dtypes=pom,jar,jar \
+              -Dclassifiers=pom,sources,javadoc \
+              -DgroupId=com.microsoft.appcenter \
+              -DartifactId=$ARTIFACT_ID \
+              -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \
+              -DrepositoryId=AppCenter \
+              -e
+
+    - task: Bash@3
+      displayName: Publish appcenter-distribute To AzureArtifacts
+      inputs:
+        targetType: 'inline'
+        script: |
+          VERSION=$(basename $(Agent.BuildDirectory)/Release/appcenter/appcenter-distribute/*/)
+          ARTIFACTS_DIR="$(Agent.BuildDirectory)/Release/appcenter/appcenter-distribute/$VERSION"
+          ARTIFACT_ID="appcenter-distribute"
+          ARTIFACT_FILE_BASE="$ARTIFACTS_DIR/$ARTIFACT_ID-$VERSION"
+
+          mvn deploy:deploy-file -DgeneratePom=false \
+              -Durl=$(AZURE_REPO) \
+              -Dfile=$ARTIFACT_FILE_BASE.aar \
+              -Dfiles=$ARTIFACT_FILE_BASE.pom,$ARTIFACT_FILE_BASE-sources.jar,$ARTIFACT_FILE_BASE-javadoc.jar \
+              -Dtypes=pom,jar,jar \
+              -Dclassifiers=pom,sources,javadoc \
+              -DgroupId=com.microsoft.appcenter \
+              -DartifactId=$ARTIFACT_ID \
+              -Dversion=$VERSION-${BUILD_SOURCEVERSION:0:7} \
+              -DrepositoryId=AppCenter \
+              -e

--- a/.azurepipelines/publish-maven-1ES.yml
+++ b/.azurepipelines/publish-maven-1ES.yml
@@ -82,8 +82,11 @@ extends:
             script: |
               VERSION=$(grep "versionName = '" versions.gradle | awk -F "[']" '{print $2}')
               echo $VERSION > $(Build.ArtifactStagingDirectory)/com/microsoft/version            
-      
+
+    - template: azure-maven-template.yml@self
+
     - stage: APIScan
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       dependsOn: BuildArtifacts
       pool:
         name: 1ES-PT-Windows-2022


### PR DESCRIPTION
This PR introduces a new stage in the CI pipeline for publishing artifacts to Azure Maven Artifacts. The artifacts are published with the commit hash included in their version to avoid conflicts during the release process.

Additionally, removed ESRP publish task, as it should be done in the release pipeline.

[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1541557&view=results)
[AB#107584](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/107584)