### PR TITLE
Fix Build and Test pipeline

### DIFF
--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -42,11 +42,11 @@ if [ -z $1 ]
 then
 
     # Using env variable COVERALLS_REPO_TOKEN if set, this will not fail process unset.
-    ./gradlew --parallel coveralls
+    ./gradlew coveralls
 else
 
     # Expose variable just for this run based on script parameter.
-    COVERALLS_REPO_TOKEN=$1 ./gradlew --parallel coveralls
+    COVERALLS_REPO_TOKEN=$1 ./gradlew coveralls
 fi
 EXIT_CODE=$?
 


### PR DESCRIPTION
## Description
During pipeline execution, the emulator encountered errors while attempting to install APKs during testing. This issue was likely caused by running the `gradlew coveralls` command with the `--parallel` flag, which led to multiple APK installations occurring simultaneously. To resolve this, we have removed the `--parallel` flag from the command.

## Related PRs or issues
[AB#107754](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/107754)