### PR TITLE
Sasquatch app build with CodeQL analysis

### DIFF
--- a/.azurepipelines/build-demo-app.yml
+++ b/.azurepipelines/build-demo-app.yml
@@ -12,13 +12,47 @@ jobs:
 - job:
   displayName: Build and CodeQL Sasquatch App
   steps:
+
   - checkout: self
+    clean: true
     submodules: recursive
+    fetchTags: false
+
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
+  - task: JavaToolInstaller@0
+    displayName: Use Java 11
+    inputs:
+      versionSpec: 11
+      jdkArchitectureOption: x64
+      jdkSourceOption: PreInstalled
+
+  - task: DownloadSecureFile@1
+    displayName: Download GPG-key
+    inputs:
+      secureFile: 98b107ca-fab1-42c0-819d-2871c022869c
+
+  - task: Bash@3
+    displayName: Put Azure Credentials
+    inputs:
+      filePath: ./scripts/put-azure-credentials.sh
+      arguments: $(AZURE_USERNAME) $(AZURE_PASSWORD)
+
+  - task: ShellScript@2
+    displayName: Configure bintray
+    inputs:
+      scriptPath: scripts/put-bintray-secrets-gradle.sh
+      args: $(MAVEN_USER) $(MAVEN_KEY) $(GDP_SIGNING_KEY_ID) "$(Agent.TempDirectory)/appcenter-gpg-key.gpg" $(GDP_KEY_PASSWORD)
+      disableAutoCwd: true
+
+  - task: Bash@3
+    displayName: Set NDK version
+    inputs:
+      filePath: ./scripts/set-ndk-version.sh
+
   - task: Gradle@3
-    displayName: Build Sasquatch App
+    displayName: Gradle - Build Sasquatch App
     inputs:
       workingDirectory: apps
       tasks: assembleRelease

--- a/.azurepipelines/build-demo-app.yml
+++ b/.azurepipelines/build-demo-app.yml
@@ -1,0 +1,28 @@
+pr:
+- master
+
+pool:
+  vmImage: macos-latest
+
+variables:
+- name: Codeql.Cadence
+  value: 0
+
+jobs:
+- job:
+  displayName: Build and CodeQL Sasquatch App
+  steps:
+  - checkout: self
+    submodules: recursive
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
+
+  - task: Gradle@3
+    displayName: Build Sasquatch App
+    inputs:
+      workingDirectory: apps
+      tasks: assembleRelease
+      publishJUnitResults: false
+
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize

--- a/.azurepipelines/build-demo-app.yml
+++ b/.azurepipelines/build-demo-app.yml
@@ -4,10 +4,6 @@ pr:
 pool:
   vmImage: macos-latest
 
-variables:
-- name: Codeql.Cadence
-  value: 0
-
 jobs:
 - job:
   displayName: Build and CodeQL Sasquatch App


### PR DESCRIPTION
## Description

Because of CodeQL analysis recognizes this repository as containing C++ code, we need to build C++ files during the CodeQL scan (even if not all of them). Currently, the repository has only one C++ file—in Sasquatch app and this file is part of the functionality (testing the handling of crashes that were raised from native C++ code) of this application.

This pull request introduces a pipeline configuration that builds Sasquatch app as part of the CodeQL scan. This ensures that CodeQL successfully scan C++ code in its analysis.

[Build succeeded](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1546315&view=results)

## Related PRs or issues

[AB#107387](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/107387)

