### PR TITLE
Add arguments to Emulator boot process

### DIFF
--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,6 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
+export ADB_INSTALL_TIMEOUT=60
 $ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off &
 
 # Ensure Android Emulator has booted successfully before continuing

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -37,6 +37,10 @@ then
     fi
 fi
 
+# Wait for 30 seconds before running tests to prevent install exception
+echo "Waiting for 30 seconds..."
+sleep 30
+
 # Run tests with coverage
 if [ -z $1 ]
 then

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off  &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-snapshot-load -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu swiftshader_indirect -no-snapshot -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off  &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -5,8 +5,7 @@
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
 export ADB_INSTALL_TIMEOUT=60
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 \ 
--no-window -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -5,7 +5,7 @@
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
 export ADB_INSTALL_TIMEOUT=60
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,6 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-export ADB_INSTALL_TIMEOUT=60
 $ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-snapshot-load -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu swiftshader_indirect -no-snapshot -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -5,7 +5,7 @@
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
 export ADB_INSTALL_TIMEOUT=60
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu swiftshader_indirect &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -4,7 +4,7 @@
 # VSTS will not execute next step until emulator killed
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-metrics -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -5,7 +5,8 @@
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
 export ADB_INSTALL_TIMEOUT=60
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu swiftshader_indirect &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 \ 
+-no-window -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'

--- a/scripts/run-code-coverage.sh
+++ b/scripts/run-code-coverage.sh
@@ -5,7 +5,7 @@
 # So we need to run tests in same step...
 export DYLD_LIBRARY_PATH="$ANDROID_HOME/emulator/lib64/qt/lib"
 export ADB_INSTALL_TIMEOUT=60
-$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
+$ANDROID_HOME/emulator/emulator -avd emulator -skin 768x1280 -no-window -gpu off -no-snapshot -no-audio -no-boot-anim -camera-back none -camera-front none &
 
 # Ensure Android Emulator has booted successfully before continuing
 EMU_BOOTED='unknown'


### PR DESCRIPTION
## Description
Added additional arguments to the emulator boot process to reduce the occurrence of installation exceptions on CI `com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: Unknown failure: cmd: Can't find service: package`
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1551477&view=results)


## Related PRs or issues
[#AB107754
](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items?System.AssignedTo=v-djordjed%40microsoft.com&workitem=107754)