### PR TITLE
Dismiss dialog instead of hiding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fixed app crush on hiding install update dialog.
+* **[Fix]** Fix app crush on hiding install update dialog.
 
 ## Version 5.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix app crush on hiding install update dialog.
+* **[Fix]** Fix app crash on hiding install update dialog.
 
 ## Version 5.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 5.0.6 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Fixed app crush on hiding install update dialog.
 
 ## Version 5.0.5
 

--- a/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
+++ b/sdk/appcenter-distribute/src/main/java/com/microsoft/appcenter/distribute/Distribute.java
@@ -41,6 +41,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
@@ -1383,7 +1384,7 @@ public class Distribute extends AbstractAppCenterService {
                 }
 
                 /* Otherwise replace dialog. */
-                dialog.hide();
+                dialog.dismiss();
             }
         }
         return true;

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeBeforeDownloadTest.java
@@ -282,7 +282,7 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
 
         /* But dialog refreshed. */
         InOrder order = inOrder(mDialog);
-        order.verify(mDialog).hide();
+        order.verify(mDialog).dismiss();
         order.verify(mDialog).show();
         order.verifyNoMoreInteractions();
         verify(mDialog, times(2)).show();
@@ -292,7 +292,7 @@ public class DistributeBeforeDownloadTest extends AbstractDistributeTest {
         Distribute.setEnabled(false);
 
         /* We already called hide once, make sure its not called a second time. */
-        verify(mDialog).hide();
+        verify(mDialog).dismiss();
 
         /* Also no toast if we don't click on actionable button. */
         verify(mToast, never()).show();

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeTest.java
@@ -648,7 +648,7 @@ public class DistributeTest extends AbstractDistributeTest {
 
         /* Call resume fourth time to trigger dialog refresh and mock that it's showing, verify it's hidden. */
         Distribute.getInstance().onActivityResumed(mActivity);
-        verify(mDialog, times(1)).hide();
+        verify(mDialog, times(1)).dismiss();
 
         /*
          * Call resume fifth time with the same activity reference as before so that

--- a/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeWarnUnknownSourcesTest.java
+++ b/sdk/appcenter-distribute/src/test/java/com/microsoft/appcenter/distribute/DistributeWarnUnknownSourcesTest.java
@@ -266,17 +266,17 @@ public class DistributeWarnUnknownSourcesTest extends AbstractDistributeTest {
 
         /* Only once check, and no hiding. */
         verify(mDialog).show();
-        verify(mDialog, never()).hide();
+        verify(mDialog, never()).dismiss();
         verify(mUnknownSourcesDialog).show();
-        verify(mUnknownSourcesDialog, never()).hide();
+        verify(mUnknownSourcesDialog, never()).dismiss();
 
         /* Cover activity. Second dialog must be replaced. First one skipped. */
         Distribute.getInstance().onActivityPaused(mFirstActivity);
         Distribute.getInstance().onActivityResumed(mock(Activity.class));
         verify(mDialog).show();
-        verify(mDialog, never()).hide();
+        verify(mDialog, never()).dismiss();
         verify(mUnknownSourcesDialog, times(2)).show();
-        verify(mUnknownSourcesDialog).hide();
+        verify(mUnknownSourcesDialog).dismiss();
     }
 
     @Test


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Dismiss dialog window instead of hiding it. We usually don't use this dialog more than once per application launch, so there's no point in saving resources on creating this dialog. This allows us to correctly remove the dialog from any thread.

[Build succeeded](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1551727&view=results)
## Related PRs or issues

https://github.com/microsoft/appcenter/issues/2647
https://github.com/microsoft/appcenter-sdk-android/issues/1747
[AB#109350](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/109350)
