### PR TITLE
Fix dependsOn for azure-maven-template.yml

### DIFF
--- a/.azurepipelines/azure-maven-template.yml
+++ b/.azurepipelines/azure-maven-template.yml
@@ -2,7 +2,7 @@ stages:
 - stage: PublishAzureMaven
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   displayName: Publish Azure Maven
-  dependsOn: stage
+  dependsOn: BuildArtifacts
   jobs:
   - job: UploadArtifacts
     steps:


### PR DESCRIPTION
## Description

Fix stage name in dependsOn option for PublishAzureMaven

[Build succeed](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1552655&view=results)

## Related PRs or issues

[AB#109330](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/109330)
